### PR TITLE
fix password validation

### DIFF
--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.js
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.js
@@ -86,10 +86,6 @@ export default class ChangeWalletPasswordDialog extends Component<Props> {
         label: this.context.intl.formatMessage(messages.currentPasswordLabel),
         placeholder: this.context.intl.formatMessage(messages.currentPasswordFieldPlaceholder),
         value: '',
-        validators: [({ field }) => [
-          isValidWalletPassword(field.value),
-          this.context.intl.formatMessage(globalMessages.invalidWalletPassword)
-        ]],
       },
       walletPassword: {
         type: 'password',


### PR DESCRIPTION
### Premise
1) In my PR for #219 I changed the validation rules for passwords which includes a more-strict length requirement.
2) When changing a wallet password, the field "current password" is checked using the password validation rules.

Therefore if your password was valid under the old rules but is no longer valid now, you can no longer change your password.