### PR TITLE
Fix right-click generate new address

### DIFF
--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -86,7 +86,7 @@ export default class WalletReceive extends Component<Props, State> {
     this.setState({ showUsed: !this.state.showUsed });
   };
 
-  submit() {
+  submit = () => {
     this.props.onGenerateAddress();
   }
 
@@ -122,7 +122,7 @@ export default class WalletReceive extends Component<Props, State> {
         <Button
           className={generateAddressButtonClasses}
           label={intl.formatMessage(messages.generateNewAddressButtonLabel)}
-          onMouseUp={this.submit.bind(this)}
+          onMouseUp={this.submit}
           skin={<SimpleButtonSkin />}
         />
       </div>


### PR DESCRIPTION
We inherited this bug from Daedalus (only happens on Windows) where if you right-click the "Generate address" button it generates a new address (instead of doing nothing as expected)

https://github.com/input-output-hk/daedalus/pull/1082