### PR TITLE
Adds error for Ledger Verify Feature

### DIFF
--- a/app/stores/ada/HWVerifyAddressStore.js
+++ b/app/stores/ada/HWVerifyAddressStore.js
@@ -109,6 +109,9 @@ export default class AddressesStore extends Store {
 
         await prepareLedgerBridger(ledgerBridge);
         Logger.info('AddressStore::_verifyAddress show path ' + JSON.stringify(path));
+        // the next line is used to get an error when
+        // Ledger is not connected or has issues.
+        await ledgerBridge.getVersion();
         await ledgerBridge.showAddress(path);
       } else {
         throw new Error(`LedgerBridge Error: LedgerBridge is undefined`);


### PR DESCRIPTION
Currently if there is an error, we don’t show anything e.g.; when Ledger is not connected.

<img width="640" alt="Screen Shot 2019-03-24 at 4 25 43 PM" src="https://user-images.githubusercontent.com/1622112/54885461-9d02c500-4e52-11e9-9715-516fb3e2cb08.png">

With this PR we are able to show this:

<img width="627" alt="Screen Shot 2019-03-24 at 4 26 37 PM" src="https://user-images.githubusercontent.com/1622112/54885462-9d02c500-4e52-11e9-9c49-c084e155b288.png">

