### PR TITLE
Add types to Stores

### DIFF
--- a/app/actions/ada/transactions-actions.js
+++ b/app/actions/ada/transactions-actions.js
@@ -1,10 +1,14 @@
 // @flow
 import Action from '../lib/Action';
 
+import type {
+  GetTransactionRowsToExportRequest,
+} from '../../api/ada';
+
 // ======= TRANSACTIONS ACTIONS =======
 
 export default class TransactionsActions {
   loadMoreTransactions: Action<any> = new Action();
-  exportTransactionsToFile: Action<void> = new Action();
+  exportTransactionsToFile: Action<GetTransactionRowsToExportRequest> = new Action();
   closeExportTransactionDialog: Action<void> = new Action();
 }

--- a/app/actions/ada/wallet-settings-actions.js
+++ b/app/actions/ada/wallet-settings-actions.js
@@ -14,6 +14,6 @@ export default class WalletSettingsActions {
   stopEditingWalletField: Action<any> = new Action();
   updateWalletField: Action<{ field: string, value: string }> = new Action();
   // eslint-disable-next-line max-len
-  updateWalletPassword: Action<{ walletId: string, oldPassword: ?string, newPassword: ?string }> = new Action();
+  updateWalletPassword: Action<{ walletId: string, oldPassword: string, newPassword: string }> = new Action();
   exportToFile: Action<WalletExportToFileParams> = new Action();
 }

--- a/app/actions/ada/wallets-actions.js
+++ b/app/actions/ada/wallets-actions.js
@@ -16,6 +16,6 @@ export default class WalletsActions {
   restoreWallet: Action<{recoveryPhrase: string, walletName: string, walletPassword: string }> = new Action();
   importWalletFromFile: Action<WalletImportFromFileParams> = new Action();
   deleteWallet: Action<{ walletId: string }> = new Action();
-  sendMoney: Action<{ receiver: string, amount: string, password: ?string }> = new Action();
+  sendMoney: Action<{ receiver: string, amount: string, password: string }> = new Action();
   updateBalance: Action <{ amount: BigNumber }> = new Action();
 }

--- a/app/api/ada/adaWallet.js
+++ b/app/api/ada/adaWallet.js
@@ -156,7 +156,7 @@ export function createAdaHardwareWallet({
 }
 
 /** Wrapper function to create new mnemonic according to bip39 */
-export const generateAdaAccountRecoveryPhrase = () => (
+export const generateAdaAccountRecoveryPhrase: void => Array<string> = () => (
   generateAdaMnemonic()
 );
 

--- a/app/api/ada/adaWallet.js
+++ b/app/api/ada/adaWallet.js
@@ -30,10 +30,6 @@ import type {
   AdaWalletMetaParams,
   AdaHardwareWalletParams,
 } from './adaTypes';
-import type {
-  ChangeAdaWalletSpendingPasswordParams,
-  AdaWalletRecoveryPhraseResponse,
-} from './index';
 import {
   getUTXOsSumsForAddresses
 } from './lib/yoroi-backend-api';
@@ -160,7 +156,7 @@ export function createAdaHardwareWallet({
 }
 
 /** Wrapper function to create new mnemonic according to bip39 */
-export const generateAdaAccountRecoveryPhrase = (): AdaWalletRecoveryPhraseResponse => (
+export const generateAdaAccountRecoveryPhrase = () => (
   generateAdaMnemonic()
 );
 
@@ -214,7 +210,10 @@ export async function getBalance(
 
 /** Update spending password and password last update time */
 export const changeAdaWalletSpendingPassword = (
-  { oldPassword, newPassword }: ChangeAdaWalletSpendingPasswordParams
+  { oldPassword, newPassword }: {
+    oldPassword: string,
+    newPassword: string,
+  }
 ): Promise<AdaWallet> => {
   // update spending password
   {

--- a/app/api/ada/hardwareWallet/newTransaction.js
+++ b/app/api/ada/hardwareWallet/newTransaction.js
@@ -27,7 +27,7 @@ import {
 import type {
   BroadcastTrezorSignedTxResponse,
   PrepareAndBroadcastLedgerSignedTxResponse
-} from '../../common';
+} from '..';
 import type {
   TrezorInput,
   TrezorOutput,

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -353,7 +353,7 @@ export type IsValidMnemonicRequest = {
 export type IsValidMnemonicResponse = boolean;
 export type IsValidMnemonicFunc = (
   request: IsValidMnemonicRequest
-) => Promise<IsValidMnemonicResponse>;
+) => IsValidMnemonicResponse;
 
 // isValidPaperMnemonic
 
@@ -364,7 +364,7 @@ export type IsValidPaperMnemonicRequest = {
 export type IsValidPaperMnemonicResponse = boolean;
 export type IsValidPaperMnemonicFunc = (
   request: IsValidPaperMnemonicRequest
-) => Promise<IsValidPaperMnemonicResponse>;
+) => IsValidPaperMnemonicResponse;
 
 // unscramblePaperMnemonic
 
@@ -376,7 +376,7 @@ export type UnscramblePaperMnemonicRequest = {
 export type UnscramblePaperMnemonicResponse = [?string, number];
 export type UnscramblePaperMnemonicFunc = (
   request: UnscramblePaperMnemonicRequest
-) => Promise<UnscramblePaperMnemonicResponse>;
+) => UnscramblePaperMnemonicResponse;
 
 // generateWalletRecoveryPhrase
 
@@ -903,26 +903,20 @@ export default class AdaApi {
 
   isValidMnemonic(
     request: IsValidMnemonicRequest,
-  ): Promise<IsValidMnemonicResponse> {
-    return Promise.resolve(
-      isValidMnemonic(request.mnemonic, request.numberOfWords)
-    );
+  ): IsValidMnemonicResponse {
+    return isValidMnemonic(request.mnemonic, request.numberOfWords);
   }
 
   isValidPaperMnemonic(
     request: IsValidPaperMnemonicRequest
-  ): Promise<IsValidPaperMnemonicResponse> {
-    return Promise.resolve(
-      isValidPaperMnemonic(request.mnemonic, request.numberOfWords)
-    );
+  ): IsValidPaperMnemonicResponse {
+    return isValidPaperMnemonic(request.mnemonic, request.numberOfWords);
   }
 
   unscramblePaperMnemonic(
     request: UnscramblePaperMnemonicRequest
-  ): Promise<UnscramblePaperMnemonicResponse> {
-    return Promise.resolve(
-      unscramblePaperMnemonic(request.mnemonic, request.numberOfWords, request.password)
-    );
+  ): UnscramblePaperMnemonicResponse {
+    return unscramblePaperMnemonic(request.mnemonic, request.numberOfWords, request.password);
   }
 
   generateWalletRecoveryPhrase(): Promise<GenerateWalletRecoveryPhraseResponse> {

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -84,27 +84,6 @@ import type {
   AdaAssurance,
 } from './adaTypes';
 import type {
-  CreateWalletRequest,
-  CreateWalletResponse,
-  GetTransactionsRequest,
-  GetTransactionsResponse,
-  GetTransactionRowsToExportRequest,
-  GetTransactionRowsToExportResponse,
-  GetAddressesRequest,
-  GetAddressesResponse,
-  GetBalanceResponse,
-  GenerateWalletRecoveryPhraseResponse,
-  GetWalletsResponse,
-  RefreshPendingTransactionsResponse,
-  RestoreWalletRequest,
-  RestoreWalletResponse,
-  UpdateWalletResponse,
-  CreateHardwareWalletRequest,
-  CreateHardwareWalletResponse,
-  BroadcastTrezorSignedTxResponse,
-  PrepareAndBroadcastLedgerSignedTxResponse,
-} from '../common';
-import type {
   SignTransactionResponse as LedgerSignTxResponse
 } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { InvalidWitnessError, RedeemAdaError, RedemptionKeyAlreadyUsedError } from './errors';
@@ -140,16 +119,130 @@ import {
 } from 'yoroi-extension-ledger-bridge';
 import { generateAdaPaperPdf } from './paperWallet/paperWalletPdf';
 import type { PdfGenStepType } from './paperWallet/paperWalletPdf';
+import type { TransactionExportRow } from '../export';
+
+import { HWFeatures } from '../../types/HWConnectStoreTypes';
 
 import { RustModule } from './lib/cardanoCrypto/rustLoader';
 
 // ADA specific Request / Response params
-export type CreateAddressResponse = WalletAddress;
+
+// createAdaPaper
+
+export type CreateAdaPaperRequest = {
+  password: string,
+  numAddresses?: number
+};
+export type AdaPaper = {
+  addresses: Array<string>,
+  scrambledWords: Array<string>,
+};
+export type CreateAdaPaperFunc = (
+  request: CreateAdaPaperRequest
+) => Promise<AdaPaper>;
+
+// createAdaPaperPdf
+
+export type CreateAdaPaperPdfRequest = {
+  paper: AdaPaper,
+  network: Network,
+  updateStatus?: PdfGenStepType => ?any,
+};
+
+export type CreateAdaPaperPdfResponse = ?Blob;
+export type CreateAdaPaperPdfFunc = (
+  request: CreateAdaPaperPdfRequest
+) => Promise<CreateAdaPaperPdfResponse>;
+
+// getWallets
+
+export type GetWalletsRequest = {};
+export type GetWalletsResponse = Array<Wallet>;
+export type GetWalletsFunc = (
+  request: GetWalletsRequest
+) => Promise<GetWalletsResponse>;
+
+// getExternalAddresses
+
+export type GetAddressesRequest = {
+  walletId: string
+};
+export type GetAddressesResponse = {
+  accountId: string,
+  addresses: Array<WalletAddress>
+};
+export type GetAddressesFunc = (
+  request: GetAddressesRequest
+) => Promise<GetAddressesResponse>;
+
+// getBalance
+
+export type GetBalanceRequest = {};
+export type GetBalanceResponse = BigNumber;
+export type GetBalanceFunc = (
+  request: GetBalanceRequest
+) => Promise<GetBalanceResponse>;
+
+// getTxLastUpdatedDate
+
+export type GetTxLastUpdateDateRequest = {};
+export type GetTxLastUpdateDateResponse = Date;
+export type GetTxLastUpdateDateFunc = (
+  request: GetTxLastUpdateDateRequest
+) => Promise<GetTxLastUpdateDateResponse>;
+
+// refreshTransactions
+
+export type GetTransactionsRequestOptions = {
+  skip: number,
+  limit: number,
+};
+export type GetTransactionsRequest = {
+  walletId: string,
+  ...$Shape<GetTransactionsRequestOptions>
+};
+export type GetTransactionsResponse = {
+  transactions: Array<WalletTransaction>,
+  total: number,
+};
+export type GetTransactionsFunc = (
+  request: GetTransactionsRequest
+) => Promise<GetTransactionsResponse>;
+
+// refreshPendingTransactions
+
+export type RefreshPendingTransactionsRequest = {};
+export type RefreshPendingTransactionsResponse = Array<WalletTransaction>;
+export type RefreshPendingTransactionsFunc = (
+  request: RefreshPendingTransactionsRequest
+) => Promise<RefreshPendingTransactionsResponse>;
+
+// createWallet
+
+export type CreateWalletRequest = {
+  name: string,
+  mnemonic: string,
+  password: string,
+};
+export type CreateWalletResponse = Wallet;
+export type CreateWalletFunc = (
+  request: CreateWalletRequest
+) => Promise<CreateWalletResponse>;
+
+// createTransaction
+
 export type CreateTransactionRequest = {
   receiver: string,
   amount: string,
   password: string
 };
+export type CreateTransactionResponse = SignedResponse;
+export type CreateTransactionFunc = (
+  request: CreateTransactionRequest
+) => Promise<CreateTransactionResponse>;
+
+// createTrezorSignTxData
+
 export type CreateTrezorSignTxDataRequest = {
   receiver: string,
   amount: string
@@ -159,9 +252,22 @@ export type CreateTrezorSignTxDataResponse = {
   trezorSignTxPayload: TrezorSignTxPayload,
   changeAddress: ?AdaAddress,
 };
+export type CreateTrezorSignTxDataFunc = (
+  request: CreateTrezorSignTxDataRequest
+) => Promise<CreateTrezorSignTxDataResponse>;
+
+// broadcastTrezorSignedTx
+
 export type BroadcastTrezorSignedTxRequest = {
   signedTxHex: string,
 };
+export type BroadcastTrezorSignedTxResponse = SignedResponse;
+export type BroadcastTrezorSignedTxFunc = (
+  request: BroadcastTrezorSignedTxRequest
+) => Promise<BroadcastTrezorSignedTxResponse>;
+
+// createLedgerSignTxData
+
 export type CreateLedgerSignTxDataRequest = {
   receiver: string,
   amount: string
@@ -171,70 +277,228 @@ export type CreateLedgerSignTxDataResponse = {
   changeAddress: ?AdaAddress,
   unsignedTx: RustModule.Wallet.Transaction
 };
+export type CreateLedgerSignTxDataFunc = (
+  request: CreateLedgerSignTxDataRequest
+) => Promise<CreateLedgerSignTxDataResponse>;
+
+// prepareAndBroadcastLedgerSignedTx
+
 export type PrepareAndBroadcastLedgerSignedTxRequest = {
   ledgerSignTxResp: LedgerSignTxResponse,
   unsignedTx: RustModule.Wallet.Transaction,
 };
-export type UpdateWalletRequest = {
-  walletId: string,
-  name: string,
-  assurance: AdaAssurance
-};
-export type RedeemAdaRequest = {
-  redemptionCode: string,
-  accountId: string,
-  walletPassword: ?string
-};
-export type RedeemAdaResponse = Wallet;
-export type RedeemPaperVendedAdaRequest = {
-  shieldedRedemptionKey: string,
-  mnemonics: string,
-  accountId: string,
-  walletPassword: ?string
-};
-export type RedeemPaperVendedAdaResponse = RedeemPaperVendedAdaRequest;
-export type ImportWalletFromKeyRequest = {
-  filePath: string,
-  walletPassword: ?string
-};
-export type ImportWalletFromKeyResponse = Wallet;
-export type ImportWalletFromFileRequest = {
-  filePath: string,
-  walletPassword: ?string,
-  walletName: ?string
-};
-export type ImportWalletFromFileResponse = Wallet;
+export type PrepareAndBroadcastLedgerSignedTxResponse = SignedResponse;
+export type PrepareAndBroadcastLedgerSignedTxFunc = (
+  request: PrepareAndBroadcastLedgerSignedTxRequest
+) => Promise<PrepareAndBroadcastLedgerSignedTxResponse>;
+
+// calculateTransactionFee
+
 export type TransactionFeeRequest = {
   sender: string,
   receiver: string,
   amount: string
 };
 export type TransactionFeeResponse = BigNumber;
-export type ExportWalletToFileRequest = {
-  walletId: string,
-  filePath: string,
-  password: ?string
+
+export type TransactionFeeFunc = (
+  request: TransactionFeeRequest
+) => Promise<TransactionFeeResponse>;
+
+// createAddress
+
+export type CreateAddressRequest = {};
+export type CreateAddressResponse = WalletAddress;
+export type CreateAddressFunc = (
+  request: CreateAddressRequest
+) => Promise<CreateAddressResponse>;
+
+// saveAddress
+
+export type SaveAddressRequest = {
+  address: AdaAddress,
+  addressType: AddressType,
 };
-export type ExportWalletToFileResponse = [];
+export type SaveAddressResponse = void;
+export type SaveAddressFunc = (
+  request: SaveAddressRequest
+) => Promise<SaveAddressResponse>;
+
+// saveTxs
+
+export type SaveTxRequest = {
+  txs: Array<AdaTransaction>
+};
+export type SaveTxResponse = void;
+export type SaveTxFunc = (
+  request: SaveTxRequest
+) => Promise<SaveTxResponse>;
+
+// isValidAddress
+
+export type IsValidAddressRequest = {
+  address: string
+};
+export type IsValidAddressResponse = boolean;
+export type IsValidAddressFunc = (
+  request: IsValidAddressRequest
+) => Promise<IsValidAddressResponse>;
+
+// isValidMnemonic
+
+export type IsValidMnemonicRequest = {
+  mnemonic: string,
+  numberOfWords: ?number
+};
+export type IsValidMnemonicResponse = boolean;
+export type IsValidMnemonicFunc = (
+  request: IsValidMnemonicRequest
+) => Promise<IsValidMnemonicResponse>;
+
+// isValidPaperMnemonic
+
+export type IsValidPaperMnemonicRequest = {
+  mnemonic: string,
+  numberOfWords: ?number
+};
+export type IsValidPaperMnemonicResponse = boolean;
+export type IsValidPaperMnemonicFunc = (
+  request: IsValidPaperMnemonicRequest
+) => Promise<IsValidPaperMnemonicResponse>;
+
+// unscramblePaperMnemonic
+
+export type UnscramblePaperMnemonicRequest = {
+  mnemonic: string,
+  numberOfWords: ?number,
+  password?: string,
+};
+export type UnscramblePaperMnemonicResponse = [?string, number];
+export type UnscramblePaperMnemonicFunc = (
+  request: UnscramblePaperMnemonicRequest
+) => Promise<UnscramblePaperMnemonicResponse>;
+
+// generateWalletRecoveryPhrase
+
+export type GenerateWalletRecoveryPhraseRequest = {};
+export type GenerateWalletRecoveryPhraseResponse = Array<string>;
+export type GenerateWalletRecoveryPhraseFunc = (
+  request: GenerateWalletRecoveryPhraseRequest
+) => Promise<GenerateWalletRecoveryPhraseResponse>;
+
+// restoreWallet
+
+export type RestoreWalletRequest = {
+  recoveryPhrase: string,
+  walletName: string,
+  walletPassword: string,
+};
+export type RestoreWalletResponse = Wallet;
+export type RestoreWalletFunc = (
+  request: RestoreWalletRequest
+) => Promise<RestoreWalletResponse>;
+
+// updateWalletMeta
+
+export type UpdateWalletRequest = {
+  walletId: string,
+  name: string,
+  assurance: AdaAssurance
+};
+export type UpdateWalletResponse = Wallet;
+export type UpdateWalletFunc = (
+  request: UpdateWalletRequest
+) => Promise<UpdateWalletResponse>;
+
+// updateWalletPassword
 
 export type UpdateWalletPasswordRequest = {
+  walletId: string,
   oldPassword: string,
   newPassword: string,
 };
-
-export type ChangeAdaWalletSpendingPasswordParams = {
-  oldPassword: string,
-  newPassword: string,
-};
-
 export type UpdateWalletPasswordResponse = boolean;
+export type UpdateWalletPasswordFunc = (
+  request: UpdateWalletPasswordRequest
+) => Promise<UpdateWalletPasswordResponse>;
 
-export type AdaWalletRecoveryPhraseResponse = Array<string>;
+// createHardwareWallet
 
-export type AdaPaper = {
-  addresses: Array<string>,
-  scrambledWords: Array<string>,
-}
+export type CreateHardwareWalletRequest = {
+  walletName: string,
+  publicMasterKey: string,
+  hwFeatures: HWFeatures,
+};
+export type CreateHardwareWalletResponse = Wallet;
+export type CreateHardwareWalletFunc = (
+  request: CreateHardwareWalletRequest
+) => Promise<CreateHardwareWalletResponse>;
+
+// getTransactionRowsToExport
+
+export type GetTransactionRowsToExportRequest = {}; // TODO: Implement in the Next iteration
+export type GetTransactionRowsToExportResponse = Array<TransactionExportRow>;
+export type GetTransactionRowsToExportFunc = (
+  request: GetTransactionRowsToExportRequest
+) => Promise<GetTransactionRowsToExportResponse>;
+
+// getPDFSecretKey
+
+export type GetPdfSecretKeyRequest = {
+  file: ?Blob,
+  decryptionKey: ?string,
+  redemptionType: string
+};
+export type GetPdfSecretKeyResponse = string;
+export type GetPdfSecretKeyFunc = (
+  request: GetPdfSecretKeyRequest
+) => Promise<GetPdfSecretKeyResponse>;
+
+// isValidRedemptionKey
+
+export type IsValidRedemptionKeyRequest = {
+  mnemonic: string,
+};
+export type IsValidRedemptionKeyResponse = boolean;
+export type IsValidRedemptionKeyFunc = (
+  request: IsValidRedemptionKeyRequest
+) => Promise<IsValidRedemptionKeyResponse>;
+
+// isValidPaperVendRedemptionKey
+
+export type IsValidPaperVendRedemptionKeyRequest = {
+  mnemonic: string,
+};
+export type IsValidPaperVendRedemptionKeyResponse = boolean;
+export type IsValidPaperVendRedemptionKeyFunc = (
+  request: IsValidPaperVendRedemptionKeyRequest
+) => Promise<IsValidPaperVendRedemptionKeyResponse>;
+
+// isValidRedemptionMnemonic
+
+export type IsValidRedemptionMnemonicRequest = {
+  mnemonic: string,
+};
+export type IsValidRedemptionMnemonicResponse = boolean;
+export type IsValidRedemptionMnemonicFunc = (
+  request: IsValidRedemptionMnemonicRequest
+) => Promise<IsValidRedemptionMnemonicResponse>;
+
+// redeemAda
+
+export type RedeemAdaRequest = RedeemAdaParams;
+export type RedeemAdaResponse = BigNumber;
+export type RedeemAdaFunc = (
+  request: RedeemAdaRequest
+) => Promise<RedeemAdaResponse>;
+
+// redeemPaperVendedAda
+
+export type RedeemPaperVendedAdaRequest = RedeemPaperVendedAdaParams;
+export type RedeemPaperVendedAdaResponse = BigNumber;
+export type RedeemPaperVendedAdaFunc = (
+  request: RedeemPaperVendedAdaRequest
+) => Promise<RedeemPaperVendedAdaResponse>;
 
 export const DEFAULT_ADDRESSES_PER_PAPER = 1;
 
@@ -245,10 +509,7 @@ export default class AdaApi {
     {
       password,
       numAddresses
-    }: {
-      password: string,
-      numAddresses?: number
-    } = {}
+    }: CreateAdaPaperRequest = {}
   ): AdaPaper {
     const { words, scrambledWords } = generatePaperWalletSecret(password);
     const addresses = mnemonicsToExternalAddresses(words.join(' '), numAddresses || DEFAULT_ADDRESSES_PER_PAPER);
@@ -260,15 +521,11 @@ export default class AdaApi {
       paper,
       network,
       updateStatus
-    }: {
-      paper: AdaPaper,
-      network: Network,
-      updateStatus?: (PdfGenStepType => ?any)
-    }
-  ): Promise<?Blob> {
+    }: CreateAdaPaperPdfRequest
+  ): Promise<CreateAdaPaperPdfResponse> {
     const { addresses, scrambledWords } = paper;
     // noinspection UnnecessaryLocalVariableJS
-    const res : Promise<?Blob> = generateAdaPaperPdf({
+    const res : Promise<CreateAdaPaperPdfResponse> = generateAdaPaperPdf({
       words: scrambledWords,
       addresses,
       network,
@@ -335,7 +592,7 @@ export default class AdaApi {
     }
   }
 
-  async getTxLastUpdatedDate(): Promise<Date> {
+  async getTxLastUpdatedDate(): Promise<GetTxLastUpdateDateResponse> {
     try {
       return getAdaTxLastUpdatedDate();
     } catch (error) {
@@ -397,7 +654,7 @@ export default class AdaApi {
 
   async createTransaction(
     request: CreateTransactionRequest
-  ): Promise<SignedResponse> {
+  ): Promise<CreateTransactionResponse> {
     Logger.debug('AdaApi::createTransaction called');
     const { receiver, amount, password } = request;
     try {
@@ -615,9 +872,11 @@ export default class AdaApi {
   }
 
   /** TODO: This method is exposed to allow injecting data when testing */
-  async saveAddress(address: AdaAddress, addressType: AddressType): Promise<void> {
+  async saveAddress(
+    request: SaveAddressRequest
+  ): Promise<SaveAddressResponse> {
     try {
-      await saveAdaAddress(address, addressType);
+      await saveAdaAddress(request.address, request.addressType);
     } catch (error) {
       Logger.error('AdaApi::saveAddress error: ' + stringifyError(error));
       throw new GenericApiError();
@@ -625,39 +884,51 @@ export default class AdaApi {
   }
 
   /** TODO: This method is exposed to allow injecting data when testing */
-  async saveTxs(txs: Array<AdaTransaction>): Promise<void> {
+  async saveTxs(
+    request: SaveTxRequest
+  ): Promise<void> {
     try {
-      await saveTxs(txs);
+      await saveTxs(request.txs);
     } catch (error) {
       Logger.error('AdaApi::saveTxs error: ' + stringifyError(error));
       throw new GenericApiError();
     }
   }
 
-  isValidAddress(address: string): Promise<boolean> {
-    return isValidAdaAddress(address);
+  isValidAddress(
+    request: IsValidAddressRequest
+  ): Promise<IsValidAddressResponse> {
+    return isValidAdaAddress(request.address);
   }
 
-  isValidMnemonic(mnemonic: string, numberOfWords: ?number): boolean {
-    return isValidMnemonic(mnemonic, numberOfWords);
+  isValidMnemonic(
+    request: IsValidMnemonicRequest,
+  ): Promise<IsValidMnemonicResponse> {
+    return Promise.resolve(
+      isValidMnemonic(request.mnemonic, request.numberOfWords)
+    );
   }
 
-  isValidPaperMnemonic(mnemonic: string, numberOfWords: ?number): boolean {
-    return isValidPaperMnemonic(mnemonic, numberOfWords);
+  isValidPaperMnemonic(
+    request: IsValidPaperMnemonicRequest
+  ): Promise<IsValidPaperMnemonicResponse> {
+    return Promise.resolve(
+      isValidPaperMnemonic(request.mnemonic, request.numberOfWords)
+    );
   }
 
   unscramblePaperMnemonic(
-    mnemonic: string,
-    numberOfWords: ?number,
-    password?: string
-  ): [?string, number] {
-    return unscramblePaperMnemonic(mnemonic, numberOfWords, password);
+    request: UnscramblePaperMnemonicRequest
+  ): Promise<UnscramblePaperMnemonicResponse> {
+    return Promise.resolve(
+      unscramblePaperMnemonic(request.mnemonic, request.numberOfWords, request.password)
+    );
   }
 
   generateWalletRecoveryPhrase(): Promise<GenerateWalletRecoveryPhraseResponse> {
     Logger.debug('AdaApi::generateWalletRecoveryPhrase called');
     try {
-      const response: Promise<AdaWalletRecoveryPhraseResponse> = new Promise(
+      const response = new Promise(
         resolve => resolve(generateAdaAccountRecoveryPhrase())
       );
       Logger.debug('AdaApi::generateWalletRecoveryPhrase success');
@@ -828,14 +1099,16 @@ export default class AdaApi {
   }
 
   async getPDFSecretKey(
-    file: ?Blob,
-    decryptionKey: ?string,
-    redemptionType: string
-  ): Promise<string> {
+    request: GetPdfSecretKeyRequest
+  ): Promise<GetPdfSecretKeyResponse> {
     Logger.debug('AdaApi::getPDFSecretKey called');
     try {
-      const fileBuffer = await readFile(file);
-      const decryptedFileBuffer = decryptFile(decryptionKey, redemptionType, fileBuffer);
+      const fileBuffer = await readFile(request.file);
+      const decryptedFileBuffer = decryptFile(
+        request.decryptionKey,
+        request.redemptionType,
+        fileBuffer
+      );
       const parsedPDFString = await parsePDFFile(decryptedFileBuffer);
       return getSecretKey(parsedPDFString);
     } catch (error) {
@@ -844,19 +1117,36 @@ export default class AdaApi {
     }
   }
 
-  isValidRedemptionKey = (mnemonic: string): boolean => (isValidRedemptionKey(mnemonic));
+  isValidRedemptionKey(
+    request: IsValidRedemptionKeyRequest
+  ): Promise<IsValidRedemptionKeyResponse> {
+    return Promise.resolve(
+      isValidRedemptionKey(request.mnemonic)
+    );
+  }
 
-  isValidPaperVendRedemptionKey = (mnemonic: string): boolean => (
-    isValidPaperVendRedemptionKey(mnemonic)
-  );
+  isValidPaperVendRedemptionKey(
+    request: IsValidPaperVendRedemptionKeyRequest
+  ): Promise<IsValidPaperVendRedemptionKeyResponse> {
+    return Promise.resolve(
+      isValidPaperVendRedemptionKey(request.mnemonic)
+    );
+  }
 
-  isValidRedemptionMnemonic = (mnemonic: string): boolean => (
-    isValidMnemonic(mnemonic, config.adaRedemption.ADA_REDEMPTION_PASSPHRASE_LENGTH)
-  );
+  isValidRedemptionMnemonic(
+    request: IsValidRedemptionMnemonicRequest
+  ): Promise<IsValidRedemptionMnemonicResponse> {
+    return Promise.resolve(
+      isValidMnemonic(
+        request.mnemonic,
+        config.adaRedemption.ADA_REDEMPTION_PASSPHRASE_LENGTH
+      )
+    );
+  }
 
   redeemAda = async (
-    request: RedeemAdaParams
-  ): BigNumber => {
+    request: RedeemAdaRequest
+  ): RedeemAdaResponse => {
     Logger.debug('AdaApi::redeemAda called');
     try {
       const transactionAmount = await redeemAda(request);
@@ -872,8 +1162,8 @@ export default class AdaApi {
   };
 
   redeemPaperVendedAda = async (
-    request: RedeemPaperVendedAdaParams
-  ): BigNumber => {
+    request: RedeemPaperVendedAdaRequest
+  ): RedeemPaperVendedAdaResponse => {
     Logger.debug('AdaApi::redeemAdaPaperVend called');
     try {
       const transactionAmount = await redeemPaperVendedAda(request);

--- a/app/api/ada/lib/cardanoCrypto/cryptoWallet.js
+++ b/app/api/ada/lib/cardanoCrypto/cryptoWallet.js
@@ -22,7 +22,7 @@ import { createCryptoAccount } from '../../adaAccount';
 declare var CONFIG : ConfigType;
 
 /** Generate a random mnemonic based on 160-bits of entropy (15 words) */
-export const generateAdaMnemonic = () => generateMnemonic(160).split(' ');
+export const generateAdaMnemonic: void => Array<string> = () => generateMnemonic(160).split(' ');
 
 /** Check validty of mnemonic (including checksum) */
 export const isValidEnglishAdaMnemonic = (

--- a/app/api/common.js
+++ b/app/api/common.js
@@ -2,14 +2,9 @@
 
 // Define types that are exposed to connect to the API layer
 
-import BigNumber from 'bignumber.js';
 import { defineMessages } from 'react-intl';
 
 import LocalizableError from '../i18n/LocalizableError';
-import WalletTransaction from '../domain/WalletTransaction';
-import WalletAddress from '../domain/WalletAddress';
-import Wallet from '../domain/Wallet';
-import { HWFeatures } from '../types/HWConnectStoreTypes';
 import type { SignedResponse } from './ada/lib/yoroi-backend-api';
 import type {
   TransactionExportRow,
@@ -85,29 +80,6 @@ export class UnusedAddressesError extends LocalizableError {
   }
 }
 
-export type GetAddressesRequest = {
-  walletId: string
-};
-export type GetAddressesResponse = {
-  accountId: string,
-  addresses: Array<WalletAddress>
-};
-
-export type GetTransactionsRequesOptions = {
-  skip: number,
-  limit: number,
-};
-export type GetTransactionsRequest = {
-  walletId: string,
-} & GetTransactionsRequesOptions;
-export type GetTransactionsResponse = {
-  transactions: Array<WalletTransaction>,
-  total: number,
-};
-
-export type GetTransactionRowsToExportRequest = void; // TODO: Implement in the Next iteration
-export type GetTransactionRowsToExportResponse = Array<TransactionExportRow>;
-
 export type ExportTransactionsRequest = {
   rows: Array<TransactionExportRow>,
   format?: TransactionExportDataFormat,
@@ -115,52 +87,16 @@ export type ExportTransactionsRequest = {
   fileName?: string
 };
 export type ExportTransactionsResponse = void;  // TODO: Implement in the Next iteration
-
-export type CreateWalletRequest = {
-  name: string,
-  mnemonic: string,
-  password: string,
-};
-export type CreateWalletResponse = Wallet;
+export type ExportTransactionsFunc = (
+  request: ExportTransactionsRequest
+) => Promise<ExportTransactionsResponse>;
 
 export type DeleteWalletRequest = {
   walletId: string,
 };
 export type DeleteWalletResponse = boolean;
-
-export type RestoreWalletRequest = {
-  recoveryPhrase: string,
-  walletName: string,
-  walletPassword: string,
-};
-export type RestoreWalletResponse = Wallet;
-
-export type CreateHardwareWalletRequest = {
-  walletName: string,
-  publicMasterKey: string,
-  hwFeatures: HWFeatures,
-};
-export type CreateHardwareWalletResponse = Wallet;
-
-export type UpdateWalletPasswordRequest = {
-  walletId: string,
-  oldPassword: string,
-  newPassword: string,
-};
-export type UpdateWalletPasswordResponse = boolean;
-
-export type UpdateWalletResponse = Wallet;
+export type DeleteWalletFunc = (
+  request: DeleteWalletRequest
+) => Promise<DeleteWalletResponse>;
 
 export type CreateTransactionResponse = SignedResponse;
-
-export type BroadcastTrezorSignedTxResponse = SignedResponse;
-
-export type PrepareAndBroadcastLedgerSignedTxResponse = SignedResponse;
-
-export type GetWalletsResponse = Array<Wallet>;
-
-export type GenerateWalletRecoveryPhraseResponse = Array<string>;
-
-export type RefreshPendingTransactionsResponse = Array<WalletTransaction>;
-
-export type GetBalanceResponse = BigNumber;

--- a/app/api/localStorage/index.js
+++ b/app/api/localStorage/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 import environment from '../../environment';
 
 const networkForLocalStorage = String(environment.NETWORK);
@@ -58,7 +60,7 @@ export default class LocalStorageApi {
 
   setTermsOfUseAcceptance = (): Promise<void> => new Promise((resolve, reject) => {
     try {
-      localStorage.setItem(storageKeys.TERMS_OF_USE_ACCEPTANCE, true);
+      localStorage.setItem(storageKeys.TERMS_OF_USE_ACCEPTANCE, JSON.stringify(true));
       resolve();
     } catch (error) {
       return reject(error);
@@ -112,8 +114,10 @@ export default class LocalStorageApi {
     }
   });
 
-  setCustomUserTheme = (customThemeVars: string, currentThemeVars: Object)
-  : Promise<void> => new Promise((resolve, reject) => {
+  setCustomUserTheme = (
+    customThemeVars: string,
+    currentThemeVars: Object
+  ): Promise<void> => new Promise((resolve, reject) => {
     try {
       // Convert CSS String into Javascript Object
       const vars = customThemeVars.split(';');
@@ -185,9 +189,9 @@ export default class LocalStorageApi {
   });
 
   async reset() {
-    await this.unsetUserLocale(); // TODO: remove after saving locale to API is restored
+    await this.unsetUserLocale();
     await this.unsetTermsOfUseAcceptance();
     await this.unsetUserTheme();
-    await this.unsetVerionNumber();
+    await this.unsetLastLaunchVersion();
   }
 }

--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -217,10 +217,10 @@ export default class AdaRedemptionForm extends Component<Props> {
           // Otherwise check mnemonic
           const passPhrase = join(field.value, ' ');
           if (!isEmpty(passPhrase)) this.props.onPassPhraseChanged(passPhrase);
-          return [
-            this.props.mnemonicValidator(passPhrase),
-            this.context.intl.formatMessage(new InvalidMnemonicError())
-          ];
+          return this.props.mnemonicValidator(passPhrase)
+            .then(isValid => (
+              [isValid, this.context.intl.formatMessage(new InvalidMnemonicError())]
+            ));
         }]
       },
       redemptionKey: {
@@ -230,10 +230,10 @@ export default class AdaRedemptionForm extends Component<Props> {
           if (this.props.redemptionType === ADA_REDEMPTION_TYPES.PAPER_VENDED) return [true];
           const value = this.props.redemptionCode || field.value;
           if (value === '') return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
-          return [
-            this.props.redemptionCodeValidator(value),
-            this.context.intl.formatMessage(messages.redemptionKeyError)
-          ];
+          return this.props.redemptionCodeValidator(value)
+            .then(isValid => (
+              [isValid, this.context.intl.formatMessage(messages.redemptionKeyError)]
+            ));
         },
       },
       shieldedRedemptionKey: {
@@ -244,10 +244,10 @@ export default class AdaRedemptionForm extends Component<Props> {
           if (this.props.redemptionType !== ADA_REDEMPTION_TYPES.PAPER_VENDED) return [true];
           const value = field.value;
           if (value === '') return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
-          return [
-            this.props.postVendRedemptionCodeValidator(value),
-            this.context.intl.formatMessage(messages.shieldedRedemptionKeyError)
-          ];
+          return this.props.postVendRedemptionCodeValidator(value)
+            .then(isValid => (
+              [isValid, this.context.intl.formatMessage(messages.shieldedRedemptionKeyError)]
+            ));
         },
       },
       walletId: {

--- a/app/stores/ada/AdaAddressesStore.js
+++ b/app/stores/ada/AdaAddressesStore.js
@@ -3,13 +3,15 @@
 import { observable } from 'mobx';
 import AddressesStore from '../base/AddressesStore';
 import Request from '../lib/LocalizedRequest';
-import type WalletAddress from '../../domain/WalletAddress';
+import type {
+  CreateAddressFunc,
+} from '../../api/ada';
 
 export default class AdaAddressesStore extends AddressesStore {
 
   // REQUESTS
-  @observable createAddressRequest:
-    Request<WalletAddress> = new Request(this.api.ada.createAddress);
+  @observable createAddressRequest: Request<CreateAddressFunc>
+    = new Request<CreateAddressFunc>(this.api.ada.createAddress);
 
   setup() {
     super.setup();

--- a/app/stores/ada/AdaRedemptionStore.js
+++ b/app/stores/ada/AdaRedemptionStore.js
@@ -68,15 +68,15 @@ export default class AdaRedemptionStore extends Store {
     ]);
   }
 
-  isValidRedemptionKey = (redemptionKey: string) => (
+  isValidRedemptionKey = (redemptionKey: string): Promise<boolean> => (
     this.api.ada.isValidRedemptionKey({ mnemonic: redemptionKey })
   );
 
-  isValidRedemptionMnemonic = (mnemonic: string) => (
+  isValidRedemptionMnemonic = (mnemonic: string): Promise<boolean> => (
     this.api.ada.isValidRedemptionMnemonic({ mnemonic })
   );
 
-  isValidPaperVendRedemptionKey = (mnemonic: string) => (
+  isValidPaperVendRedemptionKey = (mnemonic: string): Promise<boolean> => (
     this.api.ada.isValidPaperVendRedemptionKey({ mnemonic })
   );
 

--- a/app/stores/ada/AdaRedemptionStore.js
+++ b/app/stores/ada/AdaRedemptionStore.js
@@ -12,11 +12,15 @@ import {
 import LocalizableError from '../../i18n/LocalizableError';
 import { ROUTES } from '../../routes-config';
 import { matchRoute } from '../../utils/routing';
-import type { RedeemAdaParams, RedeemPaperVendedAdaParams } from '../../api/ada/adaRedemption';
 import { DECIMAL_PLACES_IN_ADA } from '../../config/numbersConfig';
 import environment from '../../environment';
 import BigNumber from 'bignumber.js';
 import Request from '../lib/LocalizedRequest';
+
+import type {
+  RedeemAdaFunc,
+  RedeemPaperVendedAdaFunc,
+} from '../../api/ada';
 
 export default class AdaRedemptionStore extends Store {
 
@@ -33,9 +37,13 @@ export default class AdaRedemptionStore extends Store {
   @observable isRedemptionDisclaimerAccepted = false;
   @observable walletId: ?string = null;
   @observable shieldedRedemptionKey: ?string = null;
-  @observable redeemAdaRequest: Request<RedeemAdaParams> = new Request(this.api.ada.redeemAda);
+  @observable redeemAdaRequest: Request<RedeemAdaFunc>
+    = new Request<RedeemAdaFunc>(this.api.ada.redeemAda);
+
   // eslint-disable-next-line
-  @observable redeemPaperVendedAdaRequest: Request<RedeemPaperVendedAdaParams> = new Request(this.api.ada.redeemPaperVendedAda);
+  @observable redeemPaperVendedAdaRequest: Request<RedeemPaperVendedAdaFunc>
+    = new Request<RedeemPaperVendedAdaFunc>(this.api.ada.redeemPaperVendedAda);
+
   @observable amountRedeemed: number = 0;
   @observable showAdaRedemptionSuccessMessage: boolean = false;
 
@@ -61,15 +69,15 @@ export default class AdaRedemptionStore extends Store {
   }
 
   isValidRedemptionKey = (redemptionKey: string) => (
-    this.api.ada.isValidRedemptionKey(redemptionKey)
+    this.api.ada.isValidRedemptionKey({ mnemonic: redemptionKey })
   );
 
   isValidRedemptionMnemonic = (mnemonic: string) => (
-    this.api.ada.isValidRedemptionMnemonic(mnemonic)
+    this.api.ada.isValidRedemptionMnemonic({ mnemonic })
   );
 
   isValidPaperVendRedemptionKey = (mnemonic: string) => (
-    this.api.ada.isValidPaperVendRedemptionKey(mnemonic)
+    this.api.ada.isValidPaperVendRedemptionKey({ mnemonic })
   );
 
   @computed get isAdaRedemptionPage(): boolean {
@@ -165,7 +173,11 @@ export default class AdaRedemptionStore extends Store {
     ) {
       decryptionKey = this.decryptionKey;
     }
-    this.api.ada.getPDFSecretKey(this.certificate, decryptionKey, this.redemptionType)
+    this.api.ada.getPDFSecretKey({
+      file: this.certificate,
+      decryptionKey,
+      redemptionType: this.redemptionType
+    })
       .then(code => this._onCodeParsed(code))
       .catch(error => this._onParseError(error));
   }
@@ -215,10 +227,11 @@ export default class AdaRedemptionStore extends Store {
     runInAction(() => { this.walletId = walletId; });
 
     try {
-      const transactionAmountInLovelace: BigNumber =
+      if (!this.passPhrase) throw new Error('should never happen');
+      const transactionAmountInLovelace =
         await this.redeemPaperVendedAdaRequest.execute({
           redemptionCode: shieldedRedemptionKey,
-          mnemonics: this.passPhrase && this.passPhrase.split(' ')
+          mnemonics: this.passPhrase.split(' ')
         });
       this._reset();
       const transactionAmountInAda = this._getTransactionAmountInAda(transactionAmountInLovelace);

--- a/app/stores/ada/AdaWalletSettingsStore.js
+++ b/app/stores/ada/AdaWalletSettingsStore.js
@@ -3,16 +3,15 @@ import { observable, action } from 'mobx';
 import _ from 'lodash';
 import WalletSettingsStore from '../base/WalletSettingsStore';
 import Request from '../lib/LocalizedRequest';
-import type { UpdateWalletPasswordResponse, UpdateWalletResponse } from '../../api/common';
+import type { UpdateWalletPasswordFunc, UpdateWalletFunc } from '../../api/ada';
 
 export default class AdaWalletSettingsStore extends WalletSettingsStore {
 
-  @observable updateWalletMetaRequest: Request<UpdateWalletResponse> = new Request(
-    this.api.ada.updateWalletMeta
-  );
-  @observable updateWalletPasswordRequest: Request<UpdateWalletPasswordResponse> = new Request(
-    this.api.ada.updateWalletPassword
-  );
+  @observable updateWalletMetaRequest: Request<UpdateWalletFunc>
+    = new Request<UpdateWalletFunc>(this.api.ada.updateWalletMeta);
+
+  @observable updateWalletPasswordRequest: Request<UpdateWalletPasswordFunc>
+    = new Request<UpdateWalletPasswordFunc>(this.api.ada.updateWalletPassword);
 
   setup() {
     const a = this.actions.ada.walletSettings;
@@ -30,8 +29,8 @@ export default class AdaWalletSettingsStore extends WalletSettingsStore {
       newPassword
     }: {
       walletId: string,
-      oldPassword: ?string,
-      newPassword: ?string
+      oldPassword: string,
+      newPassword: string
     }
   ): Promise<void> => {
     await this.updateWalletPasswordRequest.execute({ walletId, oldPassword, newPassword });

--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -95,12 +95,12 @@ export default class AdaWalletsStore extends WalletStore {
   isValidMnemonic = (
     mnemonic: string,
     numberOfWords: ?number
-  ): Promise<boolean> => this.api.ada.isValidMnemonic({ mnemonic, numberOfWords });
+  ): boolean => this.api.ada.isValidMnemonic({ mnemonic, numberOfWords });
 
   isValidPaperMnemonic = (
     mnemonic: string,
     numberOfWords: ?number
-  ): Promise<boolean> => this.api.ada.isValidPaperMnemonic({ mnemonic, numberOfWords });
+  ): boolean => this.api.ada.isValidPaperMnemonic({ mnemonic, numberOfWords });
 
   // =================== WALLET RESTORATION ==================== //
 

--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -10,38 +10,36 @@ import { matchRoute, buildRoute } from '../../utils/routing';
 import Request from '../lib/LocalizedRequest';
 import { ROUTES } from '../../routes-config';
 import type { WalletImportFromFileParams } from '../../actions/ada/wallets-actions';
-import type { ImportWalletFromFileResponse } from '../../api/ada/index';
 import type {
-  CreateTransactionResponse, CreateWalletResponse, DeleteWalletResponse,
-  GetWalletsResponse, RestoreWalletResponse,
-  GenerateWalletRecoveryPhraseResponse
-} from '../../api/common';
+  CreateTransactionFunc, CreateWalletFunc,
+  GetWalletsFunc, RestoreWalletFunc,
+  GenerateWalletRecoveryPhraseFunc
+} from '../../api/ada/index';
+import type { DeleteWalletFunc } from '../../api/common';
 
 export default class AdaWalletsStore extends WalletStore {
 
   // REQUESTS
-  @observable walletsRequest:
-    Request<GetWalletsResponse> = new Request(this.api.ada.getWallets);
+  @observable walletsRequest: Request<GetWalletsFunc>
+    = new Request<GetWalletsFunc>(this.api.ada.getWallets);
 
-  @observable importFromFileRequest:
-    Request<ImportWalletFromFileResponse> = new Request(() => {});
+  @observable importFromFileRequest: Request<{} => Promise<{}>>
+    = new Request<{} => Promise<{}>>(() => Promise.resolve({}));
 
-  @observable createWalletRequest:
-    Request<CreateWalletResponse> = new Request(this.api.ada.createWallet.bind(this.api.ada));
+  @observable createWalletRequest: Request<CreateWalletFunc>
+    = new Request<CreateWalletFunc>(this.api.ada.createWallet.bind(this.api.ada));
 
-  @observable deleteWalletRequest:
-    Request<DeleteWalletResponse> = new Request(() => {});
+  @observable deleteWalletRequestt: Request<DeleteWalletFunc>
+    = new Request<DeleteWalletFunc>(() => Promise.resolve(true));
 
-  @observable sendMoneyRequest:
-    Request<CreateTransactionResponse> = new Request(this.api.ada.createTransaction);
+  @observable sendMoneyRequest: Request<CreateTransactionFunc>
+    = new Request<CreateTransactionFunc>(this.api.ada.createTransaction);
 
-  @observable generateWalletRecoveryPhraseRequest:
-    Request<GenerateWalletRecoveryPhraseResponse> = new Request(
-      this.api.ada.generateWalletRecoveryPhrase
-    );
+  @observable generateWalletRecoveryPhraseRequest: Request<GenerateWalletRecoveryPhraseFunc>
+    = new Request<GenerateWalletRecoveryPhraseFunc>(this.api.ada.generateWalletRecoveryPhrase);
 
-  @observable restoreRequest:
-    Request<RestoreWalletResponse> = new Request(this.api.ada.restoreWallet);
+  @observable restoreRequest: Request<RestoreWalletFunc>
+    = new Request<RestoreWalletFunc>(this.api.ada.restoreWallet);
 
   setup() {
     super.setup();
@@ -63,7 +61,7 @@ export default class AdaWalletsStore extends WalletStore {
   _sendMoney = async (transactionDetails: {
     receiver: string,
     amount: string,
-    password: ?string,
+    password: string,
   }) => {
     const wallet = this.active;
     if (!wallet) throw new Error('Active wallet required before sending.');
@@ -92,17 +90,17 @@ export default class AdaWalletsStore extends WalletStore {
 
   // =================== VALIDITY CHECK ==================== //
 
-  isValidAddress = (address: string): Promise<boolean> => this.api.ada.isValidAddress(address);
+  isValidAddress = (address: string): Promise<boolean> => this.api.ada.isValidAddress({ address });
 
   isValidMnemonic = (
     mnemonic: string,
     numberOfWords: ?number
-  ): boolean => this.api.ada.isValidMnemonic(mnemonic, numberOfWords);
+  ): Promise<boolean> => this.api.ada.isValidMnemonic({ mnemonic, numberOfWords });
 
   isValidPaperMnemonic = (
     mnemonic: string,
     numberOfWords: ?number
-  ): boolean => this.api.ada.isValidPaperMnemonic(mnemonic, numberOfWords);
+  ): Promise<boolean> => this.api.ada.isValidPaperMnemonic({ mnemonic, numberOfWords });
 
   // =================== WALLET RESTORATION ==================== //
 
@@ -158,9 +156,11 @@ export default class AdaWalletsStore extends WalletStore {
     }, this.WAIT_FOR_SERVER_ERROR_TIME);
 
     const { filePath, walletName, walletPassword } = params;
-    const importedWallet = await this.importFromFileRequest.execute({
+    this.importFromFileRequest.execute({
       filePath, walletName, walletPassword,
-    }).promise;
+    });
+    // $FlowFixMe fix if we ever implement this
+    const importedWallet = await this.importFromFileRequest.promise;
     setTimeout(() => {
       this._setIsImportActive(false);
       this.actions.dialogs.closeActiveDialog.trigger();

--- a/app/stores/ada/LedgerConnectStore.js
+++ b/app/stores/ada/LedgerConnectStore.js
@@ -21,8 +21,8 @@ import LocalizedRequest from '../lib/LocalizedRequest';
 
 import type {
   CreateHardwareWalletRequest,
-  CreateHardwareWalletResponse,
-} from '../../api/common';
+  CreateHardwareWalletFunc,
+} from '../../api/ada';
 
 import {
   convertToLocalizableError
@@ -73,8 +73,8 @@ export default class LedgerConnectStore extends Store implements HWConnectStoreT
   // =================== VIEW RELATED =================== //
 
   // =================== API RELATED =================== //
-  createHWRequest: LocalizedRequest<CreateHardwareWalletResponse> =
-    new LocalizedRequest(this.api.ada.createHardwareWallet);
+  createHWRequest: LocalizedRequest<CreateHardwareWalletFunc>
+    = new LocalizedRequest<CreateHardwareWalletFunc>(this.api.ada.createHardwareWallet);
 
   /** While ledger wallet creation is taking place, we need to block users from starting a
     * ledger wallet creation on a seperate wallet and explain to them why the action is blocked */
@@ -256,8 +256,9 @@ export default class LedgerConnectStore extends Store implements HWConnectStoreT
       this.createHWRequest.reset();
 
       const reqParams = this._prepareCreateHWReqParams(walletName);
-      const ledgerWallet: CreateHardwareWalletResponse =
-        await this.createHWRequest.execute(reqParams).promise;
+      this.createHWRequest.execute(reqParams);
+      if (!this.createHWRequest.promise) throw new Error('should never happen');
+      const ledgerWallet = await this.createHWRequest.promise;
 
       await this._onSaveSucess(ledgerWallet);
     } catch (error) {

--- a/app/stores/ada/LedgerSendStore.js
+++ b/app/stores/ada/LedgerSendStore.js
@@ -16,9 +16,9 @@ import LocalizableError from '../../i18n/LocalizableError';
 
 import type {
   CreateLedgerSignTxDataRequest,
-  CreateLedgerSignTxDataResponse,
+  CreateLedgerSignTxDataFunc,
+  PrepareAndBroadcastLedgerSignedTxFunc,
 } from '../../api/ada';
-import type { PrepareAndBroadcastLedgerSignedTxResponse } from '../../api/common';
 
 import {
   convertToLocalizableError
@@ -46,11 +46,13 @@ export default class LedgerSendStore extends Store {
   // =================== VIEW RELATED =================== //
 
   // =================== API RELATED =================== //
-  createLedgerSignTxDataRequest: LocalizedRequest<CreateLedgerSignTxDataResponse> =
-    new LocalizedRequest(this.api.ada.createLedgerSignTxData);
+  createLedgerSignTxDataRequest: LocalizedRequest<CreateLedgerSignTxDataFunc>
+    = new LocalizedRequest<CreateLedgerSignTxDataFunc>(this.api.ada.createLedgerSignTxData);
 
-  broadcastLedgerSignedTxRequest: LocalizedRequest<PrepareAndBroadcastLedgerSignedTxResponse> =
-    new LocalizedRequest(this.api.ada.prepareAndBroadcastLedgerSignedTx);
+  broadcastLedgerSignedTxRequest: LocalizedRequest<PrepareAndBroadcastLedgerSignedTxFunc>
+    = new LocalizedRequest<PrepareAndBroadcastLedgerSignedTxFunc>(
+      this.api.ada.prepareAndBroadcastLedgerSignedTx
+    );
   // =================== API RELATED =================== //
 
   setup() {
@@ -115,8 +117,9 @@ export default class LedgerSendStore extends Store {
         // Since this.ledgerBridge is undefinable flow need to know that it's a LedgerBridge
         const ledgerBridge: LedgerBridge = this.ledgerBridge;
 
-        const ledgerSignTxDataResp: CreateLedgerSignTxDataResponse =
-          await this.createLedgerSignTxDataRequest.execute(params).promise;
+        this.createLedgerSignTxDataRequest.execute(params);
+        if (!this.createLedgerSignTxDataRequest.promise) throw new Error('should never happen');
+        const ledgerSignTxDataResp = await this.createLedgerSignTxDataRequest.promise;
 
         await prepareLedgerBridger(ledgerBridge);
 

--- a/app/stores/ada/PaperWalletCreateStore.js
+++ b/app/stores/ada/PaperWalletCreateStore.js
@@ -86,6 +86,7 @@ export default class PaperWalletCreateStore extends Store {
 
   @action _createPaperWallet = async () => {
     if (this.numAddresses && this.userPassword) {
+      // TODO: use Request
       this.paper = this.api.ada.createAdaPaper({
         numAddresses: this.numAddresses,
         password: this.userPassword
@@ -96,6 +97,7 @@ export default class PaperWalletCreateStore extends Store {
   @action _createPdfDocument = async () => {
     let pdf;
     if (this.paper) {
+      // TODO: use Request
       pdf = await this.api.ada.createAdaPaperPdf({
         paper: this.paper,
         network: environment.NETWORK,

--- a/app/stores/ada/PaperWalletCreateStore.js
+++ b/app/stores/ada/PaperWalletCreateStore.js
@@ -86,7 +86,6 @@ export default class PaperWalletCreateStore extends Store {
 
   @action _createPaperWallet = async () => {
     if (this.numAddresses && this.userPassword) {
-      // TODO: use Request
       this.paper = this.api.ada.createAdaPaper({
         numAddresses: this.numAddresses,
         password: this.userPassword
@@ -97,7 +96,6 @@ export default class PaperWalletCreateStore extends Store {
   @action _createPdfDocument = async () => {
     let pdf;
     if (this.paper) {
-      // TODO: use Request
       pdf = await this.api.ada.createAdaPaperPdf({
         paper: this.paper,
         network: environment.NETWORK,

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -34,8 +34,8 @@ import {
 
 import type {
   CreateHardwareWalletRequest,
-  CreateHardwareWalletResponse,
-} from '../../api/common';
+  CreateHardwareWalletFunc,
+} from '../../api/ada';
 
 /** TODO: TrezorConnectStore and LedgerConnectStore has many common methods
   * try to make a common base class */
@@ -72,8 +72,8 @@ export default class TrezorConnectStore extends Store implements HWConnectStoreT
   // =================== VIEW RELATED =================== //
 
   // =================== API RELATED =================== //
-  createHWRequest: LocalizedRequest<CreateHardwareWalletResponse> =
-    new LocalizedRequest(this.api.ada.createHardwareWallet);
+  createHWRequest: LocalizedRequest<CreateHardwareWalletFunc>
+    = new LocalizedRequest<CreateHardwareWalletFunc>(this.api.ada.createHardwareWallet);
 
   /** While trezor wallet creation is taking place, we need to block users from starting a
     * trezor wallet creation on a seperate wallet and explain to them why the action is blocked */
@@ -339,8 +339,10 @@ export default class TrezorConnectStore extends Store implements HWConnectStoreT
       this.createHWRequest.reset();
 
       const reqParams = this._prepareCreateHWReqParams(walletName);
-      const trezorWallet: Wallet =
-        await this.createHWRequest.execute(reqParams).promise;
+      this.createHWRequest.execute(reqParams);
+      if (!this.createHWRequest.promise) throw new Error('should never happen');
+
+      const trezorWallet = await this.createHWRequest.promise;
 
       await this._onSaveSucess(trezorWallet);
     } catch (error) {

--- a/app/stores/ada/TrezorSendStore.js
+++ b/app/stores/ada/TrezorSendStore.js
@@ -8,10 +8,9 @@ import LocalizedRequest from '../lib/LocalizedRequest';
 
 import type {
   CreateTrezorSignTxDataRequest,
-  CreateTrezorSignTxDataResponse,
-  BroadcastTrezorSignedTxRequest,
+  CreateTrezorSignTxDataFunc,
+  BroadcastTrezorSignedTxFunc
 } from '../../api/ada';
-import type { BroadcastTrezorSignedTxResponse } from '../../api/common';
 
 import {
   Logger,
@@ -30,11 +29,11 @@ export default class TrezorSendStore extends Store {
   // =================== VIEW RELATED =================== //
 
   // =================== API RELATED =================== //
-  createTrezorSignTxDataRequest: LocalizedRequest<CreateTrezorSignTxDataResponse> =
-    new LocalizedRequest(this.api.ada.createTrezorSignTxData);
+  createTrezorSignTxDataRequest: LocalizedRequest<CreateTrezorSignTxDataFunc>
+    = new LocalizedRequest<CreateTrezorSignTxDataFunc>(this.api.ada.createTrezorSignTxData);
 
-  broadcastTrezorSignedTxRequest: LocalizedRequest<BroadcastTrezorSignedTxResponse> =
-    new LocalizedRequest(this.api.ada.broadcastTrezorSignedTx);
+  broadcastTrezorSignedTxRequest: LocalizedRequest<BroadcastTrezorSignedTxFunc>
+    = new LocalizedRequest<BroadcastTrezorSignedTxFunc>(this.api.ada.broadcastTrezorSignedTx);
   // =================== API RELATED =================== //
 
   setup() {
@@ -75,13 +74,16 @@ export default class TrezorSendStore extends Store {
         throw new Error('Active account required before sending.');
       }
 
-      const trezorSignTxDataResp =
-        await this.createTrezorSignTxDataRequest.execute(params).promise;
+      this.createTrezorSignTxDataRequest.execute(params);
+      if (!this.createTrezorSignTxDataRequest.promise) throw new Error('should never happen');
+
+      const trezorSignTxDataResp = await this.createTrezorSignTxDataRequest.promise;
 
       // TODO: [TREZOR] fix type if possible
-      const trezorSignTxResp = await TrezorConnect.cardanoSignTransaction({
-        ...trezorSignTxDataResp.trezorSignTxPayload
-      });
+      const trezorSignTxResp = await await TrezorConnect.cardanoSignTransaction(
+        // $FlowFixMe Trezor types in Yoroi are all wrong for no good reason. TODO: fix this
+        { ...trezorSignTxDataResp.trezorSignTxPayload }
+      );
 
       if (trezorSignTxResp && trezorSignTxResp.payload && trezorSignTxResp.payload.error) {
         // this Error will be converted to LocalizableError()
@@ -101,15 +103,11 @@ export default class TrezorSendStore extends Store {
   };
 
   _brodcastSignedTx = async (
-    trezorSignTxResp: any,
+    trezorSignTxResp,
   ): Promise<void> => {
-    // TODO: [TREZOR] fix type if possible
-    const payload: any = trezorSignTxResp.payload;
-    const reqParams: BroadcastTrezorSignedTxRequest = {
-      signedTxHex: payload.body,
-    };
-
-    await this.broadcastTrezorSignedTxRequest.execute(reqParams).promise;
+    await this.broadcastTrezorSignedTxRequest.execute({
+      signedTxHex: trezorSignTxResp.payload.body,
+    }).promise;
 
     this.actions.dialogs.closeActiveDialog.trigger();
     const { wallets } = this.stores.substores[environment.API];

--- a/app/stores/base/AddressesStore.js
+++ b/app/stores/base/AddressesStore.js
@@ -6,7 +6,7 @@ import CachedRequest from '../lib/LocalizedCachedRequest';
 import Request from '../lib/LocalizedRequest';
 import WalletAddress from '../../domain/WalletAddress';
 import LocalizableError, { localizedError } from '../../i18n/LocalizableError';
-import type { GetAddressesResponse } from '../../api/common';
+import type { GetAddressesFunc, CreateAddressFunc } from '../../api/ada';
 import environment from '../../environment';
 
 export default class AddressesStore extends Store {
@@ -14,12 +14,12 @@ export default class AddressesStore extends Store {
   /** Track addresses for a set of wallets */
   @observable addressesRequests: Array<{
     walletId: string,
-    allRequest: CachedRequest<GetAddressesResponse>
+    allRequest: CachedRequest<GetAddressesFunc>
   }> = [];
   @observable error: ?LocalizableError = null;
 
   // REQUESTS
-  @observable createAddressRequest: Request<WalletAddress>;
+  @observable createAddressRequest: Request<CreateAddressFunc>;
 
   setup() {
     const actions = this.actions[environment.API].addresses;
@@ -29,7 +29,7 @@ export default class AddressesStore extends Store {
 
   _createAddress = async () => {
     try {
-      const address: ?WalletAddress = await this.createAddressRequest.execute().promise;
+      const address: ?WalletAddress = await await this.createAddressRequest.execute({}).promise;
       if (address != null) {
         this._refreshAddresses();
         runInAction('reset error', () => { this.error = null; });
@@ -98,9 +98,9 @@ export default class AddressesStore extends Store {
     return result ? result.accountId : null;
   };
 
-  _getAddressesAllRequest = (walletId: string): CachedRequest<GetAddressesResponse> => {
+  _getAddressesAllRequest = (walletId: string): CachedRequest<GetAddressesFunc> => {
     const foundRequest = _.find(this.addressesRequests, { walletId });
     if (foundRequest && foundRequest.allRequest) return foundRequest.allRequest;
-    return new CachedRequest(this.api[environment.API].getExternalAddresses);
+    return new CachedRequest<GetAddressesFunc>(this.api[environment.API].getExternalAddresses);
   };
 }

--- a/app/stores/base/AddressesStore.js
+++ b/app/stores/base/AddressesStore.js
@@ -29,7 +29,7 @@ export default class AddressesStore extends Store {
 
   _createAddress = async () => {
     try {
-      const address: ?WalletAddress = await await this.createAddressRequest.execute({}).promise;
+      const address: ?WalletAddress = await this.createAddressRequest.execute({}).promise;
       if (address != null) {
         this._refreshAddresses();
         runInAction('reset error', () => { this.error = null; });

--- a/app/stores/base/TransactionsStore.js
+++ b/app/stores/base/TransactionsStore.js
@@ -5,8 +5,9 @@ import BigNumber from 'bignumber.js';
 import Store from './Store';
 import CachedRequest from '../lib/LocalizedCachedRequest';
 import WalletTransaction from '../../domain/WalletTransaction';
-import type { GetTransactionsResponse, GetBalanceResponse,
-  GetTransactionsRequest, GetTransactionsRequesOptions } from '../../api/common';
+import type { GetTransactionsFunc, GetBalanceFunc,
+  GetTransactionsRequest, GetTransactionsRequestOptions,
+  RefreshPendingTransactionsFunc } from '../../api/ada';
 import environment from '../../environment';
 
 export default class TransactionsStore extends Store {
@@ -23,10 +24,10 @@ export default class TransactionsStore extends Store {
   /** Track transactions for a set of wallets */
   @observable transactionsRequests: Array<{
     walletId: string,
-    pendingRequest: CachedRequest<GetTransactionsResponse>,
-    recentRequest: CachedRequest<GetTransactionsResponse>,
-    allRequest: CachedRequest<GetTransactionsResponse>,
-    getBalanceRequest: CachedRequest<GetBalanceResponse>
+    pendingRequest: CachedRequest<RefreshPendingTransactionsFunc>,
+    recentRequest: CachedRequest<GetTransactionsFunc>,
+    allRequest: CachedRequest<GetTransactionsFunc>,
+    getBalanceRequest: CachedRequest<GetBalanceFunc>
   }> = [];
 
   @observable _searchOptionsForWallets = {};
@@ -45,15 +46,19 @@ export default class TransactionsStore extends Store {
     }
   };
 
-  @computed get recentTransactionsRequest(): CachedRequest<GetTransactionsResponse> {
+  @computed get recentTransactionsRequest(): CachedRequest<GetTransactionsFunc> {
     const wallet = this.stores.substores[environment.API].wallets.active;
     // TODO: Do not return new request here
-    if (!wallet) return new CachedRequest(this.api[environment.API].refreshTransactions);
+    if (!wallet) {
+      return new CachedRequest<GetTransactionsFunc>(
+        this.api[environment.API].refreshTransactions
+      );
+    }
     return this._getTransactionsRecentRequest(wallet.id);
   }
 
   /** Get (or create) the search options for the active wallet (if any)  */
-  @computed get searchOptions(): ?GetTransactionsRequesOptions {
+  @computed get searchOptions(): ?GetTransactionsRequestOptions {
     const wallet = this.stores.substores[environment.API].wallets.active;
     if (!wallet) return null;
     let options = this._searchOptionsForWallets[wallet.id];
@@ -127,12 +132,16 @@ export default class TransactionsStore extends Store {
       allRequest.invalidate({ immediately: false });
       allRequest.execute({ walletId: wallet.id });
 
+      if (!allRequest.promise) throw new Error('should never happen');
+
       allRequest.promise
         .then(async () => {
           // calculate pending tranactions just to cache the result
           const pendingRequest = this._getTransactionsPendingRequest(wallet.id);
           pendingRequest.invalidate({ immediately: false });
-          pendingRequest.execute({ walletId: wallet.id });
+          pendingRequest.execute(
+            { walletId: wallet.id } // add walletId just for cache
+          );
 
           const lastUpdateDate = await this.api[environment.API].getTxLastUpdatedDate();
           // Note: cache based on lastUpdateDate even though it's not used in balanceRequest
@@ -162,32 +171,36 @@ export default class TransactionsStore extends Store {
     this._refreshTransactionData();
   }
 
-  _getTransactionsPendingRequest = (walletId: string): CachedRequest<GetTransactionsResponse> => {
+  _getTransactionsPendingRequest = (
+    walletId: string
+  ): CachedRequest<RefreshPendingTransactionsFunc> => {
     const foundRequest = _.find(this.transactionsRequests, { walletId });
     if (foundRequest && foundRequest.pendingRequest) return foundRequest.pendingRequest;
-    return new CachedRequest(this.api[environment.API].refreshPendingTransactions);
+    return new CachedRequest<RefreshPendingTransactionsFunc>(
+      this.api[environment.API].refreshPendingTransactions
+    );
   };
 
   /** Get request for fetching transaction data.
    * Should ONLY be executed to cache query WITH search options */
-  _getTransactionsRecentRequest = (walletId: string): CachedRequest<GetTransactionsResponse> => {
+  _getTransactionsRecentRequest = (walletId: string): CachedRequest<GetTransactionsFunc> => {
     const foundRequest = _.find(this.transactionsRequests, { walletId });
     if (foundRequest && foundRequest.recentRequest) return foundRequest.recentRequest;
-    return new CachedRequest(this.api[environment.API].refreshTransactions);
+    return new CachedRequest<GetTransactionsFunc>(this.api[environment.API].refreshTransactions);
   };
 
   /** Get request for fetching transaction data.
    * Should ONLY be executed to cache query WITHOUT search options */
-  _getTransactionsAllRequest = (walletId: string): CachedRequest<GetTransactionsResponse> => {
+  _getTransactionsAllRequest = (walletId: string): CachedRequest<GetTransactionsFunc> => {
     const foundRequest = _.find(this.transactionsRequests, { walletId });
     if (foundRequest && foundRequest.allRequest) return foundRequest.allRequest;
-    return new CachedRequest(this.api[environment.API].refreshTransactions);
+    return new CachedRequest<GetTransactionsFunc>(this.api[environment.API].refreshTransactions);
   };
 
-  _getBalanceRequest = (walletId: string): CachedRequest<GetBalanceResponse> => {
+  _getBalanceRequest = (walletId: string): CachedRequest<GetBalanceFunc> => {
     const foundRequest = _.find(this.transactionsRequests, { walletId });
     if (foundRequest && foundRequest.getBalanceRequest) return foundRequest.getBalanceRequest;
-    return new CachedRequest(this.api[environment.API].getBalance);
+    return new CachedRequest<GetBalanceFunc>(this.api[environment.API].getBalance);
   };
 
 }

--- a/app/stores/lib/LocalizedCachedRequest.js
+++ b/app/stores/lib/LocalizedCachedRequest.js
@@ -1,3 +1,5 @@
+// @flow
+
 import CachedRequest from './CachedRequest';
 import LocalizableError from '../../i18n/LocalizableError';
 
@@ -5,5 +7,6 @@ import LocalizableError from '../../i18n/LocalizableError';
 * We want all errors in our program to be localizable
 * So we partially apply the LocalizableError to the CachedRequest template
 */
-export default
-class LocalizedCachedRequest<Result> extends CachedRequest<Result, LocalizableError> {}
+export default class LocalizedCachedRequest<
+  Func: (...args: any) => Promise<any>
+> extends CachedRequest<Func, LocalizableError> {}

--- a/app/stores/lib/LocalizedRequest.js
+++ b/app/stores/lib/LocalizedRequest.js
@@ -1,3 +1,5 @@
+// @flow
+
 import Request from './Request';
 import LocalizableError from '../../i18n/LocalizableError';
 
@@ -5,4 +7,6 @@ import LocalizableError from '../../i18n/LocalizableError';
 * We want all errors in our program to be localizable
 * So we partially apply the LocalizableError to the Request template
 */
-export default class LocalizedRequest<Result> extends Request<Result, LocalizableError> {}
+export default class LocalizedRequest<
+  Func: (...args: any) => Promise<any>
+> extends Request<Func, LocalizableError> {}

--- a/app/stores/lib/Request.js
+++ b/app/stores/lib/Request.js
@@ -15,31 +15,31 @@ const messages = defineMessages({
   }
 });
 
-export type ApiCallType = {
-  args: Array<any>,
-  result: any,
+export type ApiCallType<Func: Function> = {
+  args: Arguments<Func>,
+  result: ?PromisslessReturnType<Func>,
 };
 
 // Note: Do not use this class directly. Only use LocalizedRequest or CachedLocalizedRequest
-export default class Request<Result, Err> {
+export default class Request<Func: (...args: any) => Promise<any>, Err> {
 
-  @observable result: ?Result = null;
+  @observable result: ?PromisslessReturnType<Func> = null;
   @observable error: ?Err = null;
   @observable isExecuting: boolean = false;
   @observable isError: boolean = false;
   @observable wasExecuted: boolean = false;
 
-  promise: ?Promise<Result> = null;
+  promise: ?Promise<PromisslessReturnType<Func>> = null;
 
-  _method: Function;
+  _method: Func;
   _isWaitingForResponse: boolean = false;
-  _currentApiCall: ?ApiCallType = null;
+  _currentApiCall: ?ApiCallType<Func> = null;
 
-  constructor(method: Function) {
+  constructor(method: Func) {
     this._method = method;
   }
 
-  execute(...callArgs: Array<any>): Request<Result, Err> {
+  execute(...callArgs: Arguments<Func>): Request<Func, Err> {
     // Do not continue if this request is already loading
     if (this._isWaitingForResponse) return this;
 
@@ -58,7 +58,6 @@ export default class Request<Result, Err> {
         .then((result) => {
           setTimeout(action('Request::execute/then', () => {
             if (this.result != null && isObservableArray(this.result) && Array.isArray(result)) {
-              // $FlowFixMe
               this.result.replace(result);
             } else {
               this.result = result;
@@ -88,7 +87,7 @@ export default class Request<Result, Err> {
     return this;
   }
 
-  isExecutingWithArgs(...args: Array<any>): boolean {
+  isExecutingWithArgs(...args: Arguments<Func>): boolean {
     return (
       this.isExecuting &&
       (this._currentApiCall != null)
@@ -100,14 +99,14 @@ export default class Request<Result, Err> {
     return !this.wasExecuted && this.isExecuting;
   }
 
-  then(...args: Array<any>): Promise<Result> {
+  then<Cont: Function>(continuation: Cont): Promise<PromisslessReturnType<Cont>> {
     if (!this.promise) throw new NotExecutedYetError();
-    return this.promise.then(...args);
+    return this.promise.then(continuation);
   }
 
-  catch(...args: Array<any>): Promise<any> {
+  catch<Cont: Function>(continuation: Cont): Promise<PromisslessReturnType<Cont>>  {
     if (!this.promise) throw new NotExecutedYetError();
-    return this.promise.catch(...args);
+    return this.promise.catch(continuation);
   }
 
   /**
@@ -121,7 +120,9 @@ export default class Request<Result, Err> {
    *
    * @returns {Promise}
    */
-  patch(modify: Function): Promise<Request<Result, Err>> {
+  patch(
+    modify: PromisslessReturnType<Func> => ?PromisslessReturnType<Func>
+  ): Promise<Request<Func, Err>> {
     return new Promise((resolve) => {
       setTimeout(action(() => {
         const override = modify(this.result);
@@ -132,7 +133,7 @@ export default class Request<Result, Err> {
     });
   }
 
-  @action reset(): Request<Result, Err> {
+  @action reset(): Request<Func, Err> {
     this.result = null;
     this.error = null;
     this.isError = false;

--- a/app/stores/lib/Request.js
+++ b/app/stores/lib/Request.js
@@ -99,14 +99,14 @@ export default class Request<Func: (...args: any) => Promise<any>, Err> {
     return !this.wasExecuted && this.isExecuting;
   }
 
-  then<Cont: Function>(continuation: Cont): Promise<PromisslessReturnType<Cont>> {
+  // Turn Requests into promise-like objects by adding "then" and "catch"
+  then(...args: Array<any>): Promise<PromisslessReturnType<Func>> {
     if (!this.promise) throw new NotExecutedYetError();
-    return this.promise.then(continuation);
+    return this.promise.then(...args);
   }
-
-  catch<Cont: Function>(continuation: Cont): Promise<PromisslessReturnType<Cont>>  {
+  catch(...args: Array<any>): Promise<any> {
     if (!this.promise) throw new NotExecutedYetError();
-    return this.promise.catch(continuation);
+    return this.promise.catch(...args);
   }
 
   /**

--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -21,11 +21,15 @@ export default class LoadingStore extends Store {
   @observable error: ?LocalizableError = null;
   @observable _loading: boolean = true;
 
-  @observable loadRustRequest: Request<void> = new Request(RustModule.load.bind(RustModule));
-  @observable migrationRequest: Request<MigrationRequest> = new Request(migrate);
+  @observable loadRustRequest: Request<void => Promise<void>>
+    = new Request<void => Promise<void>>(RustModule.load.bind(RustModule));
+
+  @observable migrationRequest: Request<MigrationRequest => Promise<void>>
+    = new Request<MigrationRequest => Promise<void>>(migrate);
 
   // TODO: Should not make currency-specific requests in a toplevel store
-  @observable loadDbRequest: Request<void> = new Request(this.api.ada.loadDB);
+  @observable loadDbRequest: Request<void => Promise<void>>
+    = new Request<void => Promise<void>>(this.api.ada.loadDB);
 
   setup() {
   }

--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -101,6 +101,9 @@ export default class ProfileStore extends Store {
   static getDefaultLocale() {
     return 'en-US';
   }
+  static getDefaultTheme(): Theme {
+    return THEMES.YOROI_CLASSIC;
+  }
 
   // ========== Locale ========== //
 
@@ -150,7 +153,13 @@ export default class ProfileStore extends Store {
 
   @computed get currentTheme(): Theme {
     const { result } = this.getThemeRequest.execute();
-    if (this.isCurrentThemeSet && result) return result;
+    if (this.isCurrentThemeSet && result) {
+      // verify content is an actual theme
+      if (Object.values(THEMES).find(theme => theme === result)) {
+        // $FlowFixMe: can safely cast
+        return result;
+      }
+    }
     // TODO: We temporarily disable the new theme on mainnet until it's ready
     // TODO: Tests were written for the old theme so we need to use it for testing
     return (environment.isMainnet() || environment.isTest()) ?
@@ -213,7 +222,7 @@ export default class ProfileStore extends Store {
 
   getThemeVars = ({ theme }: { theme: string }) => {
     if (theme) return require(`../../themes/prebuilt/${theme}.js`);
-    return require(`../../themes/prebuilt/${THEMES.YOROI_CLASSIC}.js`); // default
+    return require(`../../themes/prebuilt/${ProfileStore.getDefaultTheme()}.js`); // default
   };
 
   hasCustomTheme = (): boolean => {

--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -39,17 +39,39 @@ export default class ProfileStore extends Store {
   };
 
   /* eslint-disable max-len */
-  @observable getProfileLocaleRequest: Request<string> = new Request(this.api.localStorage.getUserLocale);
-  @observable setProfileLocaleRequest: Request<void> = new Request(this.api.localStorage.setUserLocale);
-  @observable getThemeRequest: Request<string> = new Request(this.api.localStorage.getUserTheme);
-  @observable setThemeRequest: Request<void> = new Request(this.api.localStorage.setUserTheme);
-  @observable getCustomThemeRequest: Request<string> = new Request(this.api.localStorage.getCustomUserTheme);
-  @observable setCustomThemeRequest: Request<void> = new Request(this.api.localStorage.setCustomUserTheme);
-  @observable unsetCustomThemeRequest: Request<void> = new Request(this.api.localStorage.unsetCustomUserTheme);
-  @observable getTermsOfUseAcceptanceRequest: Request<string> = new Request(this.api.localStorage.getTermsOfUseAcceptance);
-  @observable setTermsOfUseAcceptanceRequest: Request<void> = new Request(this.api.localStorage.setTermsOfUseAcceptance);
-  @observable getLastLaunchVersionRequest: Request<string> = new Request(this.api.localStorage.getLastLaunchVersion);
-  @observable setLastLaunchVersionRequest: Request<void> = new Request(this.api.localStorage.setLastLaunchVersion);
+  @observable getProfileLocaleRequest: Request<void => Promise<string>>
+    = new Request<void => Promise<string>>(this.api.localStorage.getUserLocale);
+
+  @observable setProfileLocaleRequest: Request<string => Promise<void>>
+    = new Request<string => Promise<void>>(this.api.localStorage.setUserLocale);
+
+  @observable getThemeRequest: Request<void => Promise<string>>
+    = new Request<void => Promise<string>>(this.api.localStorage.getUserTheme);
+
+  @observable setThemeRequest: Request<string => Promise<void>>
+    = new Request<string => Promise<void>>(this.api.localStorage.setUserTheme);
+
+  @observable getCustomThemeRequest: Request<void => Promise<string>>
+    = new Request<void => Promise<string>>(this.api.localStorage.getCustomUserTheme);
+
+  @observable setCustomThemeRequest: Request<(string, Object) => Promise<void>>
+    = new Request<(string, Object) => Promise<void>>(this.api.localStorage.setCustomUserTheme);
+
+  @observable unsetCustomThemeRequest: Request<void => Promise<void>>
+    = new Request<void => Promise<void>>(this.api.localStorage.unsetCustomUserTheme);
+
+  @observable getTermsOfUseAcceptanceRequest: Request<void => Promise<boolean>>
+  = new Request<void => Promise<boolean>>(this.api.localStorage.getTermsOfUseAcceptance);
+
+  @observable setTermsOfUseAcceptanceRequest: Request<void => Promise<void>>
+    = new Request<void => Promise<void>>(this.api.localStorage.setTermsOfUseAcceptance);
+
+  @observable getLastLaunchVersionRequest: Request<void => Promise<string>>
+    = new Request<void => Promise<string>>(this.api.localStorage.getLastLaunchVersion);
+
+  @observable setLastLaunchVersionRequest: Request<string => Promise<void>>
+    = new Request<string => Promise<void>>(this.api.localStorage.setLastLaunchVersion);
+
   /* eslint-enable max-len */
 
   setup() {
@@ -84,7 +106,7 @@ export default class ProfileStore extends Store {
 
   @computed get currentLocale(): string {
     const { result } = this.getProfileLocaleRequest.execute();
-    if (this.isCurrentLocaleSet) return result;
+    if (this.isCurrentLocaleSet && result) return result;
     return ProfileStore.getDefaultLocale();
   }
 
@@ -128,7 +150,7 @@ export default class ProfileStore extends Store {
 
   @computed get currentTheme(): Theme {
     const { result } = this.getThemeRequest.execute();
-    if (this.isCurrentThemeSet) return result;
+    if (this.isCurrentThemeSet && result) return result;
     // TODO: We temporarily disable the new theme on mainnet until it's ready
     // TODO: Tests were written for the old theme so we need to use it for testing
     return (environment.isMainnet() || environment.isTest()) ?
@@ -145,11 +167,11 @@ export default class ProfileStore extends Store {
   }
 
   /* @Returns Merged Pre-Built Theme and Custom Theme */
-  @computed get currentThemeVars(): string {
+  @computed get currentThemeVars() {
     const { result } = this.getCustomThemeRequest.execute();
     const currentThemeVars = this.getThemeVars({ theme: this.currentTheme });
     let customThemeVars = {};
-    if (result !== '') customThemeVars = JSON.parse(result);
+    if (result && result !== '') customThemeVars = JSON.parse(result);
     // Merge Custom Theme and Current Theme
     return { ...currentThemeVars, ...customThemeVars };
   }
@@ -239,7 +261,7 @@ export default class ProfileStore extends Store {
 
   @computed get lastLaunchVersion(): string {
     const { result } = this.getLastLaunchVersionRequest.execute();
-    return result;
+    return result || '0.0.0';
   }
 
   setLastLaunchVersion = async (version: string) => {

--- a/app/types/HWConnectStoreTypes.js
+++ b/app/types/HWConnectStoreTypes.js
@@ -6,7 +6,7 @@ import LocalizedRequest from '../stores/lib/LocalizedRequest';
 
 import LocalizableError from '../i18n/LocalizableError';
 
-import type { CreateHardwareWalletRequest } from '../api/common';
+import type { CreateHardwareWalletRequest, CreateHardwareWalletFunc } from '../api/ada';
 
 export type ProgressStepEnum = 0 | 1 | 2;
 export const ProgressStep = {
@@ -65,7 +65,7 @@ export interface HWConnectStoreTypes {
   // =================== VIEW RELATED =================== //
 
   // =================== API RELATED =================== //
-  createHWRequest: LocalizedRequest<CreateHardwareWalletRequest>;
+  createHWRequest: LocalizedRequest<CreateHardwareWalletFunc>;
 
   /** While hardware wallet creation is taking place, we need to block users from starting a
     * hardware wallet creation on a seperate wallet and explain to them why the action is blocked */

--- a/features/ada-redemption.feature
+++ b/features/ada-redemption.feature
@@ -23,11 +23,13 @@ Feature: Ada Redemption
     Then I should see the "Ada Redemption Success Overlay" and close the dialogue
     And I should see the summary screen
 
+  @it-78
   Scenario: User tries to redeem manually entered "Regular" invalid redemption key
     Given I have accepted "Daedalus Redemption Disclaimer"
     And I enter an invalid "Regular" redemption key
     Then I should see invalid redemption key message
 
+  @it-79
   Scenario: User tries to redeem manually entered "Regular" already used redemption key
     Given I have accepted "Daedalus Redemption Disclaimer"
     And I enter an already used "Regular" redemption key

--- a/features/main-ui.feature
+++ b/features/main-ui.feature
@@ -4,6 +4,7 @@ Feature: Main UI
     Given I have opened the extension
     And I have completed the basic setup
 
+  @it-81
   Scenario: Get balance with 45 addresses
     Given I am testing "Main UI"
     And There is a wallet stored named complex-wallet

--- a/features/support/webdriver.js
+++ b/features/support/webdriver.js
@@ -230,13 +230,16 @@ function CustomWorld(cmdInput: WorldInput) {
 
   this.saveAddressesToDB = (addresses, type) => (
     this.driver.executeScript((addrs, addrType) => {
-      addrs.forEach(addr => window.yoroi.api.ada.saveAddress(addr, addrType));
+      addrs.forEach(addr => window.yoroi.api.ada.saveAddress({
+        address: addr,
+        addressType: addrType
+      }));
     }, addresses, type)
   );
 
   this.saveTxsToDB = transactions => {
     this.driver.executeScript(txs => {
-      window.yoroi.api.ada.saveTxs(txs);
+      window.yoroi.api.ada.saveTxs({ txs });
     }, transactions);
   };
 

--- a/flow/declarations/utils.js
+++ b/flow/declarations/utils.js
@@ -1,0 +1,15 @@
+
+declare type ExtractReturnType = <R>((...arg: any) => R) => R;
+declare type ReturnType<Func> = $Call<ExtractReturnType, Func>;
+
+declare type ExtractPromisslessReturnType = <R>((...arg: any) => Promise<R>) => R;
+declare type PromisslessReturnType<Func> = $Call<ExtractPromisslessReturnType, Func>;
+
+/* eslint-disable no-redeclare */
+declare function arguments<A>(() => any): []
+declare function arguments<A>((A) => any): [A]
+declare function arguments<A, B>((A, B) => any): [A, B]
+declare function arguments<A, B, C>((A, B, C) => any): [A, B, C]
+declare function arguments<A, B, C, D>((A, B, C, D) => any): [A, B, C, D]
+declare function arguments<A, B, C, D, E>((A, B, C, D, E) => any): [A, B, C, D, E]
+declare type Arguments<T: Function> = $Call<typeof arguments, T>;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-compress-crx:staging": "npm run build -- --env 'staging' && npm run compress -- --env 'staging' --app-id 'yoroi-stag' --codebase 'https://yoroiwallet.com/dw/yoroi-staging-extension.crx' --key ./staging-key.pem",
     "compress-keygen": "crx keygen",
     "clean": "rimraf build/ dev/ *.zip *.crx",
-    "flow": "flow .",
+    "flow": "flow --show-all-errors .",
     "eslint": "eslint app features chrome scripts webpack/*.js",
     "test-unit": "jest",
     "test-prepare": "npm run clean && npm run build -- --env 'test' && npm run compress-e2e-tests",


### PR DESCRIPTION
This is the workflow for Yoroi

UI -> Actions -> Stores -> API

People may not remember, but actually we have no types for any of the 3 arrows above connecting the 4 components (this is historically because Daedalus has no types at all and I did some work to add types but I didn't cover the whole codebase)

Since we will do a lot of refactoring of the API structure, I want types to avoid accidentally breaking everything. Unfortunately, since Flow is really bad at generics among other things, this whole thing is kind of a mess.