### PR TITLE
Add verify function on Trezor

### DIFF
--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -70,15 +70,6 @@ export default class WalletReceivePage extends Component<Props, State> {
     const walletAddress = addresses.active ? addresses.active.id : '';
     const isWalletAddressUsed = addresses.active ? addresses.active.isUsed : false;
 
-    /**
-     * TODO: change this condition to simple
-     * wallet.cwType === HARDWARE_WALLET
-     * once we add support for this in Trezor also
-     */
-    const isHardware = wallet.hardwareInfo
-      ? wallet.hardwareInfo.model === 'NanoS'
-      : false;
-
     const walletAddresses = addresses.all.reverse();
 
     const notification = {
@@ -129,7 +120,7 @@ export default class WalletReceivePage extends Component<Props, State> {
             error={hwVerifyAddress.error}
             walletAddress={hwVerifyAddress.selectedAddress.address}
             walletPath={hwVerifyAddress.selectedAddress.path}
-            isHardware={isHardware}
+            isHardware={wallet.isHardwareWallet}
             verify={() => actions.ada.hwVerifyAddress.verifyAddress.trigger({ wallet })}
             cancel={() => actions.ada.hwVerifyAddress.closeAddressDetailDialog.trigger()}
           />

--- a/app/domain/TrezorLocalizedError.js
+++ b/app/domain/TrezorLocalizedError.js
@@ -1,0 +1,57 @@
+// @flow
+
+import LocalizableError, { UnexpectedError } from '../i18n/LocalizableError';
+import globalMessages from '../i18n/global-messages';
+import { defineMessages } from 'react-intl';
+
+import {
+  Logger,
+} from '../utils/logging';
+
+const messages = defineMessages({
+  signTxError101: {
+    id: 'wallet.send.trezor.error.101',
+    defaultMessage: '!!!Signing cancelled on Trezor device. Please retry.',
+  },
+});
+
+/** Converts error(from API or Trezor API) to LocalizableError */
+export function convertToLocalizableError(error: any): LocalizableError {
+  let localizableError: ?LocalizableError = null;
+
+  if (error instanceof LocalizableError) {
+    // It means some API Error has been thrown
+    localizableError = error;
+  } else if (error && error.message) {
+    // Trezor device related error happend, convert then to LocalizableError
+    switch (error.message) {
+      case 'Iframe timeout':
+        localizableError = new LocalizableError(globalMessages.trezorError101);
+        break;
+      case 'Permissions not granted':
+        localizableError = new LocalizableError(globalMessages.hwError101);
+        break;
+      case 'Cancelled':
+      case 'Popup closed':
+        localizableError = new LocalizableError(globalMessages.trezorError103);
+        break;
+      case 'Signing cancelled':
+        localizableError = new LocalizableError(messages.signTxError101);
+        break;
+      default:
+        /** we are not able to figure out why Error is thrown
+          * make it, Something unexpected happened */
+        Logger.error(`TrezorSendStore::_convertToLocalizableError::error: ${error.message}`);
+        localizableError = new UnexpectedError();
+        break;
+    }
+  }
+
+  if (!localizableError) {
+    /** we are not able to figure out why Error is thrown
+      * make it, Something unexpected happened */
+    localizableError = new UnexpectedError();
+  }
+
+  return localizableError;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21182,21 +21182,21 @@
       "dev": true
     },
     "trezor-connect": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-7.0.1.tgz",
-      "integrity": "sha512-cMPwSGMfBpp4z5AZvpRwbYNOJU/X+WaxPm+O1Bl1qsdtpl1P4mX81KDtImY6GBk0xC8aKyOd/ZIqYWXZF9tCRQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-7.0.2.tgz",
+      "integrity": "sha512-KAFOqxEHHaFvrG8NGLFlM/QxHcwIa3gwfXcgTjCYM0g0zRpwIQBwe35AKsjAQO5yiTJQGa0Cu5MZufGJRGYjjw==",
       "requires": {
-        "@babel/runtime": "7.3.4",
+        "@babel/runtime": "7.4.2",
         "events": "3.0.0",
         "whatwg-fetch": "3.0.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-          "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
-            "regenerator-runtime": "0.12.1"
+            "regenerator-runtime": "0.13.2"
           }
         },
         "events": {
@@ -21205,9 +21205,9 @@
           "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
         },
         "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         },
         "whatwg-fetch": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "route-parser": "0.0.5",
     "rust-cardano-crypto": "file:js-cardano-wasm",
     "semver": "^5.6.0",
-    "trezor-connect": "7.0.1",
+    "trezor-connect": "7.0.2",
     "validator": "6.3.0",
     "unorm": "1.4.1",
     "yoroi-extension-ledger-bridge": "git+https://github.com/Emurgo/yoroi-extension-ledger-bridge.git"


### PR DESCRIPTION
#363 added the ability to verify addresses using your Ledger device. This PR adds the equivalent functionality for Trezor.

You can see the flow for the verification [here](https://wiki.trezor.io/User_manual:Receiving_payments#Confirm_on_Trezor) and the API for this functionality [here](https://github.com/trezor/connect/blob/develop/docs/methods/cardanoGetAddress.md)

At the same time I upgraded the version of TrezorConnect to fix a Flow issue in the `Cardano Input` type (see changelogs [here](https://github.com/trezor/connect/blob/develop/CHANGELOG.md#702))

# Problem

Although during testing the address and the derivation path match, the QR codes do not.

![image](https://user-images.githubusercontent.com/2608559/54872392-7ae35580-4e06-11e9-98da-7b635c3fbf3a.png)

 I scanned both QR codes and both contain the same data: `Ae2tdPwUPEZ3hNNwfupiDwymWB54yoSHhm1qqY8LCVFpze4dhCRScbHLoxC`

It turns out this is due to a few differences. Trezor & Ledger use the same library for QR code generation and you can read about its features [here](https://github.com/nayuki/QR-Code-generator#features)

## Error correction level

Here is a table of the levels
![image](https://www.qrcode.com/en/img/errorCorrection/errorCorrectionTable.png)

Trezor uses [level M](https://github.com/trezor/trezor-core/blob/4f28093d2e3c1658f742b5eff678b9aa2662ca46/embed/extmod/modtrezorui/display.c#L643) but we use [level L](https://github.com/zpao/qrcode.react#available-props)

## QR Version

Trezor uses version range [1,9]. Our QR code library doesn't support this option

## Masking

Trezor uses "auto" masking. Our QR code library doesn't support this option.