### PR TITLE
Remove unused permissions

### DIFF
--- a/chrome/extension/background.js
+++ b/chrome/extension/background.js
@@ -19,7 +19,7 @@ function promisifyAll(obj, list) {
 }
 
 // let chrome extension api support Promise
-promisifyAll(chrome, ['tabs', 'windows', 'browserAction', 'contextMenus']);
+promisifyAll(chrome, ['tabs', 'windows', 'browserAction']);
 promisifyAll(chrome.storage, ['local']);
 
 

--- a/chrome/manifest.development.json
+++ b/chrome/manifest.development.json
@@ -15,8 +15,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "contextMenus",
-    "management",
     "tabs",
     "storage"
   ],

--- a/chrome/manifest.mainnet.json
+++ b/chrome/manifest.mainnet.json
@@ -15,8 +15,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "contextMenus",
-    "management",
     "tabs",
     "storage"
   ],

--- a/chrome/manifest.staging.json
+++ b/chrome/manifest.staging.json
@@ -16,8 +16,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "contextMenus",
-    "management",
     "tabs",
     "storage"
   ],

--- a/chrome/manifest.test.json
+++ b/chrome/manifest.test.json
@@ -15,8 +15,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "contextMenus",
-    "management",
     "tabs",
     "storage"
   ],

--- a/chrome/manifest.testnet.json
+++ b/chrome/manifest.testnet.json
@@ -16,8 +16,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "contextMenus",
-    "management",
     "tabs",
     "storage"
   ],


### PR DESCRIPTION
This PR removes two permissions for the following two reasons:

1) `contextMenus` came from the template that was used to create the initial commit and was never removed and never used.
2) `management` also came from the template and through a copy-paste error during refactoring became part of the production build