### PR TITLE
Fix onClick in WalletSendConfirmationDialog

### DIFF
--- a/app/components/wallet/send/WalletSendConfirmationDialog.js
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.js
@@ -116,7 +116,9 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
     const actions = [
       {
         label: intl.formatMessage(globalMessages.walletSendConfirmationBackButtonLabel),
-        onClick: !isSubmitting && onCancel,
+        onClick: isSubmitting
+          ? () => {} // noop
+          : onCancel
       },
       {
         label: intl.formatMessage(messages.sendButtonLabel),


### PR DESCRIPTION
If `isSubmitting` was true, then `onClick` resolve as `false` which throws this exception

```
vendor.js:24654 Warning: Expected `onClick` listener to be a function, instead got a value of `boolean` type.
    in button (created by ButtonSkin)
    in ButtonSkin (created by Button)
    in Button (created by Consumer)
    in Consumer (created by withTheme(Button))
    in withTheme(Button) (created by Dialog)
    in div (created by Dialog)
    in div (created by Dialog)
    in div (created by ModalPortal)
    in div (created by ModalPortal)
    in ModalPortal (created by Modal)
    in Modal (created by ModalSkin)
    in ModalSkin (created by Modal)
    in Modal (created by Consumer)
    in Consumer (created by withTheme(Modal))
    in withTheme(Modal) (created by Dialog)
    in Dialog (created by WalletSendConfirmationDialog)
    in WalletSendConfirmationDialog (created by WalletSendConfirmationDialogContainer)
    in WalletSendConfirmationDialogContainer (created by WalletSendForm)
    in div (created by WalletSendForm)
    in div (created by WalletSendForm)
    in WalletSendForm (created by WalletSendPage)
    in WalletSendPage (created by component)
    in component (created by Route)
    in Route (created by component)
    in Switch (created by component)
    in div (created by WalletWithNavigation)
    in div (created by WalletWithNavigation)
    in WalletWithNavigation (created by Wallet)
    in div (created by TopBarLayout)
    in div (created by TopBarLayout)
    in div (created by TopBarLayout)
    in div (created by TopBarLayout)
    in TopBarLayout (created by MainLayout)
    in MainLayout (created by Wallet)
    in Wallet (created by component)
    in component (created by Route)
    in Route (created by App)
    in Switch (created by App)
    in div (created by App)
    in Router (created by App)
    in IntlProvider (created by App)
    in Provider (created by ThemeProvider)
    in ThemeProvider (created by App)
    in div (created by App)
    in App
```