### PR TITLE
log time even on empty logs

### DIFF
--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -38,7 +38,7 @@ export const downloadLogs = () => {
   const header = generateLogHeader();
   let errorLogs = logs.peekN(logs.size());
   if (errorLogs.length === 0) {
-    errorLogs = ['No errors logged.'];
+    errorLogs = [`[${moment().format()}] No errors logged.`];
   }
   errorLogs.unshift(header);
   const blob = new Blob(errorLogs, { type: 'text/plain;charset=utf-8' });


### PR DESCRIPTION
Fix #87 

Example output:

```
[INFO] Yoroi v.0.0.12
[INFO] Commit: d553fb134c552cfbf237458619b363bd6ca25f17
[INFO] Network: testnet
[2019-01-15T08:02:19+09:00] No errors logged.
```