### PR TITLE
Cleanup/ui

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { Provider, observer } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { ThemeProvider } from 'react-css-themr';
 import { Router } from 'react-router';
 import { addLocaleData, IntlProvider } from 'react-intl';
@@ -40,16 +40,14 @@ export default class App extends Component<{
     return (
       <div>
         <ThemeManager variables={theme} />
-        <Provider stores={stores} actions={actions}>
-          {/* Automatically pass a theme prop to all componenets in this subtree. */}
-          <ThemeProvider theme={yoroiTheme}>
-            <IntlProvider {...{ locale, key: locale, messages: mergedMessages }}>
-              <div style={{ height: '100%' }}>
-                <Router history={history} routes={Routes} />
-              </div>
-            </IntlProvider>
-          </ThemeProvider>
-        </Provider>
+        {/* Automatically pass a theme prop to all componenets in this subtree. */}
+        <ThemeProvider theme={yoroiTheme}>
+          <IntlProvider {...{ locale, key: locale, messages: mergedMessages }}>
+            <div style={{ height: '100%' }}>
+              <Router history={history} routes={Routes(stores, actions)} />
+            </div>
+          </IntlProvider>
+        </ThemeProvider>
       </div>
     );
   }

--- a/app/Routes.js
+++ b/app/Routes.js
@@ -3,6 +3,9 @@ import React from 'react';
 import { Route, IndexRedirect } from 'react-router';
 import { ROUTES } from './routes-config';
 import resolver from './utils/imports';
+import type { StoresMap } from './stores/index';
+import type { ActionsMap } from './actions/index';
+import type { Node } from 'react';
 
 // PAGES
 import NoWalletsPage from './containers/wallet/NoWalletsPage';
@@ -23,25 +26,75 @@ const WalletSendPage = resolver('containers/wallet/WalletSendPage');
 const WalletReceivePage = resolver('containers/wallet/WalletReceivePage');
 const DaedalusTransferPage = resolver('containers/daedalusTransfer/DaedalusTransferPage');
 
+/* eslint-disable max-len */
 export const Routes = (
+  stores: StoresMap,
+  actions: ActionsMap
+): Node => (
   <div>
-    <Route path={ROUTES.ROOT} component={LoadingPage} />
-    <Route path={ROUTES.PROFILE.LANGUAGE_SELECTION} component={LanguageSelectionPage} />
-    <Route path={ROUTES.PROFILE.TERMS_OF_USE} component={TermsOfUsePage} />
-    <Route path={ROUTES.NO_WALLETS} component={NoWalletsPage} />
-    <Route path={ROUTES.WALLETS.ADD} component={WalletAddPage} />
-    <Route path={ROUTES.WALLETS.ROOT} component={Wallet}>
-      <Route path={ROUTES.WALLETS.TRANSACTIONS} component={WalletSummaryPage} />
-      <Route path={ROUTES.WALLETS.SEND} component={WalletSendPage} />
-      <Route path={ROUTES.WALLETS.RECEIVE} component={WalletReceivePage} />
+    <Route
+      path={ROUTES.ROOT}
+      component={(props) => <LoadingPage {...props} stores={stores} actions={actions} />}
+    />
+    <Route
+      path={ROUTES.PROFILE.LANGUAGE_SELECTION}
+      component={(props) => <LanguageSelectionPage {...props} stores={stores} actions={actions} />}
+    />
+    <Route
+      path={ROUTES.PROFILE.TERMS_OF_USE}
+      component={(props) => <TermsOfUsePage {...props} stores={stores} actions={actions} />}
+    />
+    <Route
+      path={ROUTES.NO_WALLETS}
+      component={(props) => <NoWalletsPage {...props} stores={stores} actions={actions} />}
+    />
+    <Route
+      path={ROUTES.WALLETS.ADD}
+      component={(props) => <WalletAddPage {...props} stores={stores} actions={actions} />}
+    />
+    <Route
+      path={ROUTES.WALLETS.ROOT}
+      component={(props) => <Wallet {...props} stores={stores} actions={actions} />}
+    >
+      <Route
+        path={ROUTES.WALLETS.TRANSACTIONS}
+        component={(props) => <WalletSummaryPage {...props} stores={stores} actions={actions} />}
+      />
+      <Route
+        path={ROUTES.WALLETS.SEND}
+        component={(props) => <WalletSendPage {...props} stores={stores} actions={actions} />}
+      />
+      <Route
+        path={ROUTES.WALLETS.RECEIVE}
+        component={(props) => <WalletReceivePage {...props} stores={stores} actions={actions} />}
+      />
     </Route>
-    <Route path="/settings" component={Settings}>
+    <Route
+      path="/settings"
+      component={(props) => <Settings {...props} stores={stores} actions={actions} />}
+    >
       <IndexRedirect to="general" />
-      <Route path="general" component={GeneralSettingsPage} />
-      <Route path="terms-of-use" component={TermsOfUseSettingsPage} />
-      <Route path={ROUTES.SETTINGS.WALLET} component={WalletSettingsPage} />
-      <Route path="support" component={SupportSettingsPage} />
+      <Route
+        path="general"
+        component={(props) => <GeneralSettingsPage {...props} stores={stores} actions={actions} />}
+      />
+      <Route
+        path="terms-of-use"
+        component={(props) => <TermsOfUseSettingsPage {...props} stores={stores} actions={actions} />}
+      />
+      <Route
+        path={ROUTES.SETTINGS.WALLET}
+        component={(props) => <WalletSettingsPage {...props} stores={stores} actions={actions} />}
+      />
+      <Route
+        path="support"
+        component={(props) => <SupportSettingsPage {...props} stores={stores} actions={actions} />}
+      />
     </Route>
-    <Route path={ROUTES.DAEDALUS_TRANFER.ROOT} component={DaedalusTransferPage} />
+    <Route
+      path={ROUTES.DAEDALUS_TRANFER.ROOT}
+      component={(props) => <DaedalusTransferPage {...props} stores={stores} actions={actions} />}
+    />
   </div>
 );
+/* eslint-enable max-len */

