### PR TITLE
Change test version number

### DIFF
--- a/app/api/ada/adaMigration.js
+++ b/app/api/ada/adaMigration.js
@@ -36,7 +36,7 @@ export async function migrateToLatest(localStorageApi: LocalStorageApi) {
     */
 
   const migrationMap: { [ver: string]: (() => Promise<void>) } = {
-    '=0.0.0': async () => await testMigration(localStorageApi),
+    '=0.0.1': async () => await testMigration(localStorageApi),
     '<1.4.0': bip44Migration
   };
 

--- a/features/step_definitions/migration-steps.js
+++ b/features/step_definitions/migration-steps.js
@@ -13,7 +13,7 @@ Then(/^Last launch version is updated$/, async function () {
 
 Then(/^I decreast last launch version$/, async function () {
   this.driver.wait(async () => {
-    await setLastLaunchVersion(this.driver, '0.0.0');
+    await setLastLaunchVersion(this.driver, '0.0.1');
     return true;
   });
 });


### PR DESCRIPTION
The default version for computers that don't have the version set is the same magic number I used for testing the migration feature. This causes users to have their language switched to Japanese.