### PR TITLE
Remove height restriction

### DIFF
--- a/app/themes/prebuilt/YoroiClassic.js
+++ b/app/themes/prebuilt/YoroiClassic.js
@@ -35,7 +35,6 @@ const rpButton = {
   '--rp-button-bg-color-hover': '#edb3a8',
   '--rp-button-font-family': rpFonts['--rp-theme-font-medium'],
   '--rp-button-font-size': '14px',
-  '--rp-button-height': '40px',
   '--rp-button-line-height': '20px',
   '--rp-button-padding': '12px 20px',
   '--rp-button-text-color': '#fafbfc',

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -35,7 +35,6 @@ const rpButton = {
   '--rp-button-bg-color-hover': '#edb3a8',
   '--rp-button-font-family': rpFonts['--rp-theme-font-medium'],
   '--rp-button-font-size': '14px',
-  '--rp-button-height': '40px',
   '--rp-button-line-height': '20px',
   '--rp-button-padding': '12px 20px',
   '--rp-button-text-color': '#fafbfc',


### PR DESCRIPTION
Translations would often be too long to fit inside a button. This is hard to detect for our translation team and hard to fix (in cases where the sentence can't be easily reduces in size)

I can't think of any reason not to remove the height restriction on buttons. It may not look great in some cases, but it's probably better than missing text.

**Note:** Not specifying a height will instead default to `auto`.

## Example

![image](https://user-images.githubusercontent.com/2608559/54679437-9de1e100-4b4a-11e9-9371-02968df98737.png)
