### PR TITLE
fix of #287

### DIFF
--- a/app/components/footer/FooterItem.js
+++ b/app/components/footer/FooterItem.js
@@ -21,13 +21,13 @@ export default class FooterItem extends Component<Props> {
 
     return (
       <div className={styles.component}>
-        {/* Buy a Trezor Hardware wallet */}
         {
           <a
             href={url}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.block}
+            title={intl.formatMessage(message)}
           >
             <div className={styles.icon}>
               <SvgInline svg={svg} cleanup={['title']} />

--- a/app/components/footer/FooterItem.scss
+++ b/app/components/footer/FooterItem.scss
@@ -6,6 +6,7 @@ $blockHeight: 52px;
   font-size: 14px;
   font-family: var(--font-regular);
   a {
+    display: block;
     opacity: 0.7;
     color: var(--font-black);
   }
@@ -33,3 +34,11 @@ $blockHeight: 52px;
   background-color: var(--theme-footer-block-background-color-hover);
   cursor: pointer;
 };
+
+@media screen and (max-width: 1450px) {
+  .block {
+    .text {
+      display: none;
+    }
+  }
+}

--- a/app/components/layout/CenteredLayout.scss
+++ b/app/components/layout/CenteredLayout.scss
@@ -3,5 +3,5 @@
   background-color: var(--theme-loading-background-color);
   display: flex;
   height: 100%;
-  justify-content: center;
+  justify-content: space-between;
 }

--- a/app/containers/wallet/Wallet.js
+++ b/app/containers/wallet/Wallet.js
@@ -37,13 +37,10 @@ export default class Wallet extends Component<Props> {
       return <MainLayout actions={actions} stores={stores}><LoadingSpinner /></MainLayout>;
     }
 
-    const footer = undefined;
-
     return (
       <MainLayout
         actions={actions}
         stores={stores}
-        footer={footer}
       >
         <WalletWithNavigation
           isActiveScreen={this.isActiveScreen}


### PR DESCRIPTION
**[A] SYNC**

1. [Fixed] Footer Item horizontal alignment has been changed from `center` to `left`

**[B] IMPROVEMENTS**

1. [Fixed] Better display mode switching logic, switch to all icon mode or all text plus mode.

2. [Fixed] Add on-hover tool-tip irrespective of the display mode, so when its displaying in icon only mode then user will have better idea (all tool-tip text can be same as what its displaying in icon with text mode)

3. [Deleted] Delete unwanted line: 
 
4. [Deleted] Delete dead code or implement all `Wallet` page footer:
 
REF: https://github.com/Emurgo/yoroi-frontend/issues/110 https://github.com/Emurgo/yoroi-frontend/issues/111 https://github.com/Emurgo/yoroi-frontend/issues/205 https://github.com/Emurgo/yoroi-frontend/pull/282