### PR TITLE
Improve Crowdin setup

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -14,5 +14,5 @@ files:
         fr: fr-FR
         id: id-ID
   - source : /app/i18n/**/en-US.md
-    translation : /app/i18n/**/%two_letters_code%.md
+    translation : /app/i18n/**/%locale%.md
     languages_mapping: *anchor

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,8 +1,8 @@
 preserve_hierarchy: true
 
 files:
-  - source: /app/i18n/locales/en-US.json
-    translation: /app/i18n/locales/%locale%.json
+  - source: /app/i18n/locales/**/en-US.json
+    translation: /app/i18n/locales/**/%locale%.json
     languages_mapping: &anchor
       language:
         zh-CN: zh-Hans
@@ -13,6 +13,6 @@ files:
         de: de-DE
         fr: fr-FR
         id: id-ID
-  - source : /app/i18n/**/en-US.md
-    translation : /app/i18n/**/%locale%.md
+  - source : /app/i18n/locales/**/en-US.md
+    translation : /app/i18n/locales/**/%locale%.md
     languages_mapping: *anchor

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -14,5 +14,5 @@ files:
         fr: fr-FR
         id: id-ID
   - source : /app/i18n/**/en-US.md
-    translation : /locale/%two_letters_code%/**/%original_file_name%
+    translation : /app/i18n/**/%two_letters_code%.md
     languages_mapping: *anchor

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,9 @@
+preserve_hierarchy: true
+
 files:
   - source: /app/i18n/locales/en-US.json
-    translation: /app/i18n/locales/%language%.json
-    languages_mapping:
+    translation: /app/i18n/locales/%locale%.json
+    languages_mapping: &anchor
       language:
         zh-CN: zh-Hans
         zh-TW: zh-Hant
@@ -11,3 +13,6 @@ files:
         de: de-DE
         fr: fr-FR
         id: id-ID
+  - source : /app/i18n/**/en-US.md
+    translation : /locale/%two_letters_code%/**/%original_file_name%
+    languages_mapping: *anchor


### PR DESCRIPTION
Two main things I want to fix:

1) Add the ability for our Crowdin to translate markdown files (currently only ToS uses markdown but in the future we may have other long-form text we want to put in a markdown such as Ruslan's explanation of paper wallets.
2) Right now every new Crowdin language gets saved with the wrong filename (ex: `Spanish.json` instead of `es-ES`). Hopefully this should fix it.

I made a backup of our Crowdin files in case this breaks everything