### PR TITLE
Fixed handling of tx-bodies received from backend

### DIFF
--- a/app/api/ada/hardwareWallet/newTransaction.js
+++ b/app/api/ada/hardwareWallet/newTransaction.js
@@ -90,7 +90,7 @@ export async function createTrezorSignTxPayload(
 export async function txsBodiesForInputs(
   inputs: Array<TxInput>
 ): Promise<{[key: string]:string}> {
-  if (!inputs) return [];
+  if (!inputs) return {};
   try {
 
     // Map inputs to UNIQUE tx hashes (there might be multiple inputs from the same tx)

--- a/app/api/ada/lib/yoroi-backend-api.js
+++ b/app/api/ada/lib/yoroi-backend-api.js
@@ -57,7 +57,7 @@ export type UtxoSumForAddressesResponse = {
 
 export const getTxsBodiesForUTXOs = (
   txsHashes: Array<string>
-): Promise<Array<string>> => (
+): Promise<{[key: string]:string}> => (
   axios(
     `${backendUrl}/api/txs/txBodies`,
     {
@@ -66,7 +66,7 @@ export const getTxsBodiesForUTXOs = (
         txsHashes
       }
     }
-  ).then(response => Object.values(response.data))
+  ).then(response => response.data)
     .catch((error) => {
       Logger.error('yoroi-backend-api::getTxsBodiesForUTXOs error: ' + stringifyError(error));
       throw new GetTxsBodiesForUTXOsApiError();


### PR DESCRIPTION
Ledger and Trezor code were assuming all available inputs have unique tx-hashes, which is technically not necessarily true. We need code to be ready that multiple inputs might correspond to different outputs of the same transaction.

Fixed backend call to NOT turn a map of `tx-hashes -> tx-bodies` into just a list of bodies. Changes couple of functions to receive a map of tx-bodies and then to search a tx-body for each input by a tx-hash.