### PR TITLE
Fix Trezor account creation

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -462,9 +462,11 @@ export default class AdaApi {
       Logger.debug('AdaApi::prepareAndBroadcastLedgerSignedTx called');
 
       const { ledgerSignTxResp, unsignedTx } = request;
+      const cryptoAccount = getCurrentCryptoAccount().root_cached_key;
       const response = await prepareAndBroadcastLedgerSignedTx(
         ledgerSignTxResp,
-        unsignedTx
+        unsignedTx,
+        cryptoAccount
       );
       Logger.debug('AdaApi::prepareAndBroadcastLedgerSignedTx success: ' + stringifyData(response));
 

--- a/app/api/ada/lib/utils.js
+++ b/app/api/ada/lib/utils.js
@@ -11,7 +11,6 @@ import type {
 } from '../adaTypes';
 import type { TransactionExportRow } from '../../export';
 import { LOVELACES_PER_ADA } from '../../../config/numbersConfig';
-import { getCurrentAccountIndex } from '../adaLocalStorage';
 
 export const toAdaTx = function (
   amount: BigNumber,
@@ -190,14 +189,16 @@ export function utxosToLookupMap(
   return lookupMap;
 }
 
-export function derivePathAsString(chain: number, addressIndex: number): string {
-  const account = getCurrentAccountIndex();
+export function derivePathAsString(
+  accountIndex: number,
+  chain: number,
+  addressIndex: number
+): string {
   // https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
-  return `m/44'/1815'/${account}'/${chain}/${addressIndex}`;
+  return `m/44'/1815'/${accountIndex}'/${chain}/${addressIndex}`;
 }
 
-export function derivePathPrefix(): string {
-  const account = getCurrentAccountIndex();
+export function derivePathPrefix(accountIndex: number): string {
   // https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
-  return `m/44'/1815'/${account}'`;
+  return `m/44'/1815'/${accountIndex}'`;
 }

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -179,7 +179,8 @@ export default class TrezorConnectStore extends Store implements HWConnectStoreT
 
       // TODO: [TREZOR] fix type if possible
       const trezorResp = await TrezorConnect.cardanoGetPublicKey({
-        path: derivePathPrefix()
+        // TODO: only support Trezor wallest on account 0
+        path: derivePathPrefix(0)
       });
 
       const trezorEventDevice: DeviceMessage = { ...this.trezorEventDevice };


### PR DESCRIPTION
The refactoring to get rid of some of the single-account assumptions accidentally broke Trezor support so I fixed it.

At the same time, I move a few more stateful calls out of the API layer. We need to continue to do this to eventually be able to make the API a standalone package.