### PR TITLE
Fix some of the single-account assumptions in Yoroi

### DIFF
--- a/app/api/ada/adaAccount.js
+++ b/app/api/ada/adaAccount.js
@@ -8,12 +8,10 @@ import { RustModule } from './lib/cardanoCrypto/rustLoader';
 import { HARD_DERIVATION_START } from '../../config/numbersConfig';
 import type { CryptoAccount } from './adaLocalStorage';
 
-const ACCOUNT_INDEX = 0; /* Currently we only provide a SINGLE account */
-
 export function createCryptoAccount(
   encryptedMasterKey: string,
   walletPassword: string,
-  accountIndex: number = ACCOUNT_INDEX
+  accountIndex: number
 ): CryptoAccount {
   const cryptoWallet = getCryptoWalletFromMasterKey(encryptedMasterKey, walletPassword);
   // create a hardened account
@@ -30,7 +28,7 @@ export function createCryptoAccount(
 
 export function createHardwareWalletAccount(
   publicMasterKey: string,
-  accountIndex: number = ACCOUNT_INDEX
+  accountIndex: number
 ): CryptoAccount {
   const pubKey = RustModule.Wallet.PublicKey.from_hex(publicMasterKey);
   const account = RustModule.Wallet.Bip44AccountPublic.new(

--- a/app/api/ada/adaLocalStorage.js
+++ b/app/api/ada/adaLocalStorage.js
@@ -45,7 +45,7 @@ export function saveCryptoAccount(
   _saveInStorage(storageKeys.ACCOUNT_KEY, localAccount);
 }
 
-export function getSingleCryptoAccount(): CryptoAccount {
+export function getCurrentCryptoAccount(): CryptoAccount {
   const localAccount = _getFromStorage(storageKeys.ACCOUNT_KEY);
   if (localAccount.derivation_scheme !== 'V2') {
     throw Error('Sanity check');
@@ -60,6 +60,11 @@ export function getSingleCryptoAccount(): CryptoAccount {
     root_cached_key: account,
     derivation_scheme: localAccount.derivation_scheme
   };
+}
+
+export function getCurrentAccountIndex(): number {
+  const localAccount = _getFromStorage(storageKeys.ACCOUNT_KEY);
+  return localAccount.account;
 }
 
 /* Wallet storage */

--- a/app/api/ada/adaTransactions/adaNewTransactions.js
+++ b/app/api/ada/adaTransactions/adaNewTransactions.js
@@ -31,7 +31,7 @@ import {
   GetAllUTXOsForAddressesError,
   InvalidWitnessError
 } from '../errors';
-import { getWalletMasterKey } from '../adaLocalStorage';
+import { getWalletMasterKey, getCurrentAccountIndex } from '../adaLocalStorage';
 import type { ConfigType } from '../../../../config/config-types';
 import { HARD_DERIVATION_START } from '../../../config/numbersConfig';
 import type { AdaAddressMap } from '../adaAddress';
@@ -222,15 +222,15 @@ export function signTransaction(
   addressesMap: AdaAddressMap,
   cryptoWallet: RustModule.Wallet.Bip44RootPrivateKey,
 ): void {
-  const account = cryptoWallet.bip44_account(
-    // assume single account in Yoroi
-    RustModule.Wallet.AccountIndex.new(0 | HARD_DERIVATION_START)
+  const currAccount = getCurrentAccountIndex();
+  const accountPrivateKey = cryptoWallet.bip44_account(
+    RustModule.Wallet.AccountIndex.new(currAccount | HARD_DERIVATION_START)
   );
 
   // get private keys
   const privateKeys = senderUtxos.map(utxo => {
     const addressInfo = addressesMap[utxo.receiver];
-    return account.address_key(
+    return accountPrivateKey.address_key(
       addressInfo.change === 1, // is internal
       RustModule.Wallet.AddressKeyIndex.new(addressInfo.index)
     );

--- a/app/api/ada/adaTransactions/adaTransactionsHistory.js
+++ b/app/api/ada/adaTransactions/adaTransactionsHistory.js
@@ -41,7 +41,7 @@ import {
 import {
   saveLastBlockNumber,
   getLastBlockNumber,
-  getSingleCryptoAccount
+  getCurrentCryptoAccount
 } from '../adaLocalStorage';
 import type {
   CryptoAccount,
@@ -66,8 +66,7 @@ export const getAdaTxLastUpdatedDate = async (): Promise<Date> => getTxsLastUpda
  * Additionally add new addresses to DB to remain BIP-44 complaint
  */
 export async function refreshTxs(): Promise<void> {
-  // TODO: This should be an argument to this function once we support multiple accounts
-  const account = getSingleCryptoAccount();
+  const account = getCurrentCryptoAccount();
 
   /**
   * We have to make backend calls to check which of our addresses are used

--- a/app/api/ada/adaTypes.js
+++ b/app/api/ada/adaTypes.js
@@ -134,7 +134,6 @@ export type UnsignedTxResponse = {
 };
 
 export type AdaWallet = {
-  cwAccountsNumber: number,
   cwAmount: AdaAmount,
   cwId: string,
   cwMeta: AdaWalletMetaParams,

--- a/app/api/ada/adaWallet.js
+++ b/app/api/ada/adaWallet.js
@@ -56,7 +56,8 @@ export async function newAdaWallet(
   { walletPassword, walletInitData }: AdaWalletParams
 ): Promise<AdaWallet> {
   const [adaWallet, masterKey] = createAdaWallet({ walletPassword, walletInitData });
-  const cryptoAccount = createCryptoAccount(masterKey, walletPassword);
+  // always restore the 0th account
+  const cryptoAccount = createCryptoAccount(masterKey, walletPassword, 0);
 
   // creating an account same as restoring an account plus some initial setup
   await restoreTransactionsAndSave(cryptoAccount, adaWallet, masterKey);

--- a/app/api/ada/hardwareWallet/createWallet.js
+++ b/app/api/ada/hardwareWallet/createWallet.js
@@ -32,7 +32,8 @@ export async function createWallet({
 
     // create crypto account object for hardware wallet
     const cryptoAccount = createHardwareWalletAccount(
-      walletInitData.cwHardwareInfo.publicMasterKey
+      walletInitData.cwHardwareInfo.publicMasterKey,
+      0 // always create the 0th account
     );
 
     // Restore transactions and Save wallet + cryptoAccount to localstorage

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -106,7 +106,8 @@ import { WrongPassphraseError } from './lib/cardanoCrypto/cryptoErrors';
 import {
   getAdaWallet,
   getLastBlockNumber,
-  getLastReceiveAddressIndex
+  getLastReceiveAddressIndex,
+  getCurrentCryptoAccount,
 } from './adaLocalStorage';
 import LocalStorageApi from '../localStorage/index';
 import {
@@ -248,6 +249,7 @@ export default class AdaApi {
     try {
       const cuttoffIndex = getLastReceiveAddressIndex() + 1;
 
+      const accountIndex = getCurrentCryptoAccount();
       const adaAddresses: AdaAddresses = await getAdaAddressesByType('External');
       Logger.debug('AdaApi::getExternalAddresses success: ' + stringifyData(adaAddresses));
       const addresses = adaAddresses
@@ -256,7 +258,7 @@ export default class AdaApi {
       return new Promise(resolve => (
         resolve(
           {
-            accountId: '0', /* We are using a SINGLE account */
+            accountId: accountIndex.toString(),
             addresses
           }
         )
@@ -896,8 +898,7 @@ const _createAddressFromServerData = action(
   (data: AdaAddress) => (
     new WalletAddress({
       id: data.cadId,
-      // note: assume single account
-      path: makeCardanoBIP44Path(0, data.change, data.index),
+      path: makeCardanoBIP44Path(data.account, data.change, data.index),
       amount: new BigNumber(data.cadAmount.getCCoin).dividedBy(
         LOVELACES_PER_ADA
       ),

--- a/app/api/ada/lib/cardanoCrypto/cryptoToModel.js
+++ b/app/api/ada/lib/cardanoCrypto/cryptoToModel.js
@@ -14,7 +14,6 @@ import { AdaWalletTypeOption } from '../../config/AdaTypesConfig';
 export function toAdaWallet(walletInitData : AdaWalletInitData): AdaWallet {
   const { cwAssurance, cwName, cwUnit } = walletInitData.cwInitMeta;
   return {
-    cwAccountsNumber: 1,
     cwAmount: {
       getCCoin: 0
     },
@@ -33,7 +32,6 @@ export function toAdaWallet(walletInitData : AdaWalletInitData): AdaWallet {
 export function toAdaHardwareWallet(walletInitData : AdaHardwareWalletInitData): AdaWallet {
   const { cwAssurance, cwName, cwUnit } = walletInitData.cwInitMeta;
   return {
-    cwAccountsNumber: 1,
     cwAmount: {
       getCCoin: 0
     },

--- a/app/api/ada/lib/utils.js
+++ b/app/api/ada/lib/utils.js
@@ -11,6 +11,7 @@ import type {
 } from '../adaTypes';
 import type { TransactionExportRow } from '../../export';
 import { LOVELACES_PER_ADA } from '../../../config/numbersConfig';
+import { getCurrentAccountIndex } from '../adaLocalStorage';
 
 export const toAdaTx = function (
   amount: BigNumber,
@@ -187,4 +188,16 @@ export function utxosToLookupMap(
     )
   );
   return lookupMap;
+}
+
+export function derivePathAsString(chain: number, addressIndex: number): string {
+  const account = getCurrentAccountIndex();
+  // https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+  return `m/44'/1815'/${account}'/${chain}/${addressIndex}`;
+}
+
+export function derivePathPrefix(): string {
+  const account = getCurrentAccountIndex();
+  // https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+  return `m/44'/1815'/${account}'`;
 }

--- a/app/api/ada/restoreAdaWallet.js
+++ b/app/api/ada/restoreAdaWallet.js
@@ -45,7 +45,8 @@ export async function restoreAdaWallet(
   try {
     // recover master key
     const [adaWallet, masterKey] = createAdaWallet({ walletPassword, walletInitData });
-    const cryptoAccount = createCryptoAccount(masterKey, walletPassword);
+    // always create the 0th account
+    const cryptoAccount = createCryptoAccount(masterKey, walletPassword, 0);
 
     await restoreTransactionsAndSave(cryptoAccount, adaWallet, masterKey);
     return adaWallet;

--- a/app/api/common.js
+++ b/app/api/common.js
@@ -89,7 +89,7 @@ export type GetAddressesRequest = {
   walletId: string
 };
 export type GetAddressesResponse = {
-  accountId: ?string,
+  accountId: string,
   addresses: Array<WalletAddress>
 };
 

--- a/app/config.js
+++ b/app/config.js
@@ -6,8 +6,6 @@ export default {
     MAX_ALLOWED_UNUSED_ADDRESSES: 20,
     TRANSACTION_REQUEST_SIZE: 20,
     WALLET_RECOVERY_PHRASE_WORD_COUNT: 12,
-    // https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
-    BIP44_CARDANO_FIRST_ACCOUNT_SUB_PATH: 'm/44\'/1815\'/0\'',
     hardwareWallet: {
       trezorT: {
         VENDOR: 'trezor.io',

--- a/app/stores/ada/LedgerConnectStore.js
+++ b/app/stores/ada/LedgerConnectStore.js
@@ -159,6 +159,7 @@ export default class LedgerConnectStore extends Store implements HWConnectStoreT
         const versionResp: GetVersionResponse = await ledgerBridge.getVersion();
 
         Logger.debug(stringifyData(versionResp));
+
         // TODO: assume single account in Yoroi
         const accountPath = makeCardanoAccountBIP44Path(0);
         // https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#examples

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -16,6 +16,7 @@ import LocalizedRequest from '../lib/LocalizedRequest';
 import globalMessages from '../../i18n/global-messages';
 import LocalizableError, { UnexpectedError } from '../../i18n/LocalizableError';
 import { CheckAdressesInUseApiError } from '../../api/ada/errors';
+import { derivePathPrefix } from '../../api/ada/lib/utils';
 
 // This is actually just an interface
 import {
@@ -178,7 +179,7 @@ export default class TrezorConnectStore extends Store implements HWConnectStoreT
 
       // TODO: [TREZOR] fix type if possible
       const trezorResp = await TrezorConnect.cardanoGetPublicKey({
-        path: Config.wallets.BIP44_CARDANO_FIRST_ACCOUNT_SUB_PATH
+        path: derivePathPrefix()
       });
 
       const trezorEventDevice: DeviceMessage = { ...this.trezorEventDevice };

--- a/app/stores/base/AddressesStore.js
+++ b/app/stores/base/AddressesStore.js
@@ -93,6 +93,7 @@ export default class AddressesStore extends Store {
   };
 
   _getAccountIdByWalletId = (walletId: string): (?string) => {
+    // Note: assume single account in Yoroi
     const result = this._getAddressesAllRequest(walletId).result;
     return result ? result.accountId : null;
   };

--- a/docs/specs/code/TREZOR_INTEGRATION.md
+++ b/docs/specs/code/TREZOR_INTEGRATION.md
@@ -81,7 +81,6 @@ LAST_BLOCK_NUMBER = "last_block_number"
 ```
 WALLET = {
   "adaWallet": {
-    "cwAccountsNumber": 1,
     "cwAmount": {
       "getCCoin": "1000000"
     },
@@ -111,7 +110,6 @@ LAST_BLOCK_NUMBER = "last_block_number"
 ```
 WALLET = {
   "adaWallet": {
-    "cwAccountsNumber": 1,
     "cwAmount": {
       "getCCoin": "1000000"
     },

--- a/docs/specs/code/ledger-integration/README.md
+++ b/docs/specs/code/ledger-integration/README.md
@@ -111,7 +111,6 @@ LAST_BLOCK_NUMBER = "last_block_number"
 ```
 WALLET = {
   "adaWallet": {
-    "cwAccountsNumber": 1,
     "cwAmount": {
       "getCCoin": "1000000"
     },

--- a/features/support/mockData.json
+++ b/features/support/mockData.json
@@ -26,7 +26,6 @@
     "masterKey": "f5daab925d1b7ab110ed6e69568307e3708f4795a9a93b40a4db1500574ef9cdaece6aa8a4c18f7325992f40193ea39bd7f808f2bbed3f5f66e53d32f9f097cc9aa64bb6848b7ce5da13ab1175122abe3dabb144a258c23fccf643a7fe190347cccf4a0aeaf2c51162d196323d192da857544a5bc0d5cadd421f733992455fabc842547b284648ec50983145ace133711c40fcbedf972c5023ade7de",
     "password": "aaSecret_123",
     "wallet": {
-      "cwAccountsNumber": 1,
       "cwAmount": {
         "getCCoin": "0"
       },


### PR DESCRIPTION
Across Yoroi we assume in a few places we are only dealing with a single account. In most places, this isn't necessary because actually store the current account inside localstorage.

We need to do this for the following:
1) Multi-account in Yoroi
2) Migration to Redux

Note that this doesn't remove this assumption in all places. Notably, it excludes:
1) Changes to the DB format and DB queries to handle multi-accounts. Fixing this part requires a migration for all existing users (not a big deal) so I left it out of this PR
2) Stores still assume single account. This is fine because we will throw away all stores in the Redux migration anyway.