### PR TITLE
Fix Shin/ch962/fix yoroiclassic theme regression bugs

### DIFF
--- a/app/components/mixins/HeaderBlock.scss
+++ b/app/components/mixins/HeaderBlock.scss
@@ -4,7 +4,6 @@
   color: var(--theme-instructions-recovery-text-color);
   margin-bottom: 10px;
   letter-spacing: 0;
-  text-align: center;
 }
 .headerBlock {
   @include headerBlockBase;

--- a/app/components/wallet/hwConnect/common/HelpLinkBlock.scss
+++ b/app/components/wallet/hwConnect/common/HelpLinkBlock.scss
@@ -1,7 +1,5 @@
-.linkBlockClassic {
+.component {
   margin-top: 16px;
-  width: 725px;
-  height: 18px;
   text-align: center;
   font-family: var(--font-regular);
   font-size: 15px;
@@ -11,10 +9,13 @@
   }  
 }
 
-.linkBlock {
+:global(.YoroiClassic) .component {
+  width: 725px;
+  height: 18px;
+}
+
+:global(.YoroiModern) .component {
   margin-top: 24px;
-  text-align: center;
-  font-family: var(--font-regular);
   font-size: 14px;
   letter-spacing: 0;
 

--- a/app/components/wallet/hwConnect/ledger/HelpLinkBlock.js
+++ b/app/components/wallet/hwConnect/ledger/HelpLinkBlock.js
@@ -34,7 +34,7 @@ export default class HelpLinkBlock extends Component<Props> {
     const { intl } = this.context;
 
     return (
-      <div className={styles.linkBlock}>
+      <div className={styles.component}>
         <a target="_blank" rel="noopener noreferrer" href={intl.formatMessage(messages.helpLinkYoroiWithLedger)}>
           {intl.formatMessage(messages.helpLinkYoroiWithLedgerText)}
           <SvgInline svg={externalLinkSVG} />

--- a/app/components/wallet/hwConnect/trezor/HelpLinkBlock.js
+++ b/app/components/wallet/hwConnect/trezor/HelpLinkBlock.js
@@ -34,7 +34,7 @@ export default class HelpLinkBlock extends Component<Props> {
     const { intl } = this.context;
 
     return (
-      <div className={styles.linkBlock}>
+      <div className={styles.component}>
         <a target="_blank" rel="noopener noreferrer" href={intl.formatMessage(messages.helpLinkYoroiWithTrezor)}>
           {intl.formatMessage(messages.helpLinkYoroiWithTrezorText)}
           <SvgInline svg={externalLinkSVG} />

--- a/app/components/wallet/settings/paper-wallets/CreatePaperDialog.js
+++ b/app/components/wallet/settings/paper-wallets/CreatePaperDialog.js
@@ -127,6 +127,10 @@ export default class CreatePaperDialog extends Component<Props> {
     const dialogClasses = classnames(['createPaperDialog', styles.dialog]);
     const confirmButtonClasses = classnames(['confirmButton']);
     const buttonClassNames = classnames(['primary', styles.button]);
+    const downloadPaperIntroLine1ClassNames = classnames([
+      classicTheme ? headerMixin.headerBlockClassic : headerMixin.headerBlock,
+      styles.downloadPaperIntroLine1,
+    ]);
 
     const actions = [
       {
@@ -150,7 +154,7 @@ export default class CreatePaperDialog extends Component<Props> {
           closeButton={<DialogCloseButton onClose={onCancel} />}
           classicTheme={classicTheme}
         >
-          <div className={classicTheme ? headerMixin.headerBlockClassic : headerMixin.headerBlock}>
+          <div className={downloadPaperIntroLine1ClassNames}>
             <span>{intl.formatMessage(messages.downloadPaperIntroLine1)}</span>
           </div>
           <center>

--- a/app/components/wallet/settings/paper-wallets/CreatePaperDialog.scss
+++ b/app/components/wallet/settings/paper-wallets/CreatePaperDialog.scss
@@ -37,3 +37,7 @@
   font-family: var(--font-light);
   color: black;
 }
+
+.downloadPaperIntroLine1 {
+  text-align: center;
+}


### PR DESCRIPTION
Details: https://app.clubhouse.io/emurgo/story/962/fix-yoroiclassic-theme-regression-bugs

- [X] Revert text alignment to center on 6 Trezor/Ledger dialogs, 2 Paper wallet  dialogs
- [X] Revert HelpLinkBlock styling for Classic Theme and Apply Theme selection