### PR TITLE
SVG Loader on all mainnets + remove stale cleanups

### DIFF
--- a/app/components/footer/FooterItem.js
+++ b/app/components/footer/FooterItem.js
@@ -30,7 +30,7 @@ export default class FooterItem extends Component<Props> {
             title={intl.formatMessage(message)}
           >
             <div className={styles.icon}>
-              <SvgInline svg={svg} cleanup={['title']} className={className} width="20" height="52" />
+              <SvgInline svg={svg} className={className} width="20" height="52" />
             </div>
             <div className={styles.text}>
               {intl.formatMessage(message)}

--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -61,9 +61,9 @@ export default class Loading extends Component<Props> {
     return (
       <div className={componentStyles}>
         <div className={styles.logos}>
-          <SvgInline svg={currencyLoadingLogo} className={currencyLogoStyles} cleanup={['title']} />
-          <SvgInline svg={yoroiLoadingLogo} className={yoroiLogoStyles} cleanup={['title']} />
-          <SvgInline svg={apiLoadingLogo} className={apiLogoStyles} cleanup={['title']} />
+          <SvgInline svg={currencyLoadingLogo} className={currencyLogoStyles} />
+          <SvgInline svg={yoroiLoadingLogo} className={yoroiLogoStyles} />
+          <SvgInline svg={apiLoadingLogo} className={apiLogoStyles} />
         </div>
         {hasLoadedCurrentLocale && (
           <div>

--- a/app/components/topbar/TopBarCategory.js
+++ b/app/components/topbar/TopBarCategory.js
@@ -30,7 +30,7 @@ export default class TopBarCategory extends Component<Props> {
 
     return (
       <button type="button" className={componentStyles} onClick={onClick}>
-        <SvgInline svg={icon} className={iconStyles} cleanup={['title']} />
+        <SvgInline svg={icon} className={iconStyles} />
       </button>
     );
   }

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -143,7 +143,7 @@ export default class WalletReceive extends Component<Props, State> {
                 text={walletAddress}
                 onCopy={onCopyAddress.bind(this, walletAddress)}
               >
-                <SvgInline svg={iconCopy} className={styles.copyIconBig} cleanup={['title']} />
+                <SvgInline svg={iconCopy} className={styles.copyIconBig} />
               </CopyToClipboard>
             </div>
             <div className={styles.instructionsText}>
@@ -186,7 +186,7 @@ export default class WalletReceive extends Component<Props, State> {
                     onCopy={onCopyAddress.bind(this, address.id)}
                   >
                     <span className={styles.copyAddress}>
-                      <SvgInline svg={iconCopy} className={styles.copyIcon} cleanup={['title']} />
+                      <SvgInline svg={iconCopy} className={styles.copyIcon} />
                       <span>{intl.formatMessage(messages.copyAddressLabel)}</span>
                     </span>
                   </CopyToClipboard>

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -238,7 +238,7 @@ export default class WalletSendForm extends Component<Props, State> {
 
     const hasPendingTxWarning = (
       <div className={styles.contentWarning}>
-        <SvgInline svg={dangerIcon} className={styles.icon} cleanup={['title']} />
+        <SvgInline svg={dangerIcon} className={styles.icon} />
         <p className={styles.warning}>{intl.formatMessage(messages.sendingIsDisabled)}</p>
       </div>
     );

--- a/app/components/wallet/summary/WalletSummary.js
+++ b/app/components/wallet/summary/WalletSummary.js
@@ -64,14 +64,14 @@ export default class WalletSummary extends Component<Props> {
               <div className={styles.pendingConfirmation}>
                 {`${intl.formatMessage(messages.pendingIncomingConfirmationLabel)}`}
                 : <span>{pendingAmount.incoming.toFormat(DECIMAL_PLACES_IN_ADA)}</span>
-                <SvgInline svg={adaSymbolSmallest} className={styles.currencySymbolSmallest} cleanup={['title']} />
+                <SvgInline svg={adaSymbolSmallest} className={styles.currencySymbolSmallest} />
               </div>
             }
             {pendingAmount.outgoing.greaterThan(0) &&
               <div className={styles.pendingConfirmation}>
                 {`${intl.formatMessage(messages.pendingOutgoingConfirmationLabel)}`}
                 : <span>{pendingAmount.outgoing.toFormat(DECIMAL_PLACES_IN_ADA)}</span>
-                <SvgInline svg={adaSymbolSmallest} className={styles.currencySymbolSmallest} cleanup={['title']} />
+                <SvgInline svg={adaSymbolSmallest} className={styles.currencySymbolSmallest} />
               </div>
             }
             {!isLoadingTransactions ? (
@@ -85,7 +85,7 @@ export default class WalletSummary extends Component<Props> {
           {!isLoadingTransactions ? (
             <SvgInline
               svg={exportTxToFileSvg}
-              cleanup={['title']}
+             
               className={styles.exportTxToFileSvg}
               title={intl.formatMessage(messages.exportIconTooltip)}
               onClick={openExportTxToFileDialog}

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -234,7 +234,7 @@ export default class Transaction extends Component<Props, State> {
                   // hide currency (we are showing symbol instead)
                   formattedWalletAmount(data.amount, false)
                 }
-                <SvgInline svg={symbol} className={styles.currencySymbol} cleanup={['title']} />
+                <SvgInline svg={symbol} className={styles.currencySymbol} />
               </div>
             </div>
           </div>

--- a/app/components/wallet/transactions/TransactionTypeIcon.js
+++ b/app/components/wallet/transactions/TransactionTypeIcon.js
@@ -43,7 +43,7 @@ export default class TransactionTypeIcon extends Component<Props> {
 
     return (
       <div className={transactionTypeIconClasses}>
-        <SvgInline svg={icon} className={styles.transactionTypeIcon} cleanup={['title']} />
+        <SvgInline svg={icon} className={styles.transactionTypeIcon} />
       </div>
     );
   }

--- a/app/components/wallet/trezorConnect/AboutDialog.js
+++ b/app/components/wallet/trezorConnect/AboutDialog.js
@@ -127,7 +127,7 @@ export default class AboutDialog extends Component<Props> {
       <div className={classnames([styles.middleBlock, styles.middleAboutBlock])}>
         <div className={styles.prerequisiteBlock}>
           <div>
-            <SvgInline svg={aboutPrerequisiteIconSVG} cleanup={['title']} />
+            <SvgInline svg={aboutPrerequisiteIconSVG} />
             <span className={styles.prerequisiteHeaderText}>
               {intl.formatMessage(messages.aboutPrerequisiteHeader)}
             </span>
@@ -137,7 +137,7 @@ export default class AboutDialog extends Component<Props> {
               {intl.formatMessage(messages.aboutPrerequisite1Part1)}
               <a target="_blank" rel="noopener noreferrer" href={intl.formatMessage(messages.aboutPrerequisite1Part2Link)}>
                 {intl.formatMessage(messages.aboutPrerequisite1Part2LinkText)}
-                <SvgInline svg={externalLinkSVG} cleanup={['title']} />
+                <SvgInline svg={externalLinkSVG} />
               </a>
               {intl.formatMessage(messages.aboutPrerequisite1Part3)}
             </li>
@@ -148,7 +148,7 @@ export default class AboutDialog extends Component<Props> {
           </ul>
         </div>
         <div className={styles.trezorImageBlock}>
-          <SvgInline svg={aboutPrerequisiteTrezorSVG} cleanup={['title']} />
+          <SvgInline svg={aboutPrerequisiteTrezorSVG} />
         </div>
       </div>);
 

--- a/app/components/wallet/trezorConnect/ConnectDialog.js
+++ b/app/components/wallet/trezorConnect/ConnectDialog.js
@@ -99,7 +99,7 @@ export default class ConnectDialog extends Component<Props> {
         backButton = (<DialogBackButton onBack={goBack} />);
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleConnectErrorBlock])}>
-            <SvgInline svg={connectErrorSVG} cleanup={['title']} />
+            <SvgInline svg={connectErrorSVG} />
           </div>);
         break;
       default:

--- a/app/components/wallet/trezorConnect/SaveDialog.js
+++ b/app/components/wallet/trezorConnect/SaveDialog.js
@@ -126,19 +126,19 @@ export default class SaveDialog extends Component<Props> {
       case StepState.LOAD:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveLoadBlock])}>
-            <SvgInline svg={saveLoadGIF} cleanup={['title']} />
+            <SvgInline svg={saveLoadGIF} />
           </div>);
         break;
       case StepState.PROCESS:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveStartProcessBlock])}>
-            <SvgInline svg={saveStartSVG} cleanup={['title']} />
+            <SvgInline svg={saveStartSVG} />
           </div>);
         break;
       case StepState.ERROR:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveErrorBlock])}>
-            <SvgInline svg={saveErrorSVG} cleanup={['title']} />
+            <SvgInline svg={saveErrorSVG} />
           </div>);
         break;
       default:

--- a/app/components/wallet/trezorConnect/common/HelpLinkBlock.js
+++ b/app/components/wallet/trezorConnect/common/HelpLinkBlock.js
@@ -39,7 +39,7 @@ export default class HelpLinkBlock extends Component<Props> {
       <div className={styles.linkBlock}>
         <a target="_blank" rel="noopener noreferrer" href={intl.formatMessage(messages.helpLinkYoroiWithTrezor)}>
           {intl.formatMessage(messages.helpLinkYoroiWithTrezorText)}
-          <SvgInline svg={externalLinkSVG} cleanup={['title']} />
+          <SvgInline svg={externalLinkSVG} />
         </a>
       </div>);
   }

--- a/app/components/widgets/DialogBackButton.js
+++ b/app/components/widgets/DialogBackButton.js
@@ -13,7 +13,7 @@ export default class DialogBackButton extends Component<Props> {
     const { onBack } = this.props;
     return (
       <button type="button" onClick={onBack} className={styles.component}>
-        <SvgInline svg={backArrow} cleanup={['title']} />
+        <SvgInline svg={backArrow} />
       </button>
     );
   }

--- a/app/components/widgets/DialogCloseButton.js
+++ b/app/components/widgets/DialogCloseButton.js
@@ -17,7 +17,7 @@ export default class DialogCloseButton extends Component<Props> {
     const { onClose, icon } = this.props;
     return (
       <button type="button" onClick={onClose} className={styles.component}>
-        <SvgInline svg={icon || closeCross} cleanup={['title']} />
+        <SvgInline svg={icon || closeCross} />
       </button>
     );
   }

--- a/app/components/widgets/NotificationMessage.js
+++ b/app/components/widgets/NotificationMessage.js
@@ -26,7 +26,7 @@ export default class NotificationMessage extends Component<Props> {
     return (
       <div className={notificationMessageStyles}>
 
-        {icon && <SvgInline svg={icon} className={styles.icon} cleanup={['title']} />}
+        {icon && <SvgInline svg={icon} className={styles.icon} />}
 
         <div className={styles.message}>
           {children}

--- a/app/components/widgets/ProgressSteps.js
+++ b/app/components/widgets/ProgressSteps.js
@@ -60,8 +60,8 @@ export default class ProgressSteps extends Component<Props> {
           <div className={stepTopBarStyle} />
           <div className={styles.stepBottomBlock}>
             <div className={styles.stepStateIconContainer}>
-              {(displayIcon === 'done') && <SvgInline svg={iconTickSVG} cleanup={['title']} />}
-              {(displayIcon === 'error') && <SvgInline svg={iconCrossSVG} cleanup={['title']} />}
+              {(displayIcon === 'done') && <SvgInline svg={iconTickSVG} />}
+              {(displayIcon === 'error') && <SvgInline svg={iconCrossSVG} />}
             </div>
             <div className={styles.stepTextContainer}>
               <span className={stepTextStyle}>{stepText}</span>

--- a/app/components/widgets/forms/AdaCertificateUploadWidget.js
+++ b/app/components/widgets/forms/AdaCertificateUploadWidget.js
@@ -51,9 +51,9 @@ export default class AdaCertificateUploadWidget extends Component<Props> {
           {isCertificateSelected ? (
             <div className={styles.certificateUploaded}>
               <button type="button" className={styles.removeFileButton} onClick={onRemoveCertificate}>
-                <SVGInline svg={closeCrossIcon} className={styles.closeCrossIcon} cleanup={['title']} />
+                <SVGInline svg={closeCrossIcon} className={styles.closeCrossIcon} />
               </button>
-              <SVGInline svg={certificateIcon} className={styles.certificateIcon} cleanup={['title']} />
+              <SVGInline svg={certificateIcon} className={styles.certificateIcon} />
             </div>
           ) : (
             <Dropzone

--- a/webpack/development.config.js
+++ b/webpack/development.config.js
@@ -117,7 +117,7 @@ const baseDevConfig = () => ({
       {
         test: /\.inline\.svg$/,
         issuer: /\.js$/,
-        loader: 'svg-inline-loader?removeSVGTagAttrs=false&removeTags=true&removingTags=title&removingTags=desc&idPrefix=[sha512:hash:hex:5]-',
+        loader: 'svg-inline-loader?removeSVGTagAttrs=false&removeTags=true&removingTags[]=title&removingTags[]=desc&idPrefix=[sha512:hash:hex:5]-',
       },
       {
         test: /\.(eot|otf|ttf|woff|woff2|gif)$/,

--- a/webpack/mainnet.config.js
+++ b/webpack/mainnet.config.js
@@ -102,7 +102,7 @@ module.exports = {
       {
         test: /\.inline\.svg$/,
         issuer: /\.js$/,
-        loader: 'raw-loader',
+        loader: 'svg-inline-loader?removeSVGTagAttrs=false&removeTags=true&removingTags[]=title&removingTags[]=desc&idPrefix=[sha512:hash:hex:5]-',
       },
       {
         test: /\.(eot|otf|ttf|woff|woff2|gif)$/,

--- a/webpack/staging.config.js
+++ b/webpack/staging.config.js
@@ -102,7 +102,7 @@ module.exports = {
       {
         test: /\.inline\.svg$/,
         issuer: /\.js$/,
-        loader: 'raw-loader',
+        loader: 'svg-inline-loader?removeSVGTagAttrs=false&removeTags=true&removingTags[]=title&removingTags[]=desc&idPrefix=[sha512:hash:hex:5]-',
       },
       {
         test: /\.(eot|otf|ttf|woff|woff2|gif)$/,

--- a/webpack/test.config.js
+++ b/webpack/test.config.js
@@ -101,7 +101,7 @@ module.exports = {
       {
         test: /\.inline\.svg$/,
         issuer: /\.js$/,
-        loader: 'raw-loader',
+        loader: 'svg-inline-loader?removeSVGTagAttrs=false&removeTags=true&removingTags[]=title&removingTags[]=desc&idPrefix=[sha512:hash:hex:5]-',
       },
       {
         test: /\.(eot|otf|ttf|woff|woff2|gif)$/,

--- a/webpack/testnet.config.js
+++ b/webpack/testnet.config.js
@@ -102,7 +102,7 @@ module.exports = {
       {
         test: /\.inline\.svg$/,
         issuer: /\.js$/,
-        loader: 'raw-loader',
+        loader: 'svg-inline-loader?removeSVGTagAttrs=false&removeTags=true&removingTags[]=title&removingTags[]=desc&idPrefix=[sha512:hash:hex:5]-',
       },
       {
         test: /\.(eot|otf|ttf|woff|woff2|gif)$/,


### PR DESCRIPTION
This PR does two things:

1) In my PR #333 I only applied the fix to `development.config.js`. In this PR I add the fix to the webpack config for each network
1) Our code contained a lot of ` cleanup={['title']}`. This is because a `<title>` tag on an SVG image gives it an on-hover message. This isn't desired because the on-hover message generated by programs that export SVGs are often unhelpful (see example below). All these `cleanup` props are error-prone since we forget it in a few places. Since our new way of loading SVGs allows us to remove this at load-time, this is definitely the better solution so I use that instead and remove all the `cleanup` props

Example of useless auto-generated `<title>`
![image](https://user-images.githubusercontent.com/2608559/53980304-5d01c980-4153-11e9-8657-c9377e131ecf.png)
