### PR TITLE
Fix vulnerability in reactdom 16.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11772,9 +11772,9 @@
       }
     },
     "react-dom": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.0.0.tgz",
-      "integrity": "sha1-nMMHnD3NcNTG4BuEqrKn40wwP1g=",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.0.1.tgz",
+      "integrity": "sha512-gGJNmuS0VpkJsNStpzplcgc4iuHJ2X8rjiiaY/5YfHrsAd2cw1JkMXD6Z1kBOed8rDUNrRYrnDYptnhFghFFhA==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "react": "16.0.0",
     "react-copy-to-clipboard": "5.0.0",
     "react-css-themr": "2.1.2",
-    "react-dom": "16.0.0",
+    "react-dom": "16.0.1",
     "react-hot-loader": "4.3.12",
     "react-intl": "2.7.2",
     "react-markdown": "2.5.0",


### PR DESCRIPTION
Simple fix. The package upgrade doesn't change anything but fix the vulnerability.

You can read more [here](https://github.com/facebook/react/blob/master/CHANGELOG.md#react-dom-server-11)