### PR TITLE
Temporarily remove FR + DE

### DIFF
--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -17,8 +17,8 @@ export default class SettingsStore extends Store {
     { value: 'zh-Hans', label: globalMessages.languageChineseSimplified },
     { value: 'zh-Hant', label: globalMessages.languageChineseTraditional },
     { value: 'ru-RU', label: globalMessages.languageRussian },
-    { value: 'de-DE', label: globalMessages.languageGerman },
-    { value: 'fr-FR', label: globalMessages.languageFrench },
+    // { value: 'de-DE', label: globalMessages.languageGerman },
+    // { value: 'fr-FR', label: globalMessages.languageFrench },
   ];
 
   @observable bigNumberDecimalFormat = {


### PR DESCRIPTION
These two languages aren't fully translated and so we need to temporarily disable them to release the next version of Yoroi