### PR TITLE
Limit max height of dropdown selection

### DIFF
--- a/app/themes/overrides/OptionsOverrides.scss
+++ b/app/themes/overrides/OptionsOverrides.scss
@@ -1,1 +1,11 @@
 // Css module overrides go here …
+
+.ul {
+  overflow-x: hidden;
+  overflow-y: overlay;
+  max-height: 300px;
+  &::-webkit-scrollbar-button {
+    height: 7px;
+    display: block;
+  }
+}

--- a/features/step_definitions/select-language-steps.js
+++ b/features/step_definitions/select-language-steps.js
@@ -20,7 +20,7 @@ When(/^I open language selection dropdown$/, async function () {
 });
 
 When(/^I select Japanese language$/, async function () {
-  return this.click('//*[@class="SimpleOptions_label"][contains(text(), "日本語")]', By.xpath);
+  return this.click('//span[contains(text(), "日本語")]', By.xpath);
 });
 
 When(/^I submit the language selection form$/, async function () {


### PR DESCRIPTION
# Problem

Users with small screens were unable to select their language because the dropdown menu was getting cutoff

![image](https://user-images.githubusercontent.com/2608559/54639746-726ee000-4ad1-11e9-9dd7-e0c5333c792f.png)

# Solution

To fix this, I made that dropdown selections now have a scrollbar if the size of all items goes over 300px (300 was chosen because we have dropdowns approximately this size before and nobody ever complained until we got over 300)

Here is how it looks like

## Over 300px

![image](https://user-images.githubusercontent.com/2608559/54639821-9d593400-4ad1-11e9-97f6-c7daf49953ec.png)

## Under 300px

Note: scrollbar doesn't even appear when under 300px (as expected)
![image](https://user-images.githubusercontent.com/2608559/54639871-be218980-4ad1-11e9-8b99-6db50d073d8c.png)