--- a/app/components/daedalusTransfer/DaedalusTransferErrorPage.js
+++ b/app/components/daedalusTransfer/DaedalusTransferErrorPage.js
@@ -28,6 +28,9 @@ type Props = {
 
 @observer
 export default class DaedalusTransferErrorPage extends Component<Props> {
+  static defaultProps = {
+    error: undefined
+  };
 
   static contextTypes = {
     intl: intlShape.isRequired

--- a/app/components/daedalusTransfer/DaedalusTransferFormPage.js
+++ b/app/components/daedalusTransfer/DaedalusTransferFormPage.js
@@ -145,6 +145,7 @@ export default class DaedalusTransferFormPage extends Component<Props> {
               <ul className={styles.instructionsList}>
                 {
                   Array(2).fill().map((_, idx) => (
+                    // eslint-disable-next-line react/no-array-index-key
                     <div key={`step${idx}`} className={styles.text}>
                       {intl.formatMessage({ id: messages[`step${idx}`].id })}
                     </div>

--- a/app/components/daedalusTransfer/DaedalusTransferSummaryPage.js
+++ b/app/components/daedalusTransfer/DaedalusTransferSummaryPage.js
@@ -113,6 +113,7 @@ export default class DaedalusTransferSummaryPage extends Component<Props> {
                   ]);
 
                   return (
+                    // eslint-disable-next-line react/no-array-index-key
                     <div key={index} className={addressesClasses}>{sender}</div>
                   );
                 })

--- a/app/components/layout/CenteredLayout.js
+++ b/app/components/layout/CenteredLayout.js
@@ -5,14 +5,14 @@ import { observer } from 'mobx-react';
 import styles from './CenteredLayout.scss';
 
 type Props = {
-  children: Node,
+  children?: Node,
 };
 
 @observer
 export default class CenteredLayout extends Component<Props> {
 
   static defaultProps = {
-    children: null
+    children: undefined
   };
 
   render() {

--- a/app/components/layout/SidebarLayout.js
+++ b/app/components/layout/SidebarLayout.js
@@ -9,7 +9,7 @@ import styles from './SidebarLayout.scss';
 import environment from '../../environment';
 
 type Props = {
-  children: any | Node,
+  children?: Node,
   sidebar?: Node,
   topbar: Node,
   notification?: ?Node,
@@ -26,9 +26,11 @@ export const messages = defineMessages({
 
 @observer
 export default class SidebarLayout extends Component<Props> {
-
   static defaultProps = {
-    children: null
+    children: undefined,
+    sidebar: undefined,
+    notification: undefined,
+    contentDialogs: undefined
   };
 
   static contextTypes = {

--- a/app/components/layout/TextOnlyTopbar.js
+++ b/app/components/layout/TextOnlyTopbar.js
@@ -4,19 +4,20 @@ import classNames from 'classnames';
 import { kebabCase } from 'lodash';
 import TopBarCategory from './TopBarCategory';
 import styles from './TextOnlyTopbar.scss';
+import type { Category } from '../../config/sidebarConfig';
 
 type Props = {
   title: string,
-  categories?: Array<{
-    name: string,
-    route: string,
-    icon: string,
-  }>,
+  categories?: Array<Category>,
   activeSidebarCategory: string,
   onCategoryClicked?: Function,
 };
 
 export default class TextOnlyTopBar extends Component<Props> {
+  static defaultProps = {
+    categories: undefined,
+    onCategoryClicked: undefined
+  };
 
   render() {
     const { title, categories, activeSidebarCategory, onCategoryClicked } = this.props;
@@ -31,11 +32,11 @@ export default class TextOnlyTopBar extends Component<Props> {
             <div className={styles.topbarTitleText}>{title}</div>
           </div>
         </div>
-        {categories && categories.map((category, index) => {
+        {categories && categories.map(category => {
           const categoryClassName = kebabCase(category.name);
           return (
             <TopBarCategory
-              key={index}
+              key={category.name}
               className={categoryClassName}
               icon={category.icon}
               active={activeSidebarCategory === category.route}

--- a/app/components/layout/TopBar.js
+++ b/app/components/layout/TopBar.js
@@ -8,59 +8,59 @@ import TopBarCategory from './TopBarCategory';
 import styles from './TopBar.scss';
 import { matchRoute } from '../../utils/routing';
 import { ROUTES } from '../../routes-config';
-
-// TODO: this is a design mistake. Components should not depend on a store
-import WalletsStore from '../../stores/base/WalletStore';
+import type { Category } from '../../config/sidebarConfig';
+import Wallet from '../../domain/Wallet';
 
 type Props = {
   children?: ?Node,
-  wallets?: ?WalletsStore,
+  wallet: ?Wallet,
   currentRoute: string,
-  showSubMenus?: ?boolean,
   formattedWalletAmount?: Function,
-  categories: Array<{
-    name: string,
-    route: string,
-    icon: string,
-  }>,
+  categories: Array<Category>,
   activeSidebarCategory: string,
   onCategoryClicked?: Function,
 };
 
 @observer
 export default class TopBar extends Component<Props> {
+  static defaultProps = {
+    children: undefined,
+    formattedWalletAmount: undefined,
+    onCategoryClicked: undefined
+  };
 
   render() {
     const {
-      wallets, currentRoute, formattedWalletAmount,
+      wallet, currentRoute, formattedWalletAmount,
       categories, activeSidebarCategory, onCategoryClicked,
     } = this.props;
-    const activeWallet = wallets && wallets.active;
+
+    // If we are looking at a wallet, show its name and balance
     const walletRoutesMatch = matchRoute(`${ROUTES.WALLETS.ROOT}/:id(*page)`, currentRoute);
-    const showWalletInfo = walletRoutesMatch && activeWallet;
+    const showWalletInfo = walletRoutesMatch && wallet;
+    const topBarTitle = showWalletInfo && formattedWalletAmount ? (
+      <div className={styles.walletInfo}>
+        <div className={styles.walletName}>{wallet && wallet.name}</div>
+        <div className={styles.walletAmount}>
+          { wallet && formattedWalletAmount(wallet.amount) + ' ADA' }
+        </div>
+      </div>
+    ) : null;
+
     const topBarStyles = classNames([
       styles.topBar,
       showWalletInfo ? styles.withWallet : styles.withoutWallet,
     ]);
 
-    const topBarTitle = showWalletInfo && formattedWalletAmount ? (
-      <div className={styles.walletInfo}>
-        <div className={styles.walletName}>{activeWallet && activeWallet.name}</div>
-        <div className={styles.walletAmount}>
-          { activeWallet && formattedWalletAmount(activeWallet.amount) + ' ADA' }
-        </div>
-      </div>
-    ) : null;
-
     return (
       <header className={topBarStyles}>
         <div className={styles.topBarTitle}>{topBarTitle}</div>
         {this.props.children}
-        {categories.map((category, index) => {
+        {categories.map(category => {
           const categoryClassName = kebabCase(category.name);
           return (
             <TopBarCategory
-              key={index}
+              key={category.name}
               className={categoryClassName}
               icon={category.icon}
               active={activeSidebarCategory === category.route}

--- a/app/components/layout/TopBarCategory.js
+++ b/app/components/layout/TopBarCategory.js
@@ -29,7 +29,7 @@ export default class TopBarCategory extends Component<Props> {
     ]));
 
     return (
-      <button className={componentStyles} onClick={onClick}>
+      <button type="button" className={componentStyles} onClick={onClick}>
         <SvgInline svg={icon} className={iconStyles} cleanup={['title']} />
       </button>
     );

--- a/app/components/layout/TopBarLayout.js
+++ b/app/components/layout/TopBarLayout.js
@@ -12,6 +12,10 @@ type Props = {
 
 @observer
 export default class TopBarLayout extends Component<Props> {
+  static defaultProps = {
+    children: undefined,
+    notification: undefined
+  };
 
   render() {
     const { children, topbar, notification } = this.props;

--- a/app/components/layout/VerticalFlexContainer.js
+++ b/app/components/layout/VerticalFlexContainer.js
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react';
 import styles from './VerticalFlexContainer.scss';
 
 type Props = {
-  children?: ?Node,
+  children: ?Node,
 };
 
 @observer

--- a/app/components/profile/language-selection/LanguageSelectionForm.js
+++ b/app/components/profile/language-selection/LanguageSelectionForm.js
@@ -34,6 +34,9 @@ type Props = {
 
 @observer
 export default class LanguageSelectionForm extends Component<Props> {
+  static defaultProps = {
+    error: undefined
+  };
 
   static contextTypes = {
     intl: intlShape.isRequired,

--- a/app/components/profile/terms-of-use/TermsOfUseForm.js
+++ b/app/components/profile/terms-of-use/TermsOfUseForm.js
@@ -37,6 +37,9 @@ type State = {
 
 @observer
 export default class TermsOfUseForm extends Component<Props, State> {
+  static defaultProps = {
+    error: undefined
+  };
 
   static contextTypes = {
     intl: intlShape.isRequired,

--- a/app/components/settings/categories/GeneralSettings.js
+++ b/app/components/settings/categories/GeneralSettings.js
@@ -28,6 +28,9 @@ type Props = {
 
 @observer
 export default class GeneralSettings extends Component<Props> {
+  static defaultProps = {
+    error: undefined
+  };
 
   static contextTypes = {
     intl: intlShape.isRequired,

--- a/app/components/settings/categories/SupportSettings.js
+++ b/app/components/settings/categories/SupportSettings.js
@@ -93,7 +93,7 @@ export default class SupportSettings extends Component<Props> {
     );
 
     const downloadLogsLink = (
-      <button onClick={onDownloadLogs}>
+      <button type="button" onClick={onDownloadLogs}>
         {intl.formatMessage(messages.downloadLogsLink)}
       </button>
     );

--- a/app/components/settings/menu/SettingsMenuItem.js
+++ b/app/components/settings/menu/SettingsMenuItem.js
@@ -14,6 +14,10 @@ type Props = {
 
 @observer
 export default class SettingsMenuItem extends Component<Props> {
+  static defaultProps = {
+    disabled: false
+  };
+
   render() {
     const { label, active, disabled, onClick, className } = this.props;
     let state = styles.enabled;
@@ -24,7 +28,7 @@ export default class SettingsMenuItem extends Component<Props> {
     }
     const componentClasses = classNames([styles.component, state, className]);
     return (
-      <button className={componentClasses} onClick={onClick}>{label}</button>
+      <button type="button" className={componentClasses} onClick={onClick}>{label}</button>
     );
   }
 

--- a/app/components/sidebar/Sidebar.js
+++ b/app/components/sidebar/Sidebar.js
@@ -46,11 +46,11 @@ export default class Sidebar extends Component<Props> {
     return (
       <div className={sidebarStyles}>
         <div className={styles.minimized}>
-          {categories.map((category, index) => {
+          {categories.map(category => {
             const categoryClassName = kebabCase(category.name);
             return (
               <SidebarCategory
-                key={index}
+                key={category.name}
                 className={categoryClassName}
                 icon={category.icon}
                 active={activeSidebarCategory === category.route}

--- a/app/components/sidebar/SidebarCategory.js
+++ b/app/components/sidebar/SidebarCategory.js
@@ -29,7 +29,7 @@ export default class SidebarCategory extends Component<Props> {
     ]));
 
     return (
-      <button className={componentStyles} onClick={onClick}>
+      <button type="button" className={componentStyles} onClick={onClick}>
         <SvgInline svg={icon} className={iconStyles} cleanup={['title']} />
       </button>
     );

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -73,6 +73,9 @@ type State = {
 
 @observer
 export default class WalletReceive extends Component<Props, State> {
+  static defaultProps = {
+    error: undefined
+  };
 
   static contextTypes = {
     intl: intlShape.isRequired,
@@ -168,7 +171,7 @@ export default class WalletReceive extends Component<Props, State> {
         <div className={styles.generatedAddresses}>
           <h2>
             {intl.formatMessage(messages.generatedAddressesSectionTitle)}
-            <button onClick={this.toggleUsedAddresses}>
+            <button type="button" onClick={this.toggleUsedAddresses}>
               {intl.formatMessage(messages[showUsed ? 'hideUsedLabel' : 'showUsedLabel'])}
             </button>
           </h2>
@@ -181,7 +184,7 @@ export default class WalletReceive extends Component<Props, State> {
               address.isUsed ? styles.usedWalletAddress : null,
             ]);
             return (
-              <div key={index} className={addressClasses}>
+              <div key={`gen-${address.id}`} className={addressClasses}>
                 <div className={styles.addressId}>{address.id}</div>
                 <div className={styles.addressActions}>
                   <CopyToClipboard

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -87,6 +87,9 @@ type Props = {
 
 @observer
 export default class WalletRestoreDialog extends Component<Props> {
+  static defaultProps = {
+    error: undefined
+  };
 
   static contextTypes = {
     intl: intlShape.isRequired

--- a/app/components/wallet/WalletSendForm.js
+++ b/app/components/wallet/WalletSendForm.js
@@ -16,7 +16,6 @@ import BorderedBox from '../widgets/BorderedBox';
 import styles from './WalletSendForm.scss';
 import globalMessages from '../../i18n/global-messages';
 import WalletSendConfirmationDialog from './WalletSendConfirmationDialog';
-import WalletSendConfirmationDialogContainer from '../../containers/wallet/dialogs/WalletSendConfirmationDialogContainer';
 import { formattedAmountToBigNumber, formattedAmountToNaturalUnits } from '../../utils/formatters';
 import dangerIcon from '../../assets/images/danger.inline.svg';
 
@@ -102,13 +101,14 @@ messages.fieldIsRequired = globalMessages.fieldIsRequired;
 
 type Props = {
   currencyUnit: string,
-  currencyMaxIntegerDigits?: number,
+  currencyMaxIntegerDigits: number,
   currencyMaxFractionalDigits: number,
   validateAmount: (amountInNaturalUnits: string) => Promise<boolean>,
   calculateTransactionFee: (receiver: string, amount: string) => Promise<BigNumber>,
   addressValidator: Function,
   openDialogAction: Function,
   isDialogOpen: Function,
+  dialogRenderCallback: Function,
   hasAnyPending: boolean
 };
 
@@ -213,7 +213,7 @@ export default class WalletSendForm extends Component<Props, State> {
     const { intl } = this.context;
     const {
       currencyUnit, currencyMaxIntegerDigits, currencyMaxFractionalDigits,
-      openDialogAction, isDialogOpen, hasAnyPending
+      openDialogAction, isDialogOpen, hasAnyPending, dialogRenderCallback
     } = this.props;
     const { isTransactionFeeCalculated, transactionFee, transactionFeeError } = this.state;
     const amountField = form.$('amount');
@@ -234,6 +234,14 @@ export default class WalletSendForm extends Component<Props, State> {
       </div>
     );
 
+    const dialogProps = {
+      amount: amountFieldProps.value,
+      receiver: receiverFieldProps.value,
+      totalAmount: totalAmount.toFormat(currencyMaxFractionalDigits),
+      transactionFee: transactionFee.toFormat(currencyMaxFractionalDigits),
+      amountToNaturalUnits: formattedAmountToNaturalUnits,
+      currencyUnit
+    };
     return (
       <div className={styles.component}>
 
@@ -283,14 +291,9 @@ export default class WalletSendForm extends Component<Props, State> {
         </BorderedBox>
 
         {isDialogOpen(WalletSendConfirmationDialog) ? (
-          <WalletSendConfirmationDialogContainer
-            amount={amountFieldProps.value}
-            receiver={receiverFieldProps.value}
-            totalAmount={totalAmount.toFormat(currencyMaxFractionalDigits)}
-            transactionFee={transactionFee.toFormat(currencyMaxFractionalDigits)}
-            amountToNaturalUnits={formattedAmountToNaturalUnits}
-            currencyUnit={currencyUnit}
-          />
+          <div>
+            {dialogRenderCallback(dialogProps)}
+          </div>
         ) : null}
 
       </div>

--- a/app/components/wallet/WalletSettings.js
+++ b/app/components/wallet/WalletSettings.js
@@ -7,9 +7,9 @@ import LocalizableError from '../../i18n/LocalizableError';
 import InlineEditingInput from '../widgets/forms/InlineEditingInput';
 import ReadOnlyInput from '../widgets/forms/ReadOnlyInput';
 import ChangeWalletPasswordDialog from './settings/ChangeWalletPasswordDialog';
-import ChangeWalletPasswordDialogContainer from '../../containers/wallet/dialogs/ChangeWalletPasswordDialogContainer';
 import globalMessages from '../../i18n/global-messages';
 import styles from './WalletSettings.scss';
+import type { Node } from 'react';
 
 export const messages = defineMessages({
   name: {
@@ -40,6 +40,7 @@ type Props = {
   error?: ?LocalizableError,
   openDialogAction: Function,
   isDialogOpen: Function,
+  dialog: Node,
   onFieldValueChange: Function,
   onStartEditing: Function,
   onStopEditing: Function,
@@ -53,7 +54,9 @@ type Props = {
 
 @observer
 export default class WalletSettings extends Component<Props> {
-
+  static defaultProps = {
+    error: undefined
+  };
   static contextTypes = {
     intl: intlShape.isRequired,
   };
@@ -73,7 +76,7 @@ export default class WalletSettings extends Component<Props> {
       onStopEditing, onCancelEditing,
       nameValidator, activeField,
       isSubmitting, isInvalid,
-      lastUpdatedField,
+      lastUpdatedField, dialog
     } = this.props;
     const passwordMessage = (
       intl.formatMessage(messages.passwordLastUpdated, {
@@ -109,7 +112,7 @@ export default class WalletSettings extends Component<Props> {
         {error && <p className={styles.error}>{intl.formatMessage(error)}</p>}
 
         {isDialogOpen(ChangeWalletPasswordDialog) ? (
-          <ChangeWalletPasswordDialogContainer />
+          <div>{dialog}</div>
         ) : null}
 
       </div>

--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
@@ -132,7 +132,7 @@ export default class WalletRecoveryPhraseEntryDialog extends Component<Props> {
           <div className={styles.words}>
             {recoveryPhraseSorted.map(({ word, isActive }, index) => (
               <MnemonicWord
-                key={index}
+                key={index} // eslint-disable-line react/no-array-index-key
                 word={word}
                 index={index}
                 isActive={isActive}

--- a/app/components/wallet/layouts/WalletWithNavigation.js
+++ b/app/components/wallet/layouts/WalletWithNavigation.js
@@ -13,6 +13,9 @@ type Props = {
 
 @observer
 export default class WalletWithNavigation extends Component<Props> {
+  static defaultProps = {
+    children: undefined
+  };
 
   render() {
     const { children, isActiveScreen, onWalletNavItemClick } = this.props;

--- a/app/components/wallet/navigation/WalletNavButton.js
+++ b/app/components/wallet/navigation/WalletNavButton.js
@@ -15,6 +15,9 @@ type Props = {
 
 @observer
 export default class WalletNavButton extends Component<Props> {
+  static defaultProps = {
+    className: undefined
+  };
 
   render() {
     const { isActive, /* icon, */ onClick, className } = this.props;
@@ -28,7 +31,7 @@ export default class WalletNavButton extends Component<Props> {
     //   isActive ? styles.activeIcon : styles.normalIcon
     // ]);
     return (
-      <button className={componentClasses} onClick={onClick}>
+      <button type="button" className={componentClasses} onClick={onClick}>
         <div className={styles.container}>
           {/* <SvgInline svg={icon} className={iconClasses} cleanup={['title']} /> */}
           <span className={styles.label}>{this.props.label}</span>

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.js
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.js
@@ -79,13 +79,6 @@ type State = {
 
 @observer
 export default class ChangeWalletPasswordDialog extends Component<Props, State> {
-
-  static defaultProps = {
-    currentPasswordValue: '',
-    newPasswordValue: '',
-    repeatedPasswordValue: '',
-  };
-
   static contextTypes = {
     intl: intlShape.isRequired,
   };

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -227,13 +227,14 @@ export default class Transaction extends Component<Props, State> {
               <h2>
                 {intl.formatMessage(messages.fromAddresses)}
               </h2>
-              {uniq(data.addresses.from).map((address, addressIndex) => (
-                <span key={`${data.id}-from-${address}-${addressIndex}`} className={styles.address}>{address}</span>
+              {uniq(data.addresses.from).map(address => (
+                <span key={`${data.id}-from-${address}`} className={styles.address}>{address}</span>
               ))}
               <h2>
                 {intl.formatMessage(messages.toAddresses)}
               </h2>
               {data.addresses.to.map((address, addressIndex) => (
+                // eslint-disable-next-line react/no-array-index-key
                 <span key={`${data.id}-to-${address}-${addressIndex}`} className={styles.address}>{address}</span>
               ))}
 

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -121,8 +121,8 @@ export default class WalletTransactionsList extends Component<Props> {
 
     return (
       <div className={styles.component}>
-        {transactionsGroups.map((group, groupIndex) => (
-          <div className={styles.group} key={walletId + '-' + groupIndex}>
+        {transactionsGroups.map(group => (
+          <div className={styles.group} key={walletId + '-' + group.transactions.map(tx => tx.id).join('-')}>
             <div className={styles.groupDate}>{this.localizedDate(group.date)}</div>
             <div className={styles.list}>
               {group.transactions.map((transaction, transactionIndex) => (

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -11,6 +11,7 @@ import Transaction from './Transaction';
 import WalletTransaction from '../../../domain/WalletTransaction';
 import LoadingSpinner from '../../widgets/LoadingSpinner';
 import type { AssuranceMode } from '../../../types/transactionAssuranceTypes';
+import { Logger } from '../../../utils/logging';
 
 const messages = defineMessages({
   today: {
@@ -65,7 +66,9 @@ export default class WalletTransactionsList extends Component<Props> {
     const groups = [];
     for (const transaction of transactions) {
       const date = moment(transaction.date).format(dateFormat);
+      // find the group this transaction belongs in
       let group = groups.find((g) => g.date === date);
+      // if first transaltion in this group, create the group
       if (!group) {
         group = { date, transactions: [] };
         groups.push(group);
@@ -96,6 +99,18 @@ export default class WalletTransactionsList extends Component<Props> {
     return moment(date).format(this.localizedDateFormat);
   }
 
+  getTransactionKey(transactions: Array<WalletTransaction>): string {
+    if (transactions.length) {
+      const firstTransaction = transactions[0];
+      return firstTransaction.id + '-' + firstTransaction.type;
+    }
+    // this branch should not happen
+    Logger.error(
+      '[WalletTransactionsList::getTransactionKey] tried to render empty transaction group'
+    );
+    return '';
+  }
+
   render() {
     const { intl } = this.context;
     const {
@@ -122,7 +137,7 @@ export default class WalletTransactionsList extends Component<Props> {
     return (
       <div className={styles.component}>
         {transactionsGroups.map(group => (
-          <div className={styles.group} key={walletId + '-' + group.transactions.map(tx => tx.id).join('-')}>
+          <div className={styles.group} key={walletId + '-' + this.getTransactionKey(group.transactions)}>
             <div className={styles.groupDate}>{this.localizedDate(group.date)}</div>
             <div className={styles.list}>
               {group.transactions.map((transaction, transactionIndex) => (

--- a/app/components/widgets/BigButtonForDialogs.js
+++ b/app/components/widgets/BigButtonForDialogs.js
@@ -21,6 +21,7 @@ export default class BigButtonForDialogs extends Component<Props> {
     ]);
     return (
       <button
+        type="button"
         className={componentClasses}
         onClick={onClick}
         disabled={isDisabled}

--- a/app/components/widgets/BorderedBox.js
+++ b/app/components/widgets/BorderedBox.js
@@ -10,6 +10,9 @@ type Props = {
 
 @observer
 export default class BorderedBox extends Component<Props> {
+  static defaultProps = {
+    children: undefined
+  };
 
   render() {
     const { children } = this.props;

--- a/app/components/widgets/Dialog.js
+++ b/app/components/widgets/Dialog.js
@@ -20,6 +20,16 @@ type Props = {
 };
 
 export default class Dialog extends Component<Props> {
+  static defaultProps = {
+    title: undefined,
+    children: undefined,
+    actions: undefined,
+    closeButton: undefined,
+    backButton: undefined,
+    className: undefined,
+    onClose: undefined,
+    closeOnOverlayClick: undefined,
+  };
 
   render() {
     const {

--- a/app/components/widgets/DialogBackButton.js
+++ b/app/components/widgets/DialogBackButton.js
@@ -12,7 +12,7 @@ export default class DialogBackButton extends Component<Props> {
   render() {
     const { onBack } = this.props;
     return (
-      <button onClick={onBack} className={styles.component}>
+      <button type="button" onClick={onBack} className={styles.component}>
         <SvgInline svg={backArrow} cleanup={['title']} />
       </button>
     );

--- a/app/components/widgets/DialogCloseButton.js
+++ b/app/components/widgets/DialogCloseButton.js
@@ -9,11 +9,14 @@ type Props = {
 };
 
 export default class DialogCloseButton extends Component<Props> {
+  static defaultProps = {
+    icon: null
+  };
 
   render() {
     const { onClose, icon } = this.props;
     return (
-      <button onClick={onClose} className={styles.component}>
+      <button type="button" onClick={onClose} className={styles.component}>
         <SvgInline svg={icon || closeCross} cleanup={['title']} />
       </button>
     );

--- a/app/components/widgets/NotificationMessage.js
+++ b/app/components/widgets/NotificationMessage.js
@@ -11,6 +11,9 @@ type Props = {
 };
 
 export default class NotificationMessage extends Component<Props> {
+  static defaultProps = {
+    children: null
+  };
 
   render() {
     const { icon, show, children } = this.props;

--- a/app/components/widgets/forms/InlineEditingInput.js
+++ b/app/components/widgets/forms/InlineEditingInput.js
@@ -46,6 +46,9 @@ type State = {
 
 @observer
 export default class InlineEditingInput extends Component<Props, State> {
+  static defaultProps = {
+    className: undefined
+  };
 
   state = {
     isActive: false,
@@ -171,6 +174,7 @@ export default class InlineEditingInput extends Component<Props, State> {
 
         {isActive && (
           <button
+            type="button"
             className={styles.button}
             onMouseDown={this.onCancel}
           >

--- a/app/components/widgets/forms/ReadOnlyInput.js
+++ b/app/components/widgets/forms/ReadOnlyInput.js
@@ -50,6 +50,7 @@ export default class ReadOnlyInput extends Component<Props> {
         />
 
         <button
+          type="button"
           className={styles.button}
           onClick={onClick}
         >

--- a/app/config/sidebarConfig.js
+++ b/app/config/sidebarConfig.js
@@ -4,7 +4,12 @@ import walletsIcon from '../assets/images/yoroi-logo-shape-white.inline.svg';
 import settingsIcon from '../assets/images/sidebar/settings-ic.inline.svg';
 import daedalusTransferIcon from '../assets/images/sidebar/daedalus-transfer.inline.svg';
 
-export const CATEGORIES = [
+export type Category = {
+  name: string,
+  route: string,
+  icon: string
+}
+export const CATEGORIES = ([
   {
     name: 'WALLETS',
     route: ROUTES.WALLETS.ROOT,
@@ -20,4 +25,4 @@ export const CATEGORIES = [
     route: ROUTES.SETTINGS.ROOT,
     icon: settingsIcon,
   },
-];
+]: Array<Category>);

--- a/app/containers/LoadingPage.js
+++ b/app/containers/LoadingPage.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { inject, observer } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { defineMessages } from 'react-intl';
 import CenteredLayout from '../components/layout/CenteredLayout';
 import Loading from '../components/loading/Loading';
@@ -16,7 +16,7 @@ export const messages = defineMessages({
   },
 });
 
-@inject('stores', 'actions') @observer
+@observer
 export default class LoadingPage extends Component<InjectedProps> {
 
   render() {

--- a/app/containers/MainLayout.js
+++ b/app/containers/MainLayout.js
@@ -1,27 +1,19 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import type { Node } from 'react';
 import TopBarContainer from './TopBarContainer';
 import SidebarLayout from '../components/layout/SidebarLayout';
-import type { StoresMap } from '../stores/index';
-import type { ActionsMap } from '../actions/index';
+import type { InjectedContainerProps } from '../types/injectedPropsType';
 
-export type MainLayoutProps = {
-  stores: any | StoresMap,
-  actions: any | ActionsMap,
-  children: Node,
-  topbar: ?any
+export type MainLayoutProps = InjectedContainerProps & {
+  topbar: ?Node
 };
 
-@inject('stores', 'actions') @observer
+@observer
 export default class MainLayout extends Component<MainLayoutProps> {
   static defaultProps = {
-    actions: null,
-    stores: null,
-    children: null,
-    topbar: null,
-    onClose: () => {}
+    topbar: null
   };
 
   render() {

--- a/app/containers/README.md
+++ b/app/containers/README.md
@@ -3,8 +3,3 @@
 Represents higher-level building blocks of the UI. These are meant to contain **no raw html** and only simple logic to combine together `components` to form pages and other high-level concepts.
 
 `Containers` can access both `store` and `actions` to interact with application state.
-
-## Flow with mobx-react
-
-We want to use a mobx-react `Provider` to inject props throughout all containers for `store` and `actions`. However, Flow doesn't support decorators so this would lead to type errors. We instead use a type refinement trick to have it work in practice (but not ideal).
-You can read more about it [here](https://wietse.loves.engineering/using-flowtype-with-decorators-in-react-af4fe69e66d6)

--- a/app/containers/README.md
+++ b/app/containers/README.md
@@ -3,3 +3,8 @@
 Represents higher-level building blocks of the UI. These are meant to contain **no raw html** and only simple logic to combine together `components` to form pages and other high-level concepts.
 
 `Containers` can access both `store` and `actions` to interact with application state.
+
+## Flow with mobx-react
+
+We want to use a mobx-react `Provider` to inject props throughout all containers for `store` and `actions`. However, Flow doesn't support decorators so this would lead to type errors. We instead use a type refinement trick to have it work in practice (but not ideal).
+You can read more about it [here](https://wietse.loves.engineering/using-flowtype-with-decorators-in-react-af4fe69e66d6)

--- a/app/containers/TopBarContainer.js
+++ b/app/containers/TopBarContainer.js
@@ -12,7 +12,6 @@ type Props = InjectedProps;
 
 @observer
 export default class TopBarContainer extends Component<Props> {
-  static defaultProps = { actions: null, stores: null };
 
   render() {
     const { actions, stores } = this.props;
@@ -20,7 +19,7 @@ export default class TopBarContainer extends Component<Props> {
 
     return (
       <TopBar
-        wallets={stores.substores[environment.API].wallets}
+        wallet={stores.substores[environment.API].wallets.active}
         currentRoute={app.currentRoute}
         showSubMenus={false}
         formattedWalletAmount={formattedWalletAmount}

--- a/app/containers/daedalusTransfer/DaedalusTransferPage.js
+++ b/app/containers/daedalusTransfer/DaedalusTransferPage.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { intlShape, defineMessages } from 'react-intl';
 import validWords from 'bip39/wordlists/english.json';
 import type { InjectedProps } from '../../types/injectedPropsType';
@@ -25,10 +25,8 @@ const messages = defineMessages({
   },
 });
 
-@inject('stores', 'actions') @observer
+@observer
 export default class DaedalusTransferPage extends Component<InjectedProps> {
-
-  static defaultProps = { actions: null, stores: null };
 
   static contextTypes = {
     intl: intlShape.isRequired,

--- a/app/containers/profile/LanguageSelectionPage.js
+++ b/app/containers/profile/LanguageSelectionPage.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { inject, observer } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import TextOnlyTopBar from '../../components/layout/TextOnlyTopbar';
 import TopBarLayout from '../../components/layout/TopBarLayout';
@@ -15,10 +15,8 @@ const messages = defineMessages({
   },
 });
 
-@inject('stores', 'actions') @observer
+@observer
 export default class LanguageSelectionPage extends Component<InjectedProps> {
-
-  static defaultProps = { actions: null, stores: null };
 
   static contextTypes = {
     intl: intlShape.isRequired,

--- a/app/containers/profile/TermsOfUsePage.js
+++ b/app/containers/profile/TermsOfUsePage.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { inject, observer } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import TextOnlyTopBar from '../../components/layout/TextOnlyTopbar';
 import TopBarLayout from '../../components/layout/TopBarLayout';
@@ -15,10 +15,8 @@ const messages = defineMessages({
   },
 });
 
-@inject('stores', 'actions') @observer
+@observer
 export default class TermsOfUsePage extends Component<InjectedProps> {
-
-  static defaultProps = { actions: null, stores: null };
 
   static contextTypes = {
     intl: intlShape.isRequired,

--- a/app/containers/settings/Settings.js
+++ b/app/containers/settings/Settings.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import SettingsLayout from '../../components/settings/SettingsLayout';
 import SettingsMenu from '../../components/settings/menu/SettingsMenu';
@@ -18,10 +18,8 @@ const messages = defineMessages({
   },
 });
 
-@inject('stores', 'actions') @observer
+@observer
 export default class Settings extends Component<InjectedContainerProps> {
-
-  static defaultProps = { actions: null, stores: null };
 
   static contextTypes = {
     intl: intlShape.isRequired,

--- a/app/containers/settings/categories/GeneralSettingsPage.js
+++ b/app/containers/settings/categories/GeneralSettingsPage.js
@@ -1,13 +1,11 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import GeneralSettings from '../../../components/settings/categories/GeneralSettings';
 import type { InjectedProps } from '../../../types/injectedPropsType';
 
-@inject('stores', 'actions') @observer
+@observer
 export default class GeneralSettingsPage extends Component<InjectedProps> {
-
-  static defaultProps = { actions: null, stores: null };
 
   onSelectLanguage = (values: { locale: string }) => {
     this.props.actions.profile.updateLocale.trigger(values);

--- a/app/containers/settings/categories/SupportSettingsPage.js
+++ b/app/containers/settings/categories/SupportSettingsPage.js
@@ -1,15 +1,13 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { handleExternalLinkClick } from '../../../utils/routing';
 import SupportSettings from '../../../components/settings/categories/SupportSettings';
 import { downloadLogs } from '../../../utils/logging';
 import type { InjectedProps } from '../../../types/injectedPropsType';
 
-@inject('stores', 'actions') @observer
+@observer
 export default class SupportSettingsPage extends Component<InjectedProps> {
-
-  static defaultProps = { actions: null, stores: null };
 
   handleDownloadLogs = () => {
     downloadLogs();

--- a/app/containers/settings/categories/TermsOfUseSettingsPage.js
+++ b/app/containers/settings/categories/TermsOfUseSettingsPage.js
@@ -1,13 +1,11 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import TermsOfUseSettings from '../../../components/settings/categories/TermsOfUseSettings';
 import type { InjectedProps } from '../../../types/injectedPropsType';
 
-@inject('stores') @observer
+@observer
 export default class TermsOfUseSettingsPage extends Component<InjectedProps> {
-
-  static defaultProps = { actions: null, stores: null };
 
   render() {
     const { termsOfUse } = this.props.stores.profile;

--- a/app/containers/settings/categories/WalletSettingsPage.js
+++ b/app/containers/settings/categories/WalletSettingsPage.js
@@ -1,21 +1,20 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import WalletSettings from '../../../components/wallet/WalletSettings';
 import type { InjectedProps } from '../../../types/injectedPropsType';
 import { isValidWalletName } from '../../../utils/validations';
+import ChangeWalletPasswordDialogContainer from '../../wallet/dialogs/ChangeWalletPasswordDialogContainer';
 
 type Props = InjectedProps
 
-@inject('stores', 'actions') @observer
+@observer
 export default class WalletSettingsPage extends Component<Props> {
-
-  static defaultProps = { actions: null, stores: null };
 
   render() {
     const { uiDialogs } = this.props.stores;
     const { wallets, walletSettings } = this.props.stores.substores.ada;
-    const { actions } = this.props;
+    const { actions, stores } = this.props;
     const activeWallet = wallets.active;
     const {
       updateWalletMetaRequest,
@@ -32,12 +31,16 @@ export default class WalletSettingsPage extends Component<Props> {
     // Guard against potential null values
     if (!activeWallet) throw new Error('Active wallet required for WalletSettingsPage.');
 
+    const changeDialog = (
+      <ChangeWalletPasswordDialogContainer actions={actions} stores={stores} />
+    );
     return (
       <WalletSettings
         error={updateWalletMetaRequest.error}
         openDialogAction={actions.dialogs.open.trigger}
         walletPasswordUpdateDate={activeWallet.passwordUpdateDate}
         isDialogOpen={uiDialogs.isOpen}
+        dialog={changeDialog}
         walletName={activeWallet.name}
         isSubmitting={updateWalletMetaRequest.isExecuting}
         isInvalid={updateWalletMetaRequest.wasExecuted && updateWalletMetaRequest.result === false}

--- a/app/containers/wallet/NoWalletsPage.js
+++ b/app/containers/wallet/NoWalletsPage.js
@@ -1,11 +1,11 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import resolver from '../../utils/imports';
 
 const Layout = resolver('containers/MainLayout');
 
-@inject('stores', 'actions') @observer
+@observer
 export default class NoWalletsPage extends Component<any> {
 
   render() {

--- a/app/containers/wallet/Wallet.js
+++ b/app/containers/wallet/Wallet.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import MainLayout from '../MainLayout';
 import WalletWithNavigation from '../../components/wallet/layouts/WalletWithNavigation';
 import LoadingSpinner from '../../components/widgets/LoadingSpinner';
@@ -10,10 +10,8 @@ import type { InjectedContainerProps } from '../../types/injectedPropsType';
 
 type Props = InjectedContainerProps;
 
-@inject('stores', 'actions') @observer
+@observer
 export default class Wallet extends Component<Props> {
-
-  static defaultProps = { actions: null, stores: null };
 
   isActiveScreen = (page: string) => {
     const { app } = this.props.stores;
@@ -34,9 +32,12 @@ export default class Wallet extends Component<Props> {
 
   render() {
     const { wallets } = this.props.stores.substores.ada;
-    if (!wallets.active) return <MainLayout><LoadingSpinner /></MainLayout>;
+    const { actions, stores } = this.props;
+    if (!wallets.active) {
+      return <MainLayout actions={actions} stores={stores}><LoadingSpinner /></MainLayout>;
+    }
     return (
-      <MainLayout>
+      <MainLayout actions={actions} stores={stores}>
         <WalletWithNavigation
           isActiveScreen={this.isActiveScreen}
           onWalletNavItemClick={this.handleWalletNavItemClick}

--- a/app/containers/wallet/WalletAddPage.js
+++ b/app/containers/wallet/WalletAddPage.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { inject, observer } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { intlShape, defineMessages } from 'react-intl';
 import { ROUTES } from '../../routes-config';
 import WalletAdd from '../../components/wallet/WalletAdd';
@@ -26,11 +26,8 @@ const messages = defineMessages({
   },
 });
 
-@inject('actions', 'stores') @observer
+@observer
 export default class WalletAddPage extends Component<Props> {
-
-  static defaultProps = { actions: null, stores: null };
-
   static contextTypes = {
     intl: intlShape.isRequired,
   };
@@ -61,11 +58,17 @@ export default class WalletAddPage extends Component<Props> {
     let content = null;
 
     if (uiDialogs.isOpen(WalletCreateDialog)) {
-      content = <WalletCreateDialogContainer onClose={this.onClose} />;
+      content = (
+        <WalletCreateDialogContainer actions={actions} stores={stores} onClose={this.onClose} />
+      );
     } else if (uiDialogs.isOpen(WalletRestoreDialog)) {
-      content = <WalletRestoreDialogContainer onClose={this.onClose} />;
+      content = (
+        <WalletRestoreDialogContainer actions={actions} stores={stores} onClose={this.onClose} />
+      );
     } else if (uiDialogs.isOpen(WalletBackupDialog)) {
-      content = <WalletBackupDialogContainer onClose={this.onClose} />;
+      content = (
+        <WalletBackupDialogContainer actions={actions} stores={stores} onClose={this.onClose} />
+      );
     } else {
       content = (
         <WalletAdd

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { defineMessages, FormattedHTMLMessage } from 'react-intl';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { ellipsis } from '../../utils/strings';
 import config from '../../config';
 import WalletReceive from '../../components/wallet/WalletReceive';
@@ -24,11 +24,8 @@ type State = {
   copiedAddress: string,
 };
 
-@inject('stores', 'actions') @observer
+@observer
 export default class WalletReceivePage extends Component<Props, State> {
-
-  static defaultProps = { actions: null, stores: null };
-
   state = {
     copiedAddress: '',
   };

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -1,8 +1,8 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import type { InjectedContainerProps } from '../../types/injectedPropsType';
+import type { InjectedProps } from '../../types/injectedPropsType';
 import WalletTransactionsList from '../../components/wallet/transactions/WalletTransactionsList';
 import WalletSummary from '../../components/wallet/summary/WalletSummary';
 import WalletNoTransactions from '../../components/wallet/transactions/WalletNoTransactions';
@@ -12,7 +12,7 @@ import { Logger } from '../../utils/logging';
 
 const { formattedWalletAmount } = resolver('utils/formatters');
 
-type Props = InjectedContainerProps
+type Props = InjectedProps
 
 export const messages = defineMessages({
   noTransactions: {
@@ -28,10 +28,8 @@ export const messages = defineMessages({
   }
 });
 
-@inject('stores', 'actions') @observer
+@observer
 export default class WalletSummaryPage extends Component<Props> {
-  static defaultProps = { actions: null, stores: null };
-
   static contextTypes = {
     intl: intlShape.isRequired
   };

--- a/app/containers/wallet/dialogs/ChangeWalletPasswordDialogContainer.js
+++ b/app/containers/wallet/dialogs/ChangeWalletPasswordDialogContainer.js
@@ -1,14 +1,12 @@
 // @flow
 import React, { Component } from 'react';
-import { inject, observer } from 'mobx-react';
+import { observer } from 'mobx-react';
 import ChangeWalletPasswordDialog from '../../../components/wallet/settings/ChangeWalletPasswordDialog';
 import type { InjectedProps } from '../../../types/injectedPropsType';
 import environment from '../../../environment';
 
-@inject('actions', 'stores') @observer
+@observer
 export default class ChangeWalletPasswordDialogContainer extends Component<InjectedProps> {
-
-  static defaultProps = { actions: null, stores: null };
 
   render() {
     const { actions } = this.props;

--- a/app/containers/wallet/dialogs/WalletBackupDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletBackupDialogContainer.js
@@ -1,16 +1,14 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import WalletBackupDialog from '../../../components/wallet/WalletBackupDialog';
 import type { InjectedDialogContainerProps } from '../../../types/injectedPropsType';
 import environment from '../../../environment';
 
 type Props = InjectedDialogContainerProps;
 
-@inject('stores', 'actions') @observer
+@observer
 export default class WalletBackupDialogContainer extends Component<Props> {
-
-  static defaultProps = { actions: null, stores: null, children: null, onClose: () => {} };
 
   onCancelBackup = () => {
     this.props.onClose();

--- a/app/containers/wallet/dialogs/WalletCreateDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletCreateDialogContainer.js
@@ -1,16 +1,14 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import WalletCreateDialog from '../../../components/wallet/WalletCreateDialog';
 import type { InjectedDialogContainerProps } from '../../../types/injectedPropsType';
 import environment from '../../../environment';
 
 type Props = InjectedDialogContainerProps;
 
-@inject('stores', 'actions') @observer
+@observer
 export default class WalletCreateDialogContainer extends Component<Props> {
-
-  static defaultProps = { actions: null, stores: null, children: null, onClose: () => {} };
 
   onSubmit = (values: { name: string, password: string }) => {
     this.props.actions[environment.API].wallets.createWallet.trigger(values);

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import validWords from 'bip39/wordlists/english.json';
 import WalletRestoreDialog from '../../../components/wallet/WalletRestoreDialog';
 import type { InjectedDialogContainerProps } from '../../../types/injectedPropsType';
@@ -8,10 +8,8 @@ import environment from '../../../environment';
 
 type Props = InjectedDialogContainerProps;
 
-@inject('stores', 'actions') @observer
+@observer
 export default class WalletRestoreDialogContainer extends Component<Props> {
-
-  static defaultProps = { actions: null, stores: null, children: null, onClose: () => {} };
 
   onSubmit = (values: { recoveryPhrase: string, walletName: string, walletPassword: string }) => {
     this.props.actions[environment.API].wallets.restoreWallet.trigger(values);

--- a/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
@@ -1,16 +1,13 @@
 // @flow
 import React, { Component } from 'react';
-import { inject, observer } from 'mobx-react';
-import type { StoresMap } from '../../../stores/index';
-import type { ActionsMap } from '../../../actions/index';
+import { observer } from 'mobx-react';
 import environment from '../../../environment';
 import resolver from '../../../utils/imports';
+import type { InjectedProps } from '../../../types/injectedPropsType';
 
 const WalletSendConfirmationDialog = resolver('components/wallet/WalletSendConfirmationDialog');
 
-type Props = {
-  stores: any | StoresMap,
-  actions: any | ActionsMap,
+export type DialogProps = {
   amount: string,
   receiver: string,
   totalAmount: string,
@@ -18,11 +15,10 @@ type Props = {
   amountToNaturalUnits: (amountWithFractions: string) => string,
   currencyUnit: string,
 };
+type Props = InjectedProps & DialogProps;
 
-@inject('actions', 'stores') @observer
+@observer
 export default class WalletSendConfirmationDialogContainer extends Component<Props> {
-
-  static defaultProps = { actions: null, stores: null };
 
   handleWalletSendFormSubmit = (values: Object) => {
     this.props.actions[environment.API].wallets.sendMoney.trigger(values);
@@ -57,5 +53,4 @@ export default class WalletSendConfirmationDialogContainer extends Component<Pro
       />
     );
   }
-
 }

--- a/app/types/injectedPropsType.js
+++ b/app/types/injectedPropsType.js
@@ -4,19 +4,14 @@ import type { StoresMap } from '../stores/index';
 import type { ActionsMap } from '../actions/index';
 
 export type InjectedProps = {
-  stores: any | StoresMap,
-  actions: any | ActionsMap,
+  stores: StoresMap,
+  actions: ActionsMap,
 };
 
-export type InjectedContainerProps = {
-  stores: any | StoresMap,
-  actions: any | ActionsMap,
-  children: Node,
+export type InjectedContainerProps = InjectedProps & {
+  children?: Node,
 };
 
-export type InjectedDialogContainerProps = {
-  stores: any | StoresMap,
-  actions: any | ActionsMap,
-  children: Node,
+export type InjectedDialogContainerProps = InjectedContainerProps & {
   onClose: Function,
 };


### PR DESCRIPTION
More work needs to be done documenting these two folders but a few different improvements are already included in this PR so I'll get this one merged first.

This PR
- Gets rid of injection of stores/actions into containers (we need this to get rid of the weird Flow workaround where `mobx-react` injection isn't compatible with Flow. See [this article](https://wietse.loves.engineering/using-flowtype-with-decorators-in-react-af4fe69e66d6))
- Fixes eslint [require-default-props](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-default-props.md)
- Fixes eslint [button-has-type](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/button-has-type.md)
- Fixes eslint [no-array-index-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md)
- Fixed `TopBar.js` (component) depending on the `wallet` store (components should not depend on store)
- Fixed `WalletSettings.js` and `WalletSendForm.js` (both components) depending on containers (containers should not depend on components)

With this there should be no `eslint` errors left :)