### PR TITLE
TrezorConnect.cardanoSignTransaction() change outputs payload to use derived path

### DIFF
--- a/app/api/ada/adaTransactions/adaNewTransactions.js
+++ b/app/api/ada/adaTransactions/adaNewTransactions.js
@@ -203,6 +203,7 @@ function decodeRustTxWithInputs(
     outputs: tx.tx.tx.outputs.map(x => {
       if (x.address === changeAddress.cadId) {
         x.fullAddress = changeAddress;
+        x.isChange = true;
       }
       return x;
     })

--- a/app/api/ada/adaTransactions/adaNewTransactions.js
+++ b/app/api/ada/adaTransactions/adaNewTransactions.js
@@ -175,7 +175,7 @@ export async function getAdaTransactionFromSenders(
   cryptoWallet: CryptoWallet
 ): Promise<[SpendResponse, AdaAddress, UnsignedTransactionExt]> {
   // fetch new internal address from HD Wallet for change
-  const changeAdaAddr = await getAdaTransactionChangeAddr();
+  const changeAdaAddr : AdaAddress = await getAdaTransactionChangeAddr();
 
   // Consider any UTXO as a possible input
   const inputs = await getAdaTransactionInputs(senders);
@@ -185,12 +185,13 @@ export async function getAdaTransactionFromSenders(
   const result: SpendResponse = getResultOrFail(
     Wallet.spend(cryptoWallet, inputs, outputs, changeAdaAddr.cadId)
   );
-  return [result, changeAdaAddr, decodeRustTxWithInputs(result, inputs)];
+  return [result, changeAdaAddr, decodeRustTxWithInputs(result, inputs, changeAdaAddr)];
 }
 
 function decodeRustTxWithInputs(
   resp: SpendResponse,
-  availableInputs: Array<TxInput>
+  availableInputs: Array<TxInput>,
+  changeAddress: AdaAddress
 ): UnsignedTransactionExt {
   const tx: CryptoTransaction = decodeRustTx(resp.cbor_encoded_tx);
   const pointers : Array<TxInputPtr> = tx.tx.tx.inputs;
@@ -199,7 +200,12 @@ function decodeRustTxWithInputs(
   const selectedInputs = availableInputs.filter((inp: TxInput) => set.has(pointerToStr(inp.ptr)));
   return {
     inputs: selectedInputs,
-    outputs: tx.tx.tx.outputs
+    outputs: tx.tx.tx.outputs.map(x => {
+      if (x.address === changeAddress.cadId) {
+        x.fullAddress = changeAddress;
+      }
+      return x;
+    })
   };
 }
 

--- a/app/api/ada/adaTransactions/adaNewTransactions.js
+++ b/app/api/ada/adaTransactions/adaNewTransactions.js
@@ -202,8 +202,8 @@ function decodeRustTxWithInputs(
     inputs: selectedInputs,
     outputs: tx.tx.tx.outputs.map(x => {
       if (x.address === changeAddress.cadId) {
-        x.fullAddress = changeAddress;
         x.isChange = true;
+        x.fullAddress = changeAddress;
       }
       return x;
     })

--- a/app/api/ada/hardwareWallet/trezorNewTransactions.js
+++ b/app/api/ada/hardwareWallet/trezorNewTransactions.js
@@ -136,7 +136,7 @@ function _transformToTrezorInputs(inputs: Array<TxInput>): Array<TrezorInput> {
 
 function _generateTrezorOutputs(outputs: Array<TxOutput>): Array<TrezorOutput> {
   return outputs.map(x => ({
-    address: x.address,
+    address: x.fullAddress ? _derivePath(x.fullAddress.change, x.fullAddress.index) : x.address,
     amount: x.value.toString()
   }));
 }

--- a/app/api/ada/hardwareWallet/trezorNewTransactions.js
+++ b/app/api/ada/hardwareWallet/trezorNewTransactions.js
@@ -3,7 +3,8 @@ import _ from 'lodash';
 
 import {
   Logger,
-  stringifyError
+  stringifyError,
+  stringifyData
 } from '../../../utils/logging';
 import {
   saveAdaAddress,
@@ -137,8 +138,17 @@ function _transformToTrezorInputs(inputs: Array<TxInput>): Array<TrezorInput> {
 function _generateTrezorOutputs(outputs: Array<TxOutput>): Array<TrezorOutput> {
   return outputs.map(x => ({
     amount: x.value.toString(),
-    ...(x.fullAddress ?
-      { path: _derivePath(x.fullAddress.change, x.fullAddress.index) } :
-      { address: x.address })
+    ..._outputAddressOrPath(x)
   }));
+}
+
+function _outputAddressOrPath(out: TxOutput) {
+  if (out.isChange) {
+    const fullAddress : ?AdaAddress = out.fullAddress;
+    if (fullAddress) {
+      return { path: _derivePath(fullAddress.change, fullAddress.index) };
+    }
+    Logger.debug(`[WEIRD]: Trezor got a change output without a full 'Ada Address': ${stringifyData(out)}`);
+  }
+  return { address: out.address };
 }

--- a/app/api/ada/hardwareWallet/trezorNewTransactions.js
+++ b/app/api/ada/hardwareWallet/trezorNewTransactions.js
@@ -136,7 +136,9 @@ function _transformToTrezorInputs(inputs: Array<TxInput>): Array<TrezorInput> {
 
 function _generateTrezorOutputs(outputs: Array<TxOutput>): Array<TrezorOutput> {
   return outputs.map(x => ({
-    address: x.fullAddress ? _derivePath(x.fullAddress.change, x.fullAddress.index) : x.address,
-    amount: x.value.toString()
+    amount: x.value.toString(),
+    ...(x.fullAddress ?
+      { path: _derivePath(x.fullAddress.change, x.fullAddress.index) } :
+      { address: x.address })
   }));
 }

--- a/app/domain/TrezorSignTx.js
+++ b/app/domain/TrezorSignTx.js
@@ -7,7 +7,8 @@ export type TrezorInput = {
 }
 
 export type TrezorOutput = {
-  address: string,
+  address?: string,
+  path?: string,
   amount: string,
 }
 

--- a/flow/declarations/CardanoCrypto.js
+++ b/flow/declarations/CardanoCrypto.js
@@ -223,6 +223,7 @@ declare type TxDaedalusInput = {
 declare type TxOutput = {
   address: string,
   value: string,
+  isChange?: boolean,
   fullAddress?: AdaAddress
 }
 

--- a/flow/declarations/CardanoCrypto.js
+++ b/flow/declarations/CardanoCrypto.js
@@ -1,4 +1,4 @@
-import PasswordProtect from "../../js-cardano-wasm/js/PasswordProtect";
+import type { AdaAddress } from '../../app/api/ada/adaTypes';
 
 declare module 'rust-cardano-crypto' {
   declare module.exports: {
@@ -222,7 +222,8 @@ declare type TxDaedalusInput = {
 
 declare type TxOutput = {
   address: string,
-  value: string
+  value: string,
+  fullAddress?: AdaAddress
 }
 
 declare type AddressType = "External" | "Internal";


### PR DESCRIPTION
Closing #164

1. Introduced new optional field `TxOutput.fullAddress? : AdaAddress`
2. Added full-address resolving in `adaNewTransactions.js/decodeRustTxWithInputs`
3. Added case-check for full address in `trezorNewTransactions.js/_generateTrezorOutputs`