### PR TITLE
better development debugging source-map

### DIFF
--- a/webpack/development.config.js
+++ b/webpack/development.config.js
@@ -11,7 +11,7 @@ const hotScript =
   'webpack-hot-middleware/client?path=__webpack_hmr&dynamicPublicPath=true';
 
 const baseDevConfig = () => ({
-  devtool: 'eval-cheap-module-source-map',
+  devtool: 'eval-source-map',
   entry: {
     yoroi: [
       customPath,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19986226/50003463-09b22c00-ffe7-11e8-9470-1a47c29b300d.png)


Changed webpack devtool for development environment only:
`eval-cheap-module-source-map`  -> `eval-source-map`

This will enable better debugging in chrome devtools. [REF](https://webpack.js.org/configuration/devtool/)