### PR TITLE
Fix multiple tabs of Yoroi open & remove "tabs" permission

### DIFF
--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -11,6 +11,7 @@ import Request from '../lib/LocalizedRequest';
 import type { MigrationRequest } from '../../api';
 import { migrate } from '../../api';
 import { Logger, stringifyError } from '../../utils/logging';
+import { closeOtherInstances } from '../../utils/tabManager';
 
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
@@ -34,6 +35,7 @@ export default class LoadingStore extends Store {
     Promise
       .all([this.loadRustRequest.execute().promise, this.loadDbRequest.execute().promise])
       .then(async () => {
+        closeOtherInstances();
         await this.migrationRequest.execute({
           api: this.api,
           currVersion: environment.version

--- a/app/utils/tabManager.js
+++ b/app/utils/tabManager.js
@@ -1,0 +1,62 @@
+/**
+ * We may run into bugs if the user has two copies of Yoroi running on the same localstorage
+ * Since Yoroi data process is not transactional.
+ *
+ * To avoid these bugs, we only allow one tab open at a time.
+ *
+ * Since all copies of Yoroi running use the same localstorage instance,
+ * we use a localstorage listener on a specific key to detect new tabs being opened.
+ *
+ * Note: you can only listen on localstorage and not session storage
+ * Note: listener only fires for localstorage changes made by OTHER Yoroi tabs
+ * https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Responding_to_storage_changes_with_the_StorageEvent
+*/
+
+/**
+ * Name of key we use in localstorage
+ */
+const OPEN_TAB_ID_KEY = 'openTabId';
+
+/**
+ * It's possible to have two copies of Yoroi loading at the same time by going to the URL directly
+ * Therefore it's important that we add this listener BEFORE we modify the localstorage
+ * This avoids the race condition where both update localstorage but neither are listening
+ *
+ * Note: this may cause two copies of Yoroi loading at the same time close each other
+ */
+export function addCloseListener(window) {
+  window.onstorage = (e: StorageEvent) => {
+    // if another Yoroi tab open, close this tab
+    if (e.key === OPEN_TAB_ID_KEY) {
+      // note: we don't need "tabs" permission to get or remove our own tab
+      chrome.tabs.getCurrent(id => chrome.tabs.remove(id.id));
+    }
+  };
+}
+
+/**
+ * Notify any other Yoroi tabs to close before we initialize
+ * Note: for the listner to fire, the key much change values
+ * To generate a new value every time, we use the current time
+ *
+ * The precision of the clock may be of concern. Let's look at two scenarios:
+ *
+ * 1) Opening Yoroi by pressing the Yoroi icon
+ * In this case, Chrome & Firefox only allows you to load one copy of Yoroi at the same time.
+ * This restriction applies even across multiple copies of Chrome running at the same time
+ * (however this restriction can probabilistically fail if you mash the Yoroi logo very fast)
+ * Since Yoroi takes more than a millisecond to open, the time should bee unique.
+ *
+ * 2) Manually entering the Yoroi URL into a page multiple times
+ * This bypasses above-mentioned restriction of only one copy loading at once
+ * Emperically, this doesn't seem to be an issue though.
+ *
+ * WARNING: You should only call this AFTER the wasm bindings have loaded
+ * closing a different copy of Yoroi while loading WASM causes the load to hang
+ * This bug only exists in Chrome (verified still occurs in Chrome v75)
+ *
+ * WARNING: You should call this function BEFORE making any other changes to localstorage
+*/
+export function closeOtherInstances() {
+  localStorage.setItem(OPEN_TAB_ID_KEY, Date.now().toString());
+}

--- a/chrome/extension/background.js
+++ b/chrome/extension/background.js
@@ -22,45 +22,8 @@ function promisifyAll(obj, list) {
 promisifyAll(chrome, ['tabs', 'windows', 'browserAction']);
 promisifyAll(chrome.storage, ['local']);
 
-
-function getBaseUrl(url) {
-  return url.split('#')[0];
-}
-
-let currentTab;
-
-chrome.tabs.onRemoved.addListener(tabId => {
-  if (tabId === currentTab.id) currentTab = undefined;
-});
-
-const selectWindow = (windowId) => chrome.windows.update(windowId, { focused: true });
-
 const onIconClicked = () => {
-  if (currentTab) {
-    chrome.tabs.update(currentTab.id, { active: true }, () => selectWindow(currentTab.windowId));
-  } else {
-    chrome.tabs.create({ url: 'main_window.html' }, ({ id, windowId }) => {
-      currentTab = {
-        id,
-        windowId,
-      };
-    });
-  }
+  chrome.tabs.create({ url: 'main_window.html' });
 };
-
-chrome.tabs.onUpdated.addListener((tabId, changes) => {
-  if (!currentTab) return; // If no tab loaded, return.
-  if (currentTab.id === tabId && changes.url) {
-    currentTab.baseUrl = getBaseUrl((changes.url));
-    return;
-  }
-  if (changes.url) {
-    const baseUrl = getBaseUrl((changes.url));
-    if (baseUrl === currentTab.baseUrl) {
-      selectWindow(currentTab.windowId);
-      chrome.tabs.remove(tabId);
-    }
-  }
-});
 
 chrome.browserAction.onClicked.addListener(_.debounce(onIconClicked, 500));

--- a/chrome/extension/index.js
+++ b/chrome/extension/index.js
@@ -41,3 +41,58 @@ const initializeYoroi = async () => {
 
 
 window.addEventListener('load', initializeYoroi);
+/**
+ * To avoid bugs that may occur when multiple copies of Yoroi are running at the same time
+ * we only allow one tab open at a time.
+ *
+ * Since all copies of Yoroi running use the same localstorage instance,
+ * we use a localstorage listener on a specific key to detect new tabs being opened.
+ *
+ * Note: you can only listen on localstorage and not session storage
+ * Note: listener only fires for localstorage changes made by OTHER Yoroi tabs
+ * https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Responding_to_storage_changes_with_the_StorageEvent
+*/
+
+const OPEN_TAB_ID_KEY = 'openTabId';
+
+/**
+ * It's possible to have two copies of Yoroi loading at the same time by going to the URL directly
+ * Therefore it's important that we add this listener BEFORE we modify the localstorage
+ * This avoids the race condition where both update localstorage but neither are listening
+ *
+ * Note: this may cause two copies of Yoroi loading at the same time close each other
+ */
+window.onstorage = (e: StorageEvent) => {
+  // if another Yoroi tab open, close this tab
+  if (e.key === OPEN_TAB_ID_KEY) {
+    // note: we don't need "tabs" permission to get or remove our own tab
+    chrome.tabs.getCurrent(id => chrome.tabs.remove(id.id));
+  }
+};
+
+/**
+ * Notify any other Yoroi tabs to close before we initialize
+ * Note: for the listner to fire, the key much change values
+ * To generate a new value every time, we use the current time
+ *
+ * The precision of the clock may be of concern. Let's look at two scenarios:
+ *
+ * 1) Opening Yoroi by pressing the Yoroi icon
+ * In this case, Chrome only allows you to load one copy of Yoroi at the same time.
+ * This restriction applies even across multiple copies of Chrome running at the same time
+ * Since Yoroi takes more than a millisecond to open, the time will always be unique.
+ *
+ * 2) Manually entering the Yoroi URL into a page multiple times
+ * This bypasses above-mentioned restriction of only one copy loading at once
+ * Emperically, this doesn't seem to be an issue though.
+*/
+localStorage.setItem(OPEN_TAB_ID_KEY, Date.now());
+
+window.addEventListener('load', async () => {
+  /**
+   * Only initialize Yoroi once we know we're the only tab left
+   * Note: we can't reliable know how long it takes for the other tab to close
+   * so there may be a brief overlap
+  */
+  initializeYoroi();
+});

--- a/chrome/extension/index.js
+++ b/chrome/extension/index.js
@@ -10,6 +10,7 @@ import actions from '../../app/actions/index';
 import Action from '../../app/actions/lib/Action';
 import App from '../../app/App';
 import '../../app/themes/index.global.scss';
+import { addCloseListener } from '../../app/utils/tabManager';
 
 // run MobX in strict mode
 useStrict(true);
@@ -39,60 +40,6 @@ const initializeYoroi = async () => {
   );
 };
 
+addCloseListener(window);
 
 window.addEventListener('load', initializeYoroi);
-/**
- * To avoid bugs that may occur when multiple copies of Yoroi are running at the same time
- * we only allow one tab open at a time.
- *
- * Since all copies of Yoroi running use the same localstorage instance,
- * we use a localstorage listener on a specific key to detect new tabs being opened.
- *
- * Note: you can only listen on localstorage and not session storage
- * Note: listener only fires for localstorage changes made by OTHER Yoroi tabs
- * https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Responding_to_storage_changes_with_the_StorageEvent
-*/
-
-const OPEN_TAB_ID_KEY = 'openTabId';
-
-/**
- * It's possible to have two copies of Yoroi loading at the same time by going to the URL directly
- * Therefore it's important that we add this listener BEFORE we modify the localstorage
- * This avoids the race condition where both update localstorage but neither are listening
- *
- * Note: this may cause two copies of Yoroi loading at the same time close each other
- */
-window.onstorage = (e: StorageEvent) => {
-  // if another Yoroi tab open, close this tab
-  if (e.key === OPEN_TAB_ID_KEY) {
-    // note: we don't need "tabs" permission to get or remove our own tab
-    chrome.tabs.getCurrent(id => chrome.tabs.remove(id.id));
-  }
-};
-
-/**
- * Notify any other Yoroi tabs to close before we initialize
- * Note: for the listner to fire, the key much change values
- * To generate a new value every time, we use the current time
- *
- * The precision of the clock may be of concern. Let's look at two scenarios:
- *
- * 1) Opening Yoroi by pressing the Yoroi icon
- * In this case, Chrome only allows you to load one copy of Yoroi at the same time.
- * This restriction applies even across multiple copies of Chrome running at the same time
- * Since Yoroi takes more than a millisecond to open, the time will always be unique.
- *
- * 2) Manually entering the Yoroi URL into a page multiple times
- * This bypasses above-mentioned restriction of only one copy loading at once
- * Emperically, this doesn't seem to be an issue though.
-*/
-localStorage.setItem(OPEN_TAB_ID_KEY, Date.now());
-
-window.addEventListener('load', async () => {
-  /**
-   * Only initialize Yoroi once we know we're the only tab left
-   * Note: we can't reliable know how long it takes for the other tab to close
-   * so there may be a brief overlap
-  */
-  initializeYoroi();
-});

--- a/chrome/manifest.development.json
+++ b/chrome/manifest.development.json
@@ -25,7 +25,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "tabs",
     "storage",
     "*://connect.trezor.io/*"
   ],

--- a/chrome/manifest.mainnet.json
+++ b/chrome/manifest.mainnet.json
@@ -25,7 +25,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "tabs",
     "storage",
     "*://connect.trezor.io/*"
   ],

--- a/chrome/manifest.staging.json
+++ b/chrome/manifest.staging.json
@@ -26,7 +26,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "tabs",
     "storage",
     "*://connect.trezor.io/*"
   ],

--- a/chrome/manifest.test.json
+++ b/chrome/manifest.test.json
@@ -25,7 +25,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "tabs",
     "storage",
     "*://connect.trezor.io/*"
   ],

--- a/chrome/manifest.testnet.json
+++ b/chrome/manifest.testnet.json
@@ -26,7 +26,6 @@
     "page": "background.html"
   },
   "permissions": [
-    "tabs",
     "storage",
     "*://connect.trezor.io/*"
   ],

--- a/webpack/commonConfig.js
+++ b/webpack/commonConfig.js
@@ -137,6 +137,6 @@ module.exports = {
   rules,
   optimization,
   node,
-  resolve, 
+  resolve,
   definePlugin,
 };


### PR DESCRIPTION
- [x] rebase after new WASM bindings merged
- [x] test with Trezor device connected

**Rationale**

We need to ensure we only have one copy of Yoroi running per localstorage instance as Yoroi is non-transactional.

**Old system**

The old way we did this is we would disable the Yoroi button if a Yoroi tab was already open (we know if it's already open by scanning all tabs the user has open). Instead, we would focus the existing copy of Yoroi open

This approach is not ideal because 
1) The user can access Yoroi directly by just accessing the Yoroi URL directly (this is especially problematic once we add URI schemes for payments)
2) The copy of Yoroi may be open on a different instance of Chrome (which shares the same localstorage) meaning you can't focus it.

**New system**

We monitor tabs inside Yoroi itself instead of the background thread which allows us to handle closing duplicate copies of Yoroi even if they're opened directly from the URL.
Additionally, we no longer iterate over all user tabs and instead use localcache to communicate across copies of Yoroi.

Unlike the old system that would block opening new tabs, the new system closes the old tab and allows you to open a new one.

**Problem**

If a new copied of Yoroi is opened at the SAME TIME as an old copy of Yoroi is closing, `loadRustModule` will livelock causing Yoroi to be stuck in the loading screen forever. We can solve this with a `sleep` call or maybe upgrading our WASM binding system will solve this issue 😓

**Gif example**

![newtab](https://user-images.githubusercontent.com/2608559/54620236-34f65c80-4aa9-11e9-8983-f99cf3747fb1.gif)
