### PR TITLE
ruslan / Delete unused flow type field

### DIFF
--- a/flow/declarations/CardanoCrypto.js
+++ b/flow/declarations/CardanoCrypto.js
@@ -150,7 +150,6 @@ declare type CryptoWallet = {
 }
 
 declare type CryptoDaedalusWallet = {
-  root_key: string,
   root_cached_key: string,
   config: CryptoConfig,
   selection_policy: SelectionPolicy,

--- a/flow/declarations/CardanoCrypto.js
+++ b/flow/declarations/CardanoCrypto.js
@@ -150,7 +150,7 @@ declare type CryptoWallet = {
 }
 
 declare type CryptoDaedalusWallet = {
-  root_cached_key: string,
+  root_cached_key: string, // equal to `root_key` in CryptoWallet
   config: CryptoConfig,
   selection_policy: SelectionPolicy,
   derivation_scheme: DerivationScheme


### PR DESCRIPTION
`CardanoCrypto.js/CryptoDaedalusWallet.root_key` is never used and there's no such field in the corresponding Rust type - https://github.com/input-output-hk/js-cardano-wasm/blob/def5d9a0ebd69435d29e737c7e99ea04f692ab70/wallet-wasm/src/lib.rs#L612

Also this field was very confusing next to `root_cached_key`.