### PR TITLE
Give name to test setup

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -2,7 +2,8 @@
   "network": {
     "protocolMagic": 633343913,
     "backendUrl": "http://localhost:8080",
-    "websocketUrl": "ws://localhost:8080"
+    "websocketUrl": "ws://localhost:8080",
+    "name": "test"
   },
   "app": {
     "walletRefreshInterval": 2000,


### PR DESCRIPTION
"Test" is a really bad name in the first place. I almost think we should rename all occurrences to "localhost" instead to avoid confusion between "test" and "testnet".

In the meantime, I'll add the name "test" just to keep everything consistent