### PR TITLE
Temporally hide foot links

### DIFF
--- a/app/containers/wallet/Wallet.js
+++ b/app/containers/wallet/Wallet.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import MainLayout from '../MainLayout';
 import WalletWithNavigation from '../../components/wallet/layouts/WalletWithNavigation';
-import HelpLinkFooter from '../../components/footer/HelpLinkFooter';
 import LoadingSpinner from '../../components/widgets/LoadingSpinner';
 import { buildRoute } from '../../utils/routing';
 import { ROUTES } from '../../routes-config';
@@ -38,12 +37,7 @@ export default class Wallet extends Component<Props> {
       return <MainLayout actions={actions} stores={stores}><LoadingSpinner /></MainLayout>;
     }
 
-    const footer = wallets.active.isWebWallet ?
-      (<HelpLinkFooter
-        showBuyTrezorHardwareWallet
-        showWhatIsHardwareWallet
-      />) :
-      undefined;
+    const footer = undefined;
 
     return (
       <MainLayout


### PR DESCRIPTION
Hides footer links for now, because it felt too pushy under normal usage.

<img width="840" alt="screen shot 2018-12-30 at 5 48 18 am" src="https://user-images.githubusercontent.com/1622112/50546998-cd5f0c80-0c31-11e9-9f2d-3590fd38b760.png">
