### PR TITLE
Fix various manage-translations problems

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,8 @@
+#!/bin/bash                                                                      
+
+set -e
+
+# not purging your cache when you switch to a branch
+# which changed translation files can cause issues
+echo 'puring translation cache'
+npm run purge-translations

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ Check out our [documents](docs/specs/meta) on the governance of this project.
 ## First-time setup (or branch change)
 
 [SETUP.md](docs/SETUP.md)
-[TOOLS.md](docs/TOOLS.md)
 
-*if you switched git branches, it may affect translation files*. Consider [rebuilding the translation cache](app/i18n/README.md)
+[TOOLS.md](docs/TOOLS.md)
 
 ## Build Yoroi Chrome extension
 

--- a/app/i18n/README.md
+++ b/app/i18n/README.md
@@ -14,7 +14,7 @@ Now we can use `react-intl-translations-manager` to generate a report of our tra
 
 `babel-plugin-react-intl` forces us to pollute our code with all these `defineMessages` that require a default text also specified in the code. This causes duplication of the translations where it occurs in both our `json` and our source (you can see discussion about this [here](https://github.com/yahoo/babel-plugin-react-intl/issues/43)). We could fix this by wrapping `defineMessages` again with our own wrapper that removes this requirement.
 
-Since the `defineMessages` occur inside our code, it means you have to compile the project to detect which translations are used. This makes switching branches problematic since switching branches will invalidate your `translation/messages` cache and you have to rebuild to fix it (if you call `manage-translations` before doing this, you will get bad results).
+Since the `defineMessages` occur inside our code, it means you have to compile the project to detect which translations are used. This makes switching branches problematic since switching branches will invalidate your `translation/messages` cache and you have to rebuild to fix it (if you call `manage-translations` before doing this, you will get bad results). To fix this, we have a custom git hook that automatically purges the cache whenever you switch branches.
 
 One advantage is that this setup allows us to include the `translation-manager` results as part of our CI build (not done as of Oct 30th)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -55,3 +55,11 @@ Rebuild dll
 ```bash
 $ npm run build-dll
 ```
+
+### Git hooks
+
+To regiter the githooks locally you must run this command
+
+```bash
+$ git config core.hooksPath .githooks
+```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build-dll": "rimraf ./dll && webpack --config=webpack/dll.config.js",
     "build-js-cardano-wasm": "./setup_cardano_crypto.sh",
     "manage-translations": "node ./translations/translation-runner.js",
-    "purge-translations": "rm -rf ./translations/messages"
+    "purge-translations": "rimraf ./translations/messages"
   },
   "repository": {
     "type": "git",

--- a/translations/translation-runner.js
+++ b/translations/translation-runner.js
@@ -1,21 +1,30 @@
 const manageTranslations = require('react-intl-translations-manager').default;
 
+const fs = require('fs');
+
+const messagesDirectory = 'translations/messages';
+if (!fs.existsSync(messagesDirectory)) {
+  console.log('Run `npm run dev` once to build your translation cache');
+  return;
+}
+
 function disableWhitelistFile(langResults) {
   // we hijack this hook to modify an otherwise unrelated property
   // this causes a downstream function that writes whitelists to write to dev/null
   // kind of hacky but this suprpesses generation of pointless whitelist files
 
   // TBD: does this work on Windows? Maybe there is a more platform-independent way to do this
-  langResults.whitelistFilepath = "/dev/null";
+  langResults.whitelistFilepath = '/dev/null';
   return undefined;
 }
 
 manageTranslations({
-  messagesDirectory: 'translations/messages',
+  messagesDirectory,
   translationsDirectory: 'app/i18n/locales',
   singleMessagesFile: true,
   languages: ['en-US', 'zh-Hans', 'zh-Hant', 'ko-KR', 'ja-JP', 'ru-RU'],
   overrideCoreMethods: {
-    provideWhitelistFile: (langResults) => { disableWhitelistFile(langResults); }
+    provideWhitelistFile: (langResults) => { disableWhitelistFile(langResults); },
+    outputSingleFile: (combinedFiles) => { /* do nothing to suppress defaultMessages.json */ }
   }
 });


### PR DESCRIPTION
- can no longer accidentally call `manage-translations` before building rebuilding your translation cache (this used to delete all your i18n files)
- purge-translations automatically when checking out new branch (not doing this manually before caused `manage-translations` to give incorrect results)
- suppress generation of `defaultMessages.json` (used to be automatically generated after m`manage-translations` but was unnecessary)