### PR TITLE
Wallet creation fix

### DIFF
--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
@@ -123,8 +123,9 @@ export default class WalletRecoveryPhraseEntryDialog extends Component<Props> {
     const phraseOld = enteredPhraseString;
     const phrase = enteredPhrase.length ? (
       <div className={styles.phraseWrapper}>
-        {enteredPhrase.map((item) => (
-          <div key={item.word} className={styles.phraseWord}>{item.word}</div>
+        {enteredPhrase.map((item, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={item.word + i} className={styles.phraseWord}>{item.word}</div>
         ))}
       </div>
     ) : (
@@ -161,7 +162,7 @@ export default class WalletRecoveryPhraseEntryDialog extends Component<Props> {
           <div className={wordsClasses}>
             {recoveryPhraseSorted.map(({ word, isActive }, index) => (
               <MnemonicWord
-                key={index} // eslint-disable-line react/no-array-index-key
+                key={word + index} // eslint-disable-line react/no-array-index-key
                 word={word}
                 index={index}
                 isActive={isActive}

--- a/app/stores/base/WalletStore.js
+++ b/app/stores/base/WalletStore.js
@@ -79,8 +79,7 @@ export default class WalletsStore extends Store {
     this._newWalletDetails.mnemonic = this.stores.walletBackup.recoveryPhrase.join(' ');
     const wallet = await this.createWalletRequest.execute(this._newWalletDetails).promise;
     if (wallet) {
-      // TODO: add this back once we support multiple wallets
-      // await this.walletsRequest.patch(result => { result.push(wallet); });
+      await this.walletsRequest.patch(result => { result.push(wallet); });
       this.actions.dialogs.closeActiveDialog.trigger();
       this.goToWalletRoute(wallet.id);
     } else {


### PR DESCRIPTION
Turns out the call in `WalletStore` is necessary for the regular wallet creation.

The reason it fixed itself is that `refreshWalletsData` fixes things up and it's called a few seconds after creating your wallet. In the wallet restore case, it's called right away (which is why this bug didn't happen when you restored a wallet)