### PR TITLE
Generate screenshots during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ production-key.pem
 build/
 dev/
 dll/
+screenshots/
 
 *.zip
 *.xpi

--- a/features/settings-ui.feature
+++ b/features/settings-ui.feature
@@ -158,9 +158,9 @@ Feature: Wallet UI Settings
     When I navigate to the general settings screen
     And I open General Settings language selection dropdown
     And I select Japanese language
-    Then I should see Japanese language as selected
+    Then The Japanese language should be selected
     When I refresh the page
-    Then I should see Japanese language as selected
+    Then The Japanese language should be selected
 
   @it-3
   Scenario: Yoroi Settings Screen / Terms of Use in Default English(IT-3)

--- a/features/step_definitions/common-steps.js
+++ b/features/step_definitions/common-steps.js
@@ -1,11 +1,27 @@
 // @flow
 
-import { BeforeAll, Given, After, AfterAll } from 'cucumber';
+import { Before, BeforeAll, Given, After, AfterAll, setDefinitionFunctionWrapper } from 'cucumber';
 import { getMockServer, closeMockServer } from '../support/mockServer';
 import { buildFeatureData, getFeatureData, getFakeAddresses } from '../support/mockDataBuilder';
 import i18nHelper from '../support/helpers/i18n-helpers';
 
+const { promisify } = require('util');
+const fs = require('fs');
+const rimraf = require('rimraf');
+
+const screenshotsDir = './screenshots/';
+
+/** We need to keep track of our progress in testing to give unique names to screenshots */
+const testProgress = {
+  scenarioName: '',
+  lineNum: 0, // we need this to differentiate scenarios with multiple "examples"
+  step: 0
+};
+
 BeforeAll(() => {
+  rimraf.sync(screenshotsDir);
+  fs.mkdirSync(screenshotsDir);
+
   getMockServer({});
 });
 
@@ -13,8 +29,47 @@ AfterAll(() => {
   closeMockServer();
 });
 
+Before((scenario) => {
+  // cleanup scenario name so it is folder-name friendly
+  testProgress.scenarioName = scenario.pickle.name.replace(/[^0-9a-z_ ]/gi, '');
+  testProgress.lineNum = scenario.sourceLocation.line;
+  testProgress.step = 0;
+});
+
+
 After(async function () {
   await this.driver.quit();
+});
+
+const writeFile = promisify(fs.writeFile);
+
+/** Wrap every step to take screenshots for UI-based testing */
+setDefinitionFunctionWrapper((fn, _, pattern) => {
+  if (!pattern) {
+    return fn;
+  }
+  return async function (...args) {
+    const ret = await fn.apply(this, args);
+
+    // Regex patterns contain non-ascii characters.
+    // We want to remove this to get a filename-friendly string
+    const cleanString = pattern.toString().replace(/[^0-9a-z_ ]/gi, '');
+
+    if (cleanString.includes('I should see')) {
+      // path logic
+      const dir = `${screenshotsDir}/${testProgress.scenarioName}`;
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+      }
+      const path = `${dir}/${testProgress.step}_${testProgress.lineNum}-${cleanString}.png`;
+
+      const screenshot = await this.driver.takeScreenshot();
+      await writeFile(path, screenshot, 'base64');
+    }
+
+    testProgress.step += 1;
+    return ret;
+  };
 });
 
 Given(/^I am testing "([^"]*)"$/, feature => {

--- a/features/step_definitions/general-settings-steps.js
+++ b/features/step_definitions/general-settings-steps.js
@@ -34,7 +34,7 @@ Then(/^I should see secondary menu (.*) item disabled$/, async function (buttonN
 });
 
 Then(/^The Japanese language should be selected$/, async function () {
-  return this.driver.wait(async () => {
+  this.driver.wait(async () => {
     const activeLanguage = await i18n.getActiveLanguage(this.driver);
     return activeLanguage === 'ja-JP';
   });

--- a/features/step_definitions/general-settings-steps.js
+++ b/features/step_definitions/general-settings-steps.js
@@ -33,8 +33,8 @@ Then(/^I should see secondary menu (.*) item disabled$/, async function (buttonN
   await this.waitUntilText(buttonSelector, label);
 });
 
-Then(/^I should see Japanese language as selected$/, async function () {
-  this.driver.wait(async () => {
+Then(/^The Japanese language should be selected$/, async function () {
+  return this.driver.wait(async () => {
     const activeLanguage = await i18n.getActiveLanguage(this.driver);
     return activeLanguage === 'ja-JP';
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,6 +1333,30 @@
         }
       }
     },
+    "@babel/polyfill": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.6.3",
+        "regenerator-runtime": "0.12.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+          "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",
@@ -2039,7 +2063,7 @@
       "integrity": "sha512-cjC3jUCh9spkroKue5PDSKH5RFQ/KNuZJhk3GwHYmB/8qqETxLOmMdLH+ohi/VukNzxDlMvIe7zScvLoOdhb6Q==",
       "dev": true,
       "requires": {
-        "diff": "3.2.0",
+        "diff": "3.5.0",
         "pad-right": "0.2.2",
         "repeat-string": "1.6.1"
       }
@@ -2189,55 +2213,10 @@
       }
     },
     "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.11",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
-          "requires": {
-            "core-js": "2.6.2",
-            "regenerator-runtime": "0.11.1"
-          }
-        },
-        "core-js": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
-          "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "dev": true
     },
     "babel-eslint": {
       "version": "10.0.1",
@@ -2315,14 +2294,14 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.6.2",
+            "core-js": "2.6.3",
             "regenerator-runtime": "0.11.1"
           }
         },
         "core-js": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
-          "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+          "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
           "dev": true
         }
       }
@@ -2598,27 +2577,60 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.6.2",
+        "core-js": "2.6.3",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.11",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       },
       "dependencies": {
+        "babel-core": {
+          "version": "6.26.3",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          }
+        },
         "babel-runtime": {
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.6.2",
+            "core-js": "2.6.3",
             "regenerator-runtime": "0.11.1"
           }
         },
         "core-js": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
-          "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+          "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -3471,7 +3483,7 @@
         "anymatch": "2.0.0",
         "async-each": "1.0.1",
         "braces": "2.3.2",
-        "fsevents": "1.2.4",
+        "fsevents": "1.2.7",
         "glob-parent": "3.1.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3670,20 +3682,47 @@
         "restore-cursor": "2.0.0"
       }
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+    "cli-table3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "requires": {
-        "colors": "1.0.3"
+        "colors": "1.1.2",
+        "object-assign": "4.1.1",
+        "string-width": "2.1.1"
       },
       "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
@@ -4479,70 +4518,71 @@
       }
     },
     "cucumber": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-4.2.1.tgz",
-      "integrity": "sha512-3gQ0Vv4kSHsvXEFC6b1c+TfLRDzWD1/kU7e5vm8Kh8j35b95k6favan9/4ixcBNqd7UsU1T6FYcawC87+DlNKw==",
+      "version": "git+https://github.com/SebastienGllmt/cucumber-js.git#965b44ed683ac8d8facbd3e242072d37f48426d6",
       "dev": true,
       "requires": {
+        "@babel/polyfill": "7.2.5",
         "assertion-error-formatter": "2.0.1",
-        "babel-runtime": "6.26.0",
-        "bluebird": "3.5.1",
-        "cli-table": "0.3.1",
+        "bluebird": "3.5.3",
+        "cli-table3": "0.5.1",
         "colors": "1.1.2",
         "commander": "2.15.0",
-        "cucumber-expressions": "5.0.18",
+        "cross-spawn": "6.0.5",
+        "cucumber-expressions": "6.0.1",
         "cucumber-tag-expressions": "1.1.1",
-        "duration": "0.2.0",
+        "duration": "0.2.2",
         "escape-string-regexp": "1.0.5",
         "figures": "2.0.0",
-        "gherkin": "5.0.0",
-        "glob": "7.1.2",
+        "gherkin": "5.1.0",
+        "glob": "7.1.3",
         "indent-string": "3.2.0",
         "is-generator": "1.0.3",
         "is-stream": "1.1.0",
         "knuth-shuffle-seeded": "1.0.6",
         "lodash": "4.17.11",
         "mz": "2.7.0",
-        "progress": "2.0.0",
+        "progress": "2.0.1",
         "resolve": "1.5.0",
-        "serialize-error": "2.1.0",
+        "serialize-error": "3.0.0",
         "stack-chain": "2.0.0",
         "stacktrace-js": "2.0.0",
-        "string-argv": "0.0.2",
+        "string-argv": "0.1.1",
         "title-case": "2.1.1",
         "util-arity": "1.1.0",
         "verror": "1.10.0"
       },
       "dependencies": {
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+        "bluebird": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "core-js": "2.5.7",
-            "regenerator-runtime": "0.11.1"
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-          "dev": true
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "indent-string": {
@@ -4550,19 +4590,13 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
-        },
-        "progress": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-          "dev": true
         }
       }
     },
     "cucumber-expressions": {
-      "version": "5.0.18",
-      "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-5.0.18.tgz",
-      "integrity": "sha1-bHB3nv0668Xp54U5OLERAyJClZY=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-6.0.1.tgz",
+      "integrity": "sha1-R8nFc3gcL/ch161bLNHJf0OZq44=",
       "dev": true,
       "requires": {
         "becke-ch--regex--s0-0-v1--base--pl--lib": "1.4.0"
@@ -4848,9 +4882,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "diffie-hellman": {
@@ -4924,22 +4958,24 @@
       "dev": true
     },
     "duration": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.0.tgz",
-      "integrity": "sha1-X5xN+q//ZV3phhEu/iXFl43YUUY=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
+      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
       "dev": true,
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.40"
+        "d": "1.0.0",
+        "es5-ext": "0.10.47"
       },
       "dependencies": {
-        "d": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-          "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+        "es5-ext": {
+          "version": "0.10.47",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.47.tgz",
+          "integrity": "sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.40"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1",
+            "next-tick": "1.0.0"
           }
         }
       }
@@ -5048,6 +5084,15 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
+      "integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
+      "dev": true,
+      "requires": {
+        "stackframe": "1.0.4"
       }
     },
     "errorhandler": {
@@ -6751,13 +6796,13 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
+        "node-pre-gyp": "0.10.3"
       },
       "dependencies": {
         "abbrev": {
@@ -6775,7 +6820,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6796,7 +6841,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "optional": true
         },
@@ -6826,7 +6871,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "optional": true
         },
@@ -6845,7 +6890,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "2.3.5"
           }
         },
         "fs.realpath": {
@@ -6865,11 +6910,11 @@
             "signal-exit": "3.0.2",
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6887,7 +6932,7 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6944,19 +6989,19 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "2.3.5"
           }
         },
         "mkdirp": {
@@ -6972,30 +7017,30 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "optional": true,
           "requires": {
             "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
+            "iconv-lite": "0.4.24",
             "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "optional": true,
           "requires": {
             "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
-            "needle": "2.2.0",
+            "needle": "2.2.4",
             "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
+            "npm-packlist": "1.2.0",
             "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "rc": "1.2.8",
+            "rimraf": "2.6.3",
+            "semver": "5.6.0",
+            "tar": "4.4.8"
           }
         },
         "nopt": {
@@ -7008,17 +7053,17 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "npm-bundled": "1.0.5"
           }
         },
         "npmlog": {
@@ -7026,7 +7071,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
+            "are-we-there-yet": "1.1.5",
             "console-control-strings": "1.1.0",
             "gauge": "2.7.4",
             "set-blocking": "2.0.0"
@@ -7078,11 +7123,11 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
+            "deep-extend": "0.6.0",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -7104,21 +7149,21 @@
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true
         },
         "safer-buffer": {
@@ -7132,7 +7177,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "optional": true
         },
@@ -7160,7 +7205,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
@@ -7176,17 +7221,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
+            "chownr": "1.1.1",
             "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
             "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "util-deprecate": {
@@ -7195,7 +7240,7 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7207,7 +7252,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true
         }
       }
@@ -7371,9 +7416,9 @@
       }
     },
     "gherkin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-5.0.0.tgz",
-      "integrity": "sha1-lt70EZjsOQgli1Ea909lWidk0qE=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-5.1.0.tgz",
+      "integrity": "sha1-aEu7A63STq9731RPWAM+so+zxtU=",
       "dev": true
     },
     "glob": {
@@ -8991,6 +9036,43 @@
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
+        "babel-core": {
+          "version": "6.26.3",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.6.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
@@ -9001,6 +9083,12 @@
             "preserve": "0.2.0",
             "repeat-element": "1.1.2"
           }
+        },
+        "core-js": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+          "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+          "dev": true
         },
         "expand-brackets": {
           "version": "0.1.5",
@@ -9055,6 +9143,12 @@
             "parse-glob": "3.0.4",
             "regex-cache": "0.4.4"
           }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -9065,7 +9159,7 @@
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
-        "diff": "3.2.0",
+        "diff": "3.5.0",
         "jest-get-type": "22.4.3",
         "pretty-format": "23.6.0"
       }
@@ -9474,6 +9568,43 @@
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
+        "babel-core": {
+          "version": "6.26.3",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.6.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
@@ -9501,6 +9632,12 @@
             "strip-ansi": "4.0.0",
             "wrap-ansi": "2.1.0"
           }
+        },
+        "core-js": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+          "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+          "dev": true
         },
         "expand-brackets": {
           "version": "0.1.5",
@@ -9570,6 +9707,12 @@
             "parse-glob": "3.0.4",
             "regex-cache": "0.4.4"
           }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
@@ -11395,6 +11538,12 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.0.tgz",
       "integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g==",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
@@ -16708,7 +16857,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.1",
-            "fsevents": "1.2.4",
+            "fsevents": "1.2.7",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -19855,7 +20004,7 @@
         "capture-exit": "1.2.0",
         "exec-sh": "0.2.2",
         "fb-watchman": "2.0.0",
-        "fsevents": "1.2.4",
+        "fsevents": "1.2.7",
         "micromatch": "3.1.10",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -20151,9 +20300,9 @@
       }
     },
     "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-3.0.0.tgz",
+      "integrity": "sha512-+y3nkkG/go1Vdw+2f/+XUXM1DXX1XcxTl99FfiD/OEPUNw4uo0i6FKABfTAN5ZcgGtjTRZcEbxcE/jtXbEY19A==",
       "dev": true
     },
     "serve-static": {
@@ -20555,26 +20704,24 @@
       "dev": true
     },
     "stack-generator": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.2.tgz",
-      "integrity": "sha512-Qj3X+vY7qQ0OOLQomEihHk5SSnSPCI3z4RfB8kDk9lnzwznBODlkWODitEo8sHpp0a2VdSy3yuJkabNsQN5RGA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
+      "integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
       "dev": true,
       "requires": {
         "stackframe": "1.0.4"
-      },
-      "dependencies": {
-        "stackframe": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-          "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
-          "dev": true
-        }
       }
     },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "dev": true
+    },
+    "stackframe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
       "dev": true
     },
     "stacktrace-gps": {
@@ -20592,12 +20739,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
-        },
-        "stackframe": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-          "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
-          "dev": true
         }
       }
     },
@@ -20607,26 +20748,9 @@
       "integrity": "sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=",
       "dev": true,
       "requires": {
-        "error-stack-parser": "2.0.1",
-        "stack-generator": "2.0.2",
+        "error-stack-parser": "2.0.2",
+        "stack-generator": "2.0.3",
         "stacktrace-gps": "3.0.2"
-      },
-      "dependencies": {
-        "error-stack-parser": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
-          "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
-          "dev": true,
-          "requires": {
-            "stackframe": "1.0.4"
-          }
-        },
-        "stackframe": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-          "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
-          "dev": true
-        }
       }
     },
     "static-extend": {
@@ -20736,9 +20860,9 @@
       "dev": true
     },
     "string-argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
-      "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.1.1.tgz",
+      "integrity": "sha512-El1Va5ehZ0XTj3Ekw4WFidXvTmt9SrC0+eigdojgtJMVtPkF0qbBe9fyNSl9eQf+kUHnTSQxdQYzuHfZy8V+DQ==",
       "dev": true
     },
     "string-length": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "config-webpack": "1.0.4",
     "crx": "3.2.1",
     "css-loader": "0.25.0",
-    "cucumber": "4.2.1",
+    "cucumber": "git+https://github.com/SebastienGllmt/cucumber-js.git",
     "eslint": "5.8.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-plugin-flowtype": "3.2.0",


### PR DESCRIPTION
# Overview

This PR makes that all `cucumber-js` steps that contain "I should see" take a screenshot AFTER the step is done.

The problem with screenshot-based testing is that you may get very small pixel differences between baseline.
This is caused by UI elements like a spinner indicating a loading (the difference could just be the spinner at a different rotation)

The rationale for only taking screenshots on "I should see" tests is that these tests should BLOcK on UI elements and "see" a stable view of the UI after the blocking is done
This is exactly what we want to take a screenshot of to compare with.

# Changes made to `cucumber` library

Unfortunately Cucumber doesn't let you add a hook for every step (which is what we need)

To fix this, I did the following: 

1) Upgraded `cucumber-js` to 5.1.0 (changelog [here](https://github.com/cucumber/cucumber-js/blob/master/CHANGELOG.md))
2) Forked `cucumber-js` into my own repo
3) Copied [this PR](https://github.com/cucumber/cucumber-js/pull/1121) to my personal repo
4) Made changes to my branch to match NPM releae format of `cucumber-js` (notably, `lib` folder was required (otherwise in .gitignore)

# Future work

You can see for example in my PR, one of our tests said "I should see" but in fact it had no blocking UI call at all (it only checked the value of some variable)

Therefore, to effectively do screenshot-based testing, one would have to
1) Run the E2E-test a few times and see if any of the screenshot differ by small amounts (and then figure out how we can avoid it)
2) Go over all our tests to see which steps should be renamed to use "I should see" (for maximum screenshot coverage)

This PR doesn't make screenshot testing as part of our CI but that is the ultimate goal.

Ideally, our CI would cache the screenshot tests for specific commits. Then, when you make a PR, it checks at which commit you forked from `develop` and compare your PR to that (Note: you CANNOT compare to current `develop` as too many things may have changed. You have to compare to where the branch forked)

# Save Location

- Scenarios in their own folders
- Each step is its own file (step # as first part of key)
- Some tests have multiple "examples" that mean we run the same scenario multiple times. Therefore we also add the line number to the unique key of the file

*Note*: Screenshots folder is deleted every time you run a new test

# Example

### Test definition
```
  @it-8
  Scenario Outline: Wallet renaming (IT-8)
    When I am testing "Wallet Settings Screen"
    And There is a wallet stored named Test
    And I navigate to the general settings screen
    And I click on secondary menu "wallet" item
    And I click on "name" input field
    And I enter new wallet name:
    | name         |
    | <walletName> |
    And I click outside "name" input field
    And I navigate to wallet transactions screen
    Then I should see new wallet name "<walletName>"
    Examples:
    | walletName                               |                    |
    | first Edited                             |2 words name        | 
    |ウォレットの追加                             |Japanese            |
    |지갑 추가                                 | Korean             |
    |НАСТРОЙКИ                                 | Russian            |
    | a                                        |1-characters length |
    | asdfghjklpoiuytrewqazxcvbnmlkjhgfdsaqwer |40 characters length|
```

### Run test
```
npm run test-by-tag-chrome @it-8
```

### Created files

```
yoroi-frontend/screenshots/Wallet renaming IT8/10_96-I should see new wallet name .png
yoroi-frontend/screenshots/Wallet renaming IT8/10_97-I should see new wallet name .png
yoroi-frontend/screenshots/Wallet renaming IT8/10_98-I should see new wallet name .png
yoroi-frontend/screenshots/Wallet renaming IT8/10_99-I should see new wallet name .png
yoroi-frontend/screenshots/Wallet renaming IT8/10_100-I should see new wallet name .png
yoroi-frontend/screenshots/Wallet renaming IT8/10_101-I should see new wallet name .png
```
### Screenshot generated

![image](https://user-images.githubusercontent.com/2608559/51816466-07433180-230a-11e9-856b-62b51e3a1e6d.png)
