### PR TITLE
Disable confirm button if boxes are unchecked

### DIFF
--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
@@ -116,6 +116,7 @@ export default class WalletRecoveryPhraseEntryDialog extends Component<Props> {
         className: isSubmitting ? styles.isSubmitting : null,
         label: intl.formatMessage(messages.buttonLabelConfirm),
         onClick: onFinishBackup,
+        disabled: !isTermDeviceAccepted || !isTermRecoveryAccepted,
         primary: true
       });
     }


### PR DESCRIPTION
Keep confirm button disabled if boxes about understanding the security implications of key storage and mnemonic phrase are unchecked.