### PR TITLE
ID calculation for newly sent transactions

### DIFF
--- a/app/api/ada/adaTransactions/adaNewTransactions.js
+++ b/app/api/ada/adaTransactions/adaNewTransactions.js
@@ -44,6 +44,7 @@ import {
 import { getSingleCryptoAccount, getWalletMasterKey } from '../adaLocalStorage';
 import type { ConfigType } from '../../../../config/config-types';
 import type { AdaAddressMap } from '../adaAddress';
+import type { SignedResponse } from '../lib/yoroi-backend-api';
 
 declare var CONFIG: ConfigType;
 
@@ -79,7 +80,7 @@ export async function newAdaTransaction(
   receiver: string,
   amount: string,
   password: string
-): Promise<Array<void>> {
+): Promise<SignedResponse> {
   const masterKey = getWalletMasterKey();
   const cryptoWallet = getCryptoWalletFromMasterKey(masterKey, password);
   // eslint-disable-next-line camelcase

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -87,6 +87,7 @@ import { InvalidWitnessError } from './errors';
 import { WrongPassphraseError } from './lib/cardanoCrypto/cryptoErrors';
 import { getSingleCryptoAccount, getAdaWallet, getLastBlockNumber } from './adaLocalStorage';
 import { saveTxs } from './lib/lovefieldDatabase';
+import type { SignedResponse } from './lib/yoroi-backend-api';
 
 // ADA specific Request / Response params
 export type CreateAddressResponse = WalletAddress;
@@ -277,7 +278,7 @@ export default class AdaApi {
 
   async createTransaction(
     request: CreateTransactionRequest
-  ): Promise<Array<void>> {
+  ): Promise<SignedResponse> {
     Logger.debug('AdaApi::createTransaction called');
     const { receiver, amount, password } = request;
     try {

--- a/app/api/ada/lib/utils.js
+++ b/app/api/ada/lib/utils.js
@@ -11,6 +11,8 @@ import type {
 import {
   stringifyError
 } from '../../../utils/logging';
+// eslint-disable-next-line
+import { Blake2b } from 'rust-cardano-crypto';
 
 export const localeDateToUnixTimestamp =
   (localeDate: string) => new Date(localeDate).getTime();
@@ -64,6 +66,48 @@ const _getTxCondition = (state: string): AdaTransactionCondition => {
   if (state === 'Pending') return 'CPtxApplying';
   return 'CPtxWontApply';
 };
+
+export class CborIndefiniteLengthArray {
+  elements: Array<any>;
+  constructor(elements: Array<any>) {
+    this.elements = elements;
+  }
+  encodeCBOR(encoder: cbor.Encoder) {
+    return encoder.push(
+      Buffer.concat([
+        Buffer.from([0x9f]), // indefinite array prefix
+        ...this.elements.map((e) => cbor.encode(e)),
+        Buffer.from([0xff]), // end of array
+      ])
+    );
+  }
+}
+
+export function rustRawTxToId(rustTxBody: RustRawTxBody): string {
+  if (!rustTxBody) {
+    throw new Error('Cannot decode inputs from undefined transaction!');
+  }
+  try {
+    const [inputs, outputs, attributes] = decodedTxToAux(cbor.decode(Buffer.from(rustTxBody)));
+    const enc = cbor.encode([
+      new CborIndefiniteLengthArray(inputs),
+      new CborIndefiniteLengthArray(outputs),
+      attributes
+    ]);
+    // eslint-disable-next-line
+    return Buffer.from(Blake2b.blake2b_256(enc)).toString('hex');
+  } catch (e) {
+    throw new Error('Failed to convert raw transaction to ID! ' + stringifyError(e));
+  }
+}
+
+function decodedTxToAux(decodedTx) {
+  switch (decodedTx.length) {
+    case 2: return decodedTx[0]; // signed
+    case 3: return decodedTx; // unsigned
+    default: throw new Error('Unexpected decoded tx structure! ' + JSON.stringify(decodedTx));
+  }
+}
 
 export function decodeRustTx(rustTxBody: RustRawTxBody): CryptoTransaction {
   if (!rustTxBody) {

--- a/app/api/ada/lib/yoroi-backend-api.js
+++ b/app/api/ada/lib/yoroi-backend-api.js
@@ -22,6 +22,7 @@ import type {
   UTXO,
   Transaction
 } from '../adaTypes';
+import { rustRawTxToId } from './utils';
 
 declare var CONFIG: ConfigType;
 const backendUrl = CONFIG.network.backendUrl;
@@ -118,7 +119,9 @@ export const getTransactionsHistoryForAddresses = (
 export type SignedRequest = {
   signedTx: string
 };
-export type SignedResponse = Array<void>;
+export type SignedResponse = {
+  txId: string
+};
 
 export const sendTx = (
   body: SignedRequest
@@ -131,7 +134,9 @@ export const sendTx = (
         signedTx: body.signedTx
       }
     }
-  ).then(response => response.data)
+  ).then(() => ({
+    txId: rustRawTxToId(Buffer.from(body.signedTx, 'base64'))
+  }))
     .catch((error) => {
       Logger.error('yoroi-backend-api::sendTx error: ' + stringifyError(error));
       if (error.request.response.includes('Invalid witness')) {

--- a/app/api/common.js
+++ b/app/api/common.js
@@ -10,6 +10,7 @@ import LocalizableError from '../i18n/LocalizableError';
 import WalletTransaction from '../domain/WalletTransaction';
 import WalletAddress from '../domain/WalletAddress';
 import Wallet from '../domain/Wallet';
+import type { SignedResponse } from './ada/lib/yoroi-backend-api';
 
 const messages = defineMessages({
   genericApiError: {
@@ -139,9 +140,9 @@ export type UpdateWalletPasswordResponse = boolean;
 
 export type UpdateWalletResponse = Wallet;
 
-export type CreateTransactionResponse = Array<void>;
+export type CreateTransactionResponse = SignedResponse;
 
-export type SendTrezorSignedTxResponse = Array<void>;
+export type SendTrezorSignedTxResponse = SignedResponse;
 
 export type GetWalletsResponse = Array<Wallet>;
 

--- a/app/stores/ada/DaedalusTransferStore.js
+++ b/app/stores/ada/DaedalusTransferStore.js
@@ -23,6 +23,7 @@ import {
   generateTransferTx
 } from '../../api/ada/daedalusTransfer';
 import environment from '../../environment';
+import type { SignedResponse } from '../../api/ada/lib/yoroi-backend-api';
 
 declare var CONFIG: ConfigType;
 const websocketUrl = CONFIG.network.websocketUrl;
@@ -35,7 +36,7 @@ export default class DaedalusTransferStore extends Store {
   @observable disableTransferFunds: boolean = true;
   @observable error: ?LocalizableError = null;
   @observable transferTx: ?TransferTx = null;
-  @observable transferFundsRequest: Request<Array<void>> = new Request(this._transferFundsRequest);
+  @observable transferFundsRequest: Request<SignedResponse> = new Request(this._transferFundsRequest);
   @observable ws: any = null;
 
   setup(): void {
@@ -158,7 +159,7 @@ export default class DaedalusTransferStore extends Store {
   /** Send a transaction to the backend-service to be broadcast into the network */
   _transferFundsRequest = async (payload: {
     cborEncodedTx: Array<number>
-  }): Promise<Array<void>> => {
+  }): Promise<SignedResponse> => {
     const { cborEncodedTx } = payload;
     const signedTx = Buffer.from(cborEncodedTx).toString('base64');
     return sendTx({ signedTx });

--- a/features/support/mockServer.js
+++ b/features/support/mockServer.js
@@ -46,7 +46,7 @@ function _defaultSignedTransaction(
   },
   res: { send(arg: SignedResponse): any }
 ): void {
-  res.send([]);
+  res.send({ txId: 'id' });
 }
 
 let MockServer = null;

--- a/flow/declarations/CardanoCrypto.js
+++ b/flow/declarations/CardanoCrypto.js
@@ -127,7 +127,7 @@ declare module 'rust-cardano-crypto' {
   }
 }
 
-declare type RustRawTxBody = Array<number>
+declare type RustRawTxBody = Array<number> | Buffer
 
 declare type SpendResponse = {
   cbor_encoded_tx: RustRawTxBody,


### PR DESCRIPTION
1. Call to `yoroi-backend-api.js/sendTx` now returns instance of `SignedResponse` with the `txId` field.
2. `adaNewTransactions.js/newAdaTransaction` and `trezorNewTransactions.js/newTrezorTransaction` are returning the same result instance
3. `api/ada/index.js/newAdaTransaction` and `api/ada/index.js/sendTrezorSignedTx` also return the same result instance

It was necessary to implement `CborIndefiniteLengthArray` in utils, because `cbor.encode(cbor.decode(data))` genuinely returns result different from initial data.