### PR TITLE
New flow-typed definitions

### DIFF
--- a/app/api/ada/errors.js
+++ b/app/api/ada/errors.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { defineMessages } from 'react-intl';
 import LocalizableError from '../../i18n/LocalizableError';
 
@@ -144,7 +146,7 @@ export class WalletAlreadyImportedError extends LocalizableError {
   constructor() {
     super({
       id: messages.walletAlreadyImportedError.id,
-      defaultMessage: messages.walletAlreadyImportedError.defaultMessage,
+      defaultMessage: messages.walletAlreadyImportedError.defaultMessage || '',
     });
   }
 }
@@ -153,7 +155,7 @@ export class RedeemAdaError extends LocalizableError {
   constructor() {
     super({
       id: messages.redeemAdaError.id,
-      defaultMessage: messages.redeemAdaError.defaultMessage,
+      defaultMessage: messages.redeemAdaError.defaultMessage || '',
     });
   }
 }
@@ -162,7 +164,7 @@ export class WalletFileImportError extends LocalizableError {
   constructor() {
     super({
       id: messages.walletFileImportError.id,
-      defaultMessage: messages.walletFileImportError.defaultMessage,
+      defaultMessage: messages.walletFileImportError.defaultMessage || '',
     });
   }
 }
@@ -171,7 +173,7 @@ export class NotEnoughMoneyToSendError extends LocalizableError {
   constructor() {
     super({
       id: messages.notEnoughMoneyToSendError.id,
-      defaultMessage: messages.notEnoughMoneyToSendError.defaultMessage,
+      defaultMessage: messages.notEnoughMoneyToSendError.defaultMessage || '',
     });
   }
 }
@@ -180,7 +182,7 @@ export class UpdateAdaWalletError extends LocalizableError {
   constructor() {
     super({
       id: messages.updateAdaWalletError.id,
-      defaultMessage: messages.updateAdaWalletError.defaultMessage,
+      defaultMessage: messages.updateAdaWalletError.defaultMessage || '',
     });
   }
 }
@@ -189,7 +191,7 @@ export class GetBalanceError extends LocalizableError {
   constructor() {
     super({
       id: messages.getBalanceError.id,
-      defaultMessage: messages.getBalanceError.defaultMessage,
+      defaultMessage: messages.getBalanceError.defaultMessage || '',
     });
   }
 }
@@ -198,7 +200,7 @@ export class UpdateAdaTxsHistoryError extends LocalizableError {
   constructor() {
     super({
       id: messages.updateAdaTxsHistoryError.id,
-      defaultMessage: messages.updateAdaTxsHistoryError.defaultMessage,
+      defaultMessage: messages.updateAdaTxsHistoryError.defaultMessage || '',
     });
   }
 }
@@ -207,7 +209,7 @@ export class TransactionError extends LocalizableError {
   constructor() {
     super({
       id: messages.transactionError.id,
-      defaultMessage: messages.transactionError.defaultMessage,
+      defaultMessage: messages.transactionError.defaultMessage || '',
     });
   }
 }
@@ -216,7 +218,7 @@ export class PendingTransactionError extends LocalizableError {
   constructor() {
     super({
       id: messages.pendingTransactionError.id,
-      defaultMessage: messages.pendingTransactionError.defaultMessage,
+      defaultMessage: messages.pendingTransactionError.defaultMessage || '',
     });
   }
 }
@@ -225,7 +227,7 @@ export class GetAddressesWithFundsError extends LocalizableError {
   constructor() {
     super({
       id: messages.getAddressesWithFundsError.id,
-      defaultMessage: messages.getAddressesWithFundsError.defaultMessage
+      defaultMessage: messages.getAddressesWithFundsError.defaultMessage || '',
     });
   }
 }
@@ -234,7 +236,7 @@ export class NoInputsError extends LocalizableError {
   constructor() {
     super({
       id: messages.noInputsError.id,
-      defaultMessage: messages.noInputsError.defaultMessage
+      defaultMessage: messages.noInputsError.defaultMessage || '',
     });
   }
 }
@@ -243,7 +245,7 @@ export class GenerateTransferTxError extends LocalizableError {
   constructor() {
     super({
       id: messages.generateTransferTxError.id,
-      defaultMessage: messages.generateTransferTxError.defaultMessage
+      defaultMessage: messages.generateTransferTxError.defaultMessage || '',
     });
   }
 }
@@ -252,7 +254,7 @@ export class SendTransactionError extends LocalizableError {
   constructor() {
     super({
       id: messages.sendTransactionError.id,
-      defaultMessage: messages.sendTransactionError.defaultMessage
+      defaultMessage: messages.sendTransactionError.defaultMessage || '',
     });
   }
 }
@@ -261,7 +263,7 @@ export class GetAllUTXOsForAddressesError extends LocalizableError {
   constructor() {
     super({
       id: messages.getAllUTXOsForAddressesError.id,
-      defaultMessage: messages.getAllUTXOsForAddressesError.defaultMessage
+      defaultMessage: messages.getAllUTXOsForAddressesError.defaultMessage || '',
     });
   }
 }
@@ -270,7 +272,7 @@ export class DiscoverAddressesError extends LocalizableError {
   constructor() {
     super({
       id: messages.discoverAddressesError.id,
-      defaultMessage: messages.discoverAddressesError.defaultMessage
+      defaultMessage: messages.discoverAddressesError.defaultMessage || '',
     });
   }
 }
@@ -279,7 +281,7 @@ export class GetUtxosForAddressesApiError extends LocalizableError {
   constructor() {
     super({
       id: messages.getUtxosForAddressesApiError.id,
-      defaultMessage: messages.getUtxosForAddressesApiError.defaultMessage
+      defaultMessage: messages.getUtxosForAddressesApiError.defaultMessage || '',
     });
   }
 }
@@ -288,7 +290,7 @@ export class GetTxsBodiesForUTXOsError extends LocalizableError {
   constructor() {
     super({
       id: messages.getTxsBodiesForUTXOsError.id,
-      defaultMessage: messages.getTxsBodiesForUTXOsError.defaultMessage
+      defaultMessage: messages.getTxsBodiesForUTXOsError.defaultMessage || '',
     });
   }
 }
@@ -297,7 +299,7 @@ export class GetTxsBodiesForUTXOsApiError extends LocalizableError {
   constructor() {
     super({
       id: messages.getTxsBodiesForUTXOsApiError.id,
-      defaultMessage: messages.getTxsBodiesForUTXOsApiError.defaultMessage
+      defaultMessage: messages.getTxsBodiesForUTXOsApiError.defaultMessage || '',
     });
   }
 }
@@ -306,7 +308,7 @@ export class GetUtxosSumsForAddressesApiError extends LocalizableError {
   constructor() {
     super({
       id: messages.getUtxosSumsForAddressesApiError.id,
-      defaultMessage: messages.getUtxosSumsForAddressesApiError.defaultMessage
+      defaultMessage: messages.getUtxosSumsForAddressesApiError.defaultMessage || '',
     });
   }
 }
@@ -315,7 +317,7 @@ export class GetTxHistoryForAddressesApiError extends LocalizableError {
   constructor() {
     super({
       id: messages.getTxHistoryForAddressesApiError.id,
-      defaultMessage: messages.getTxHistoryForAddressesApiError.defaultMessage
+      defaultMessage: messages.getTxHistoryForAddressesApiError.defaultMessage || '',
     });
   }
 }
@@ -324,7 +326,7 @@ export class SendTransactionApiError extends LocalizableError {
   constructor() {
     super({
       id: messages.sendTransactionApiError.id,
-      defaultMessage: messages.sendTransactionApiError.defaultMessage
+      defaultMessage: messages.sendTransactionApiError.defaultMessage || '',
     });
   }
 }
@@ -333,7 +335,7 @@ export class CheckAdressesInUseApiError extends LocalizableError {
   constructor() {
     super({
       id: messages.checkAdressesInUseApiError.id,
-      defaultMessage: messages.checkAdressesInUseApiError.defaultMessage
+      defaultMessage: messages.checkAdressesInUseApiError.defaultMessage || '',
     });
   }
 }
@@ -342,7 +344,7 @@ export class InvalidWitnessError extends LocalizableError {
   constructor() {
     super({
       id: messages.invalidWitnessError.id,
-      defaultMessage: messages.invalidWitnessError.defaultMessage
+      defaultMessage: messages.invalidWitnessError.defaultMessage || '',
     });
   }
 }
@@ -351,7 +353,7 @@ export class InvalidCertificateError extends LocalizableError {
   constructor() {
     super({
       id: messages.invalidCertificateError.id,
-      defaultMessage: messages.invalidCertificateError.defaultMessage
+      defaultMessage: messages.invalidCertificateError.defaultMessage || '',
     });
   }
 }
@@ -360,7 +362,7 @@ export class ReadFileError extends LocalizableError {
   constructor() {
     super({
       id: messages.readFileError.id,
-      defaultMessage: messages.readFileError.defaultMessage
+      defaultMessage: messages.readFileError.defaultMessage || '',
     });
   }
 }
@@ -369,7 +371,7 @@ export class DecryptionError extends LocalizableError {
   constructor() {
     super({
       id: messages.decryptionError.id,
-      defaultMessage: messages.decryptionError.defaultMessage
+      defaultMessage: messages.decryptionError.defaultMessage || '',
     });
   }
 }
@@ -378,7 +380,7 @@ export class ParsePDFFileError extends LocalizableError {
   constructor() {
     super({
       id: messages.parsePDFFileError.id,
-      defaultMessage: messages.parsePDFFileError.defaultMessage
+      defaultMessage: messages.parsePDFFileError.defaultMessage || '',
     });
   }
 }
@@ -387,7 +389,7 @@ export class ParsePDFPageError extends LocalizableError {
   constructor() {
     super({
       id: messages.parsePDFPageError.id,
-      defaultMessage: messages.parsePDFPageError.defaultMessage
+      defaultMessage: messages.parsePDFPageError.defaultMessage || '',
     });
   }
 }
@@ -396,7 +398,7 @@ export class ParsePDFKeyError extends LocalizableError {
   constructor() {
     super({
       id: messages.parsePDFKeyError.id,
-      defaultMessage: messages.parsePDFKeyError.defaultMessage
+      defaultMessage: messages.parsePDFKeyError.defaultMessage || '',
     });
   }
 }
@@ -405,7 +407,7 @@ export class InvalidMnemonicError extends LocalizableError {
   constructor() {
     super({
       id: messages.invalidMnemonicError.id,
-      defaultMessage: messages.invalidMnemonicError.defaultMessage
+      defaultMessage: messages.invalidMnemonicError.defaultMessage || '',
     });
   }
 }
@@ -414,7 +416,7 @@ export class AdaRedemptionEncryptedCertificateParseError extends LocalizableErro
   constructor() {
     super({
       id: messages.adaRedemptionEncryptedCertificateParseError.id,
-      defaultMessage: messages.adaRedemptionEncryptedCertificateParseError.defaultMessage
+      defaultMessage: messages.adaRedemptionEncryptedCertificateParseError.defaultMessage || '',
     });
   }
 }
@@ -423,7 +425,7 @@ export class AdaRedemptionCertificateParseError extends LocalizableError {
   constructor() {
     super({
       id: messages.adaRedemptionCertificateParseError.id,
-      defaultMessage: messages.adaRedemptionCertificateParseError.defaultMessage
+      defaultMessage: messages.adaRedemptionCertificateParseError.defaultMessage || '',
     });
   }
 }
@@ -432,7 +434,7 @@ export class NoCertificateError extends LocalizableError {
   constructor() {
     super({
       id: messages.noCertificateError.id,
-      defaultMessage: messages.noCertificateError.defaultMessage
+      defaultMessage: messages.noCertificateError.defaultMessage || '',
     });
   }
 }
@@ -441,7 +443,7 @@ export class RedemptionKeyAlreadyUsedError extends LocalizableError {
   constructor() {
     super({
       id: messages.redemptionKeyAlreadyUsedError.id,
-      defaultMessage: messages.redemptionKeyAlreadyUsedError.defaultMessage,
+      defaultMessage: messages.redemptionKeyAlreadyUsedError.defaultMessage || '',
     });
   }
 }

--- a/app/api/common.js
+++ b/app/api/common.js
@@ -38,7 +38,7 @@ export class GenericApiError extends LocalizableError {
   constructor() {
     super({
       id: messages.genericApiError.id,
-      defaultMessage: messages.genericApiError.defaultMessage,
+      defaultMessage: messages.genericApiError.defaultMessage || '',
     });
   }
 }
@@ -47,7 +47,7 @@ export class IncorrectWalletPasswordError extends LocalizableError {
   constructor() {
     super({
       id: messages.incorrectWalletPasswordError.id,
-      defaultMessage: messages.incorrectWalletPasswordError.defaultMessage,
+      defaultMessage: messages.incorrectWalletPasswordError.defaultMessage || '',
     });
   }
 }
@@ -56,7 +56,7 @@ export class WalletAlreadyRestoredError extends LocalizableError {
   constructor() {
     super({
       id: messages.walletAlreadyRestoredError.id,
-      defaultMessage: messages.walletAlreadyRestoredError.defaultMessage,
+      defaultMessage: messages.walletAlreadyRestoredError.defaultMessage || '',
     });
   }
 }
@@ -65,7 +65,7 @@ export class ReportRequestError extends LocalizableError {
   constructor() {
     super({
       id: messages.reportRequestError.id,
-      defaultMessage: messages.reportRequestError.defaultMessage,
+      defaultMessage: messages.reportRequestError.defaultMessage || '',
     });
   }
 }
@@ -74,7 +74,7 @@ export class UnusedAddressesError extends LocalizableError {
   constructor() {
     super({
       id: messages.unusedAddressesError.id,
-      defaultMessage: messages.unusedAddressesError.defaultMessage,
+      defaultMessage: messages.unusedAddressesError.defaultMessage || '',
     });
   }
 }

--- a/app/components/layout/GridFlexContainer.js
+++ b/app/components/layout/GridFlexContainer.js
@@ -8,7 +8,7 @@ import HorizontalFlexContainer from './HorizontalFlexContainer';
 
 type Props = {
   children: ?Node,
-  rowSize: Number
+  rowSize: number
 };
 
 @observer

--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import LoadingSpinner from '../widgets/LoadingSpinner';
 import yoroiLogo from '../../assets/images/yoroi-logo-shape-white.inline.svg';
 import styles from './Loading.scss';
-import type { ReactIntlMessage } from '../../types/i18nTypes';
+import type { MessageDescriptor } from 'react-intl';
 import environment from '../../environment';
 import LocalizableError from '../../i18n/LocalizableError';
 
@@ -15,7 +15,7 @@ type Props = {
   currencyIcon: string,
   apiIcon: string,
   isLoadingDataForNextScreen: boolean,
-  loadingDataForNextScreenMessage: ReactIntlMessage,
+  loadingDataForNextScreenMessage: MessageDescriptor,
   hasLoadedCurrentLocale: boolean,
   hasLoadedCurrentTheme: boolean,
   error: ?LocalizableError

--- a/app/components/profile/language-selection/LanguageSelectionForm.js
+++ b/app/components/profile/language-selection/LanguageSelectionForm.js
@@ -10,7 +10,7 @@ import { defineMessages, intlShape } from 'react-intl';
 import ReactToolboxMobxForm from '../../../utils/ReactToolboxMobxForm';
 import LocalizableError from '../../../i18n/LocalizableError';
 import styles from './LanguageSelectionForm.scss';
-import type { ReactIntlMessage } from '../../../types/i18nTypes';
+import type { MessageDescriptor } from 'react-intl';
 import FlagLabel from '../../widgets/FlagLabel';
 
 const messages = defineMessages({
@@ -25,7 +25,7 @@ const messages = defineMessages({
 });
 
 type Props = {
-  languages: Array<{ value: string, label: ReactIntlMessage, svg: string }>,
+  languages: Array<{ value: string, label: MessageDescriptor, svg: string }>,
   onSubmit: Function,
   isSubmitting: boolean,
   error?: ?LocalizableError,

--- a/app/components/settings/categories/GeneralSettings.js
+++ b/app/components/settings/categories/GeneralSettings.js
@@ -8,7 +8,7 @@ import { defineMessages, intlShape } from 'react-intl';
 import ReactToolboxMobxForm from '../../../utils/ReactToolboxMobxForm';
 import LocalizableError from '../../../i18n/LocalizableError';
 import styles from './GeneralSettings.scss';
-import type { ReactIntlMessage } from '../../../types/i18nTypes';
+import type { MessageDescriptor } from 'react-intl';
 import FlagLabel from '../../widgets/FlagLabel';
 
 const messages = defineMessages({
@@ -20,7 +20,7 @@ const messages = defineMessages({
 });
 
 type Props = {
-  languages: Array<{ value: string, label: ReactIntlMessage, svg: string }>,
+  languages: Array<{ value: string, label: MessageDescriptor, svg: string }>,
   currentLocale: string,
   onSelectLanguage: Function,
   isSubmitting: boolean,
@@ -82,7 +82,7 @@ export default class GeneralSettings extends Component<Props> {
             <FlagLabel svg={option.svg} label={option.label} />
           )}
         />
-        {error && <p className={styles.error}>{error}</p>}
+        {error && <p className={styles.error}>{intl.formatMessage(error)}</p>}
 
       </div>
     );

--- a/app/components/settings/categories/PaperWalletSettings.js
+++ b/app/components/settings/categories/PaperWalletSettings.js
@@ -61,6 +61,7 @@ export default class PaperWalletSettings extends Component<Props> {
   });
 
   render() {
+    const { intl } = this.context;
     const { error, isDialogOpen, dialog, paperWalletsIntroText } = this.props;
     const numAddresses = this.form.$('numAddresses');
     const numAddressOptions = [...Array(5).keys()].map(x => ({ value: `${x + 1}`, label: `${x + 1}` }));
@@ -97,7 +98,7 @@ export default class PaperWalletSettings extends Component<Props> {
           <div>{dialog}</div>
         ) : null}
 
-        {error && <p className={styles.error}>{error}</p>}
+        {error && <p className={styles.error}>{intl.formatMessage(error)}</p>}
 
       </div>
     );

--- a/app/components/transfer/TransferInstructionsPage.js
+++ b/app/components/transfer/TransferInstructionsPage.js
@@ -22,7 +22,6 @@ const messages = defineMessages({
     id: 'transfer.instructions.attention.title.label',
     defaultMessage: '!!!Attention',
   },
-  instructionTitle: globalMessages.instructionTitle,
 });
 
 type Props = {
@@ -83,7 +82,7 @@ export default class TransferInstructionsPage extends Component<Props> {
 
               <div>
                 <div className={styles.title}>
-                  {intl.formatMessage(messages.instructionTitle)}
+                  {intl.formatMessage(globalMessages.instructionTitle)}
                 </div>
                 <div className={styles.text}>
                   {intl.formatMessage(messages.instructionsText)}

--- a/app/components/transfer/TransferInstructionsPage.js
+++ b/app/components/transfer/TransferInstructionsPage.js
@@ -22,10 +22,8 @@ const messages = defineMessages({
     id: 'transfer.instructions.attention.title.label',
     defaultMessage: '!!!Attention',
   },
+  instructionTitle: globalMessages.instructionTitle,
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
-messages.instructionTitle = globalMessages.instructionTitle;
 
 type Props = {
   onFollowInstructionsPrerequisites: Function,

--- a/app/components/transfer/TransferMasterKeyPage.js
+++ b/app/components/transfer/TransferMasterKeyPage.js
@@ -27,14 +27,13 @@ const messages = defineMessages({
     id: 'transfer.form.masterkey.requirement',
     defaultMessage: '!!!Note: master keys are 192 characters and hexadecimal-encoded',
   },
+  fieldIsRequired: globalMessages.fieldIsRequired,
+  invalidMasterKey: globalMessages.invalidMasterKey,
+  nextButtonLabel: globalMessages.nextButtonLabel,
+  backButtonLabel: globalMessages.backButtonLabel,
+  step1: globalMessages.step1,
+  instructionTitle: globalMessages.instructionTitle,
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
-messages.invalidMasterKey = globalMessages.invalidMasterKey;
-messages.nextButtonLabel = globalMessages.nextButtonLabel;
-messages.backButtonLabel = globalMessages.backButtonLabel;
-messages.step1 = globalMessages.step1;
-messages.instructionTitle = globalMessages.instructionTitle;
 
 type Props = {
   onSubmit: Function,

--- a/app/components/transfer/TransferMasterKeyPage.js
+++ b/app/components/transfer/TransferMasterKeyPage.js
@@ -27,12 +27,6 @@ const messages = defineMessages({
     id: 'transfer.form.masterkey.requirement',
     defaultMessage: '!!!Note: master keys are 192 characters and hexadecimal-encoded',
   },
-  fieldIsRequired: globalMessages.fieldIsRequired,
-  invalidMasterKey: globalMessages.invalidMasterKey,
-  nextButtonLabel: globalMessages.nextButtonLabel,
-  backButtonLabel: globalMessages.backButtonLabel,
-  step1: globalMessages.step1,
-  instructionTitle: globalMessages.instructionTitle,
 });
 
 type Props = {
@@ -58,13 +52,13 @@ export default class TransferMasterKeyPage extends Component<Props> {
         validators: [({ field }) => {
           const value = field.value;
           if (value === '') {
-            return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
+            return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           }
           if (value.length !== 192) {
-            return [false, this.context.intl.formatMessage(messages.invalidMasterKey)];
+            return [false, this.context.intl.formatMessage(globalMessages.invalidMasterKey)];
           }
           if (!value.match('^[0-9a-fA-F]+$')) {
-            return [false, this.context.intl.formatMessage(messages.invalidMasterKey)];
+            return [false, this.context.intl.formatMessage(globalMessages.invalidMasterKey)];
           }
           return true;
         }],
@@ -117,14 +111,14 @@ export default class TransferMasterKeyPage extends Component<Props> {
             { /* Instructions for how to transfer */ }
             <div>
               <div className={styles.title}>
-                {intl.formatMessage(messages.instructionTitle)}
+                {intl.formatMessage(globalMessages.instructionTitle)}
               </div>
 
               <ul className={styles.instructionsList}>
                 {
                   <div className={styles.text}>
                     {step0}
-                    {intl.formatMessage(messages.step1)}
+                    {intl.formatMessage(globalMessages.step1)}
                     <br /><br />
                     {intl.formatMessage(messages.masterKeyRequirements)}
                   </div>
@@ -143,14 +137,14 @@ export default class TransferMasterKeyPage extends Component<Props> {
             <div className={styles.buttonsWrapper}>
               <Button
                 className={nextButtonClasses}
-                label={intl.formatMessage(messages.nextButtonLabel)}
+                label={intl.formatMessage(globalMessages.nextButtonLabel)}
                 onClick={this.submit}
                 skin={ButtonSkin}
               />
 
               <Button
                 className={backButtonClasses}
-                label={intl.formatMessage(messages.backButtonLabel)}
+                label={intl.formatMessage(globalMessages.backButtonLabel)}
                 onClick={onBack}
                 skin={ButtonSkin}
               />

--- a/app/components/transfer/TransferMnemonicPage.js
+++ b/app/components/transfer/TransferMnemonicPage.js
@@ -34,13 +34,12 @@ const messages = defineMessages({
     id: 'transfer.form.errors.invalidRecoveryPhrase',
     defaultMessage: '!!!Invalid recovery phrase',
   },
+  fieldIsRequired: globalMessages.fieldIsRequired,
+  nextButtonLabel: globalMessages.nextButtonLabel,
+  backButtonLabel: globalMessages.backButtonLabel,
+  step1: globalMessages.step1,
+  instructionTitle: globalMessages.instructionTitle,
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
-messages.nextButtonLabel = globalMessages.nextButtonLabel;
-messages.backButtonLabel = globalMessages.backButtonLabel;
-messages.step1 = globalMessages.step1;
-messages.instructionTitle = globalMessages.instructionTitle;
 
 type Props = {
   onSubmit: Function,

--- a/app/components/transfer/TransferMnemonicPage.js
+++ b/app/components/transfer/TransferMnemonicPage.js
@@ -34,11 +34,6 @@ const messages = defineMessages({
     id: 'transfer.form.errors.invalidRecoveryPhrase',
     defaultMessage: '!!!Invalid recovery phrase',
   },
-  fieldIsRequired: globalMessages.fieldIsRequired,
-  nextButtonLabel: globalMessages.nextButtonLabel,
-  backButtonLabel: globalMessages.backButtonLabel,
-  step1: globalMessages.step1,
-  instructionTitle: globalMessages.instructionTitle,
 });
 
 type Props = {
@@ -66,7 +61,7 @@ export default class TransferMnemonicPage extends Component<Props> {
         value: '',
         validators: [({ field }) => {
           const value = join(field.value, ' ');
-          if (value === '') return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
+          if (value === '') return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           return [
             this.props.mnemonicValidator(value),
             this.context.intl.formatMessage(messages.invalidRecoveryPhrase)
@@ -122,14 +117,14 @@ export default class TransferMnemonicPage extends Component<Props> {
             { /* Instructions for how to transfer */ }
             <div>
               <div className={styles.title}>
-                {intl.formatMessage(messages.instructionTitle)}
+                {intl.formatMessage(globalMessages.instructionTitle)}
               </div>
 
               <ul className={styles.instructionsList}>
                 {
                   <div className={styles.text}>
                     {step0}
-                    {intl.formatMessage(messages.step1)}
+                    {intl.formatMessage(globalMessages.step1)}
                   </div>
                 }
               </ul>
@@ -149,14 +144,14 @@ export default class TransferMnemonicPage extends Component<Props> {
             <div className={styles.buttonsWrapper}>
               <Button
                 className={nextButtonClasses}
-                label={intl.formatMessage(messages.nextButtonLabel)}
+                label={intl.formatMessage(globalMessages.nextButtonLabel)}
                 onClick={this.submit}
                 skin={ButtonSkin}
               />
 
               <Button
                 className={backButtonClasses}
-                label={intl.formatMessage(messages.backButtonLabel)}
+                label={intl.formatMessage(globalMessages.backButtonLabel)}
                 onClick={onBack}
                 skin={ButtonSkin}
               />

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -13,7 +13,6 @@ import BorderedBox from '../widgets/BorderedBox';
 import iconCopy from '../../assets/images/clipboard-ic.inline.svg';
 import magnifyingGlass from '../../assets/images/search-ic-dark.inline.svg';
 import WalletAddress from '../../domain/WalletAddress';
-import globalMessages from '../../i18n/global-messages';
 import LocalizableError from '../../i18n/LocalizableError';
 import LoadingSpinner from '../widgets/LoadingSpinner';
 import styles from './WalletReceive.scss';
@@ -49,8 +48,6 @@ const messages = defineMessages({
     defaultMessage: '!!!Copy address',
   },
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
 
 type Props = {
   walletAddress: string,

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -99,9 +99,8 @@ const messages = defineMessages({
     id: 'wallet.restore.dialog.passwordDisclaimer',
     defaultMessage: '!!!Typing the wrong wallet password will give you a different wallet. This allows for plausible deniability.',
   },
+  fieldIsRequired: globalMessages.fieldIsRequired,
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
 
 type Props = {
   onSubmit: Function,

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -99,7 +99,6 @@ const messages = defineMessages({
     id: 'wallet.restore.dialog.passwordDisclaimer',
     defaultMessage: '!!!Typing the wrong wallet password will give you a different wallet. This allows for plausible deniability.',
   },
-  fieldIsRequired: globalMessages.fieldIsRequired,
 });
 
 type Props = {
@@ -152,7 +151,7 @@ export default class WalletRestoreDialog extends Component<Props> {
         value: '',
         validators: [({ field }) => {
           const value = join(field.value, ' ');
-          if (value === '') return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
+          if (value === '') return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           return [
             this.props.mnemonicValidator(value),
             this.context.intl.formatMessage(messages.invalidRecoveryPhrase)

--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -155,7 +155,6 @@ where Ada should be redeemed and enter {adaRedemptionPassphraseLength} word mnem
     id: 'wallet.redeem.dialog.adaAmountHint',
     defaultMessage: '!!!Enter your Ada amount',
   },
-  fieldIsRequired: globalMessages.fieldIsRequired,
 });
 
 type Props = {
@@ -228,7 +227,7 @@ export default class AdaRedemptionForm extends Component<Props> {
         validators: ({ field }) => {
           if (this.props.redemptionType === ADA_REDEMPTION_TYPES.PAPER_VENDED) return [true];
           const value = this.props.redemptionCode || field.value;
-          if (value === '') return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
+          if (value === '') return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           return this.props.redemptionCodeValidator(value)
             .then(isValid => (
               [isValid, this.context.intl.formatMessage(messages.redemptionKeyError)]
@@ -242,7 +241,7 @@ export default class AdaRedemptionForm extends Component<Props> {
         validators: ({ field }) => {
           if (this.props.redemptionType !== ADA_REDEMPTION_TYPES.PAPER_VENDED) return [true];
           const value = field.value;
-          if (value === '') return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
+          if (value === '') return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           return this.props.postVendRedemptionCodeValidator(value)
             .then(isValid => (
               [isValid, this.context.intl.formatMessage(messages.shieldedRedemptionKeyError)]

--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -154,10 +154,9 @@ where Ada should be redeemed and enter {adaRedemptionPassphraseLength} word mnem
   adaAmountHint: {
     id: 'wallet.redeem.dialog.adaAmountHint',
     defaultMessage: '!!!Enter your Ada amount',
-  }
+  },
+  fieldIsRequired: globalMessages.fieldIsRequired,
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
 
 type Props = {
   wallets: Array<{ value: string, label: string }>,

--- a/app/components/wallet/hwConnect/trezor/AboutDialog.js
+++ b/app/components/wallet/hwConnect/trezor/AboutDialog.js
@@ -54,9 +54,8 @@ const messages = defineMessages({
     id: 'wallet.connect.trezor.dialog.step.about.prerequisite.5',
     defaultMessage: '!!!Trezor device must remain connected to the computer throughout the process',
   },
+  nextButtonLabel: globalMessages.nextButtonLabel,
 });
-
-messages.nextButtonLabel = globalMessages.nextButtonLabel;
 
 type Props = {
   progressInfo: ProgressInfo,

--- a/app/components/wallet/hwConnect/trezor/AboutDialog.js
+++ b/app/components/wallet/hwConnect/trezor/AboutDialog.js
@@ -132,7 +132,7 @@ export default class AboutDialog extends Component<Props> {
 
     const dailogActions = [{
       className: isActionProcessing ? styles.processing : null,
-      label: intl.formatMessage(globalglobalMessages.nextButtonLabel),
+      label: intl.formatMessage(globalMessages.nextButtonLabel),
       primary: true,
       disabled: false,
       onClick: submit,

--- a/app/components/wallet/hwConnect/trezor/AboutDialog.js
+++ b/app/components/wallet/hwConnect/trezor/AboutDialog.js
@@ -54,7 +54,6 @@ const messages = defineMessages({
     id: 'wallet.connect.trezor.dialog.step.about.prerequisite.5',
     defaultMessage: '!!!Trezor device must remain connected to the computer throughout the process',
   },
-  nextButtonLabel: globalMessages.nextButtonLabel,
 });
 
 type Props = {
@@ -133,7 +132,7 @@ export default class AboutDialog extends Component<Props> {
 
     const dailogActions = [{
       className: isActionProcessing ? styles.processing : null,
-      label: intl.formatMessage(globalMessages.nextButtonLabel),
+      label: intl.formatMessage(globalglobalMessages.nextButtonLabel),
       primary: true,
       disabled: false,
       onClick: submit,

--- a/app/components/wallet/send/HWSendConfirmationDialog.js
+++ b/app/components/wallet/send/HWSendConfirmationDialog.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import { intlShape } from 'react-intl';
-import type { MessageDescriptorMap } from 'react-intl';
+import type { MessageDescriptor } from 'react-intl';
 
 import Dialog from '../../widgets/Dialog';
 import DialogCloseButton from '../../widgets/DialogCloseButton';
@@ -14,6 +14,12 @@ import LocalizableError from '../../../i18n/LocalizableError';
 
 import styles from './HWSendConfirmationDialog.scss';
 
+type ExpectedMessages = {
+  infoLine1: MessageDescriptor,
+  infoLine2: MessageDescriptor,
+  sendUsingHWButtonLabel: MessageDescriptor,
+};
+
 type Props = {
   amount: string,
   receiver: string,
@@ -21,7 +27,7 @@ type Props = {
   transactionFee: string,
   currencyUnit: string,
   amountToNaturalUnits: Function,
-  messages: MessageDescriptorMap,
+  messages: ExpectedMessages,
   isSubmitting: boolean,
   error: ?LocalizableError,
   onSubmit: Function,

--- a/app/components/wallet/send/WalletSendConfirmationDialog.js
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.js
@@ -30,9 +30,8 @@ const messages = defineMessages({
     id: 'wallet.send.confirmationDialog.submit',
     defaultMessage: '!!!Send',
   },
+  fieldIsRequired: globalMessages.fieldIsRequired,
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
 
 type Props = {
   amount: string,

--- a/app/components/wallet/send/WalletSendConfirmationDialog.js
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.js
@@ -30,7 +30,6 @@ const messages = defineMessages({
     id: 'wallet.send.confirmationDialog.submit',
     defaultMessage: '!!!Send',
   },
-  fieldIsRequired: globalMessages.fieldIsRequired,
 });
 
 type Props = {
@@ -63,7 +62,7 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
         value: '',
         validators: [({ field }) => {
           if (field.value === '') {
-            return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
+            return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           }
           return [true];
         }],

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -83,8 +83,6 @@ const messages = defineMessages({
     id: 'wallet.send.form.sendingIsDisabled',
     defaultMessage: '!!!Cannot send a transaction while there is a pending one',
   },
-  fieldIsRequired: globalMessages.fieldIsRequired,
-  nextButtonLabel: globalMessages.nextButtonLabel,
 });
 
 type Props = {
@@ -150,7 +148,7 @@ export default class WalletSendForm extends Component<Props, State> {
           const value = field.value;
           if (value === '') {
             this._resetTransactionFee();
-            return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
+            return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           }
           return this.props.addressValidator(value)
             .then(isValid => {
@@ -174,7 +172,7 @@ export default class WalletSendForm extends Component<Props, State> {
           const amountValue = field.value;
           if (amountValue === '') {
             this._resetTransactionFee();
-            return [false, this.context.intl.formatMessage(messages.fieldIsRequired)];
+            return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           }
           const isValid = await this.props.validateAmount(
             formattedAmountToNaturalUnits(amountValue)
@@ -303,7 +301,7 @@ export default class WalletSendForm extends Component<Props, State> {
     return (
       <Button
         className={buttonClasses}
-        label={intl.formatMessage(messages.nextButtonLabel)}
+        label={intl.formatMessage(globalMessages.nextButtonLabel)}
         onMouseUp={onMouseUp}
         /** Next Action can't be performed in case transaction fees are not calculated
           * or there's a transaction waiting to be confirmed (pending) */

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -82,11 +82,10 @@ const messages = defineMessages({
   sendingIsDisabled: {
     id: 'wallet.send.form.sendingIsDisabled',
     defaultMessage: '!!!Cannot send a transaction while there is a pending one',
-  }
+  },
+  fieldIsRequired: globalMessages.fieldIsRequired,
+  nextButtonLabel: globalMessages.nextButtonLabel,
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
-messages.nextButtonLabel = globalMessages.nextButtonLabel;
 
 type Props = {
   currencyUnit: string,

--- a/app/containers/transfer/DaedalusTransferErrorPage.js
+++ b/app/containers/transfer/DaedalusTransferErrorPage.js
@@ -11,7 +11,6 @@ const messages = defineMessages({
     id: 'daedalusTransfer.errorPage.title.label',
     defaultMessage: '!!!Unable to restore Daedalus wallet',
   },
-  backButtonLabel: globalMessages.backButtonLabel,
 });
 
 type Props = {
@@ -36,7 +35,7 @@ export default class DaedalusTransferErrorPage extends Component<Props> {
 
     return (<ErrorPage
       title={intl.formatMessage(messages.title)}
-      backButtonLabel={intl.formatMessage(messages.backButtonLabel)}
+      backButtonLabel={intl.formatMessage(globalMessages.backButtonLabel)}
       onCancel={onCancel}
       error={error}
       classicTheme={classicTheme}

--- a/app/containers/transfer/DaedalusTransferErrorPage.js
+++ b/app/containers/transfer/DaedalusTransferErrorPage.js
@@ -11,9 +11,8 @@ const messages = defineMessages({
     id: 'daedalusTransfer.errorPage.title.label',
     defaultMessage: '!!!Unable to restore Daedalus wallet',
   },
+  backButtonLabel: globalMessages.backButtonLabel,
 });
-
-messages.backButtonLabel = globalMessages.backButtonLabel;
 
 type Props = {
   error?: ?LocalizableError,

--- a/app/containers/transfer/DaedalusTransferFormPage.js
+++ b/app/containers/transfer/DaedalusTransferFormPage.js
@@ -2,9 +2,7 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import globalMessages from '../../i18n/global-messages';
 import TransferMnemonicPage from '../../components/transfer/TransferMnemonicPage';
-import type { Theme } from '../../themes';
 
 const messages = defineMessages({
   step0: {
@@ -16,8 +14,6 @@ const messages = defineMessages({
     defaultMessage: '!!!Enter the 27-word recovery phrase used to back up your Daedalus Paper wallet to restore the balance and transfer all the funds from Daedalus to Yoroi.',
   },
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
 
 type Props = {
   onSubmit: Function,

--- a/app/containers/transfer/DaedalusTransferInstructionsPage.js
+++ b/app/containers/transfer/DaedalusTransferInstructionsPage.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import globalMessages from '../../i18n/global-messages';
 import TransferInstructionsPage from '../../components/transfer/TransferInstructionsPage';
 
 const messages = defineMessages({
@@ -39,8 +38,6 @@ const messages = defineMessages({
     defaultMessage: '!!!Daedalus Master Key',
   },
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
 
 type Props = {
   onFollowInstructionsPrerequisites: Function,

--- a/app/containers/transfer/DaedalusTransferMasterKeyFormPage.js
+++ b/app/containers/transfer/DaedalusTransferMasterKeyFormPage.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import globalMessages from '../../i18n/global-messages';
 import TransferMasterKeyPage from '../../components/transfer/TransferMasterKeyPage';
 
 const messages = defineMessages({
@@ -11,8 +10,6 @@ const messages = defineMessages({
     defaultMessage: '!!!Enter the unencrypted master key for your Daedalus wallet to restore the balance and transfer all the funds from Daedalus to Yoroi.',
   },
 });
-
-messages.fieldIsRequired = globalMessages.fieldIsRequired;
 
 type Props = {
   onSubmit: Function,

--- a/app/containers/wallet/WalletSendPage.js
+++ b/app/containers/wallet/WalletSendPage.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import type { Node } from 'react';
 import { defineMessages, intlShape } from 'react-intl';
-import type { MessageDescriptorMap } from 'react-intl';
 
 import environment from '../../environment';
 import type { InjectedProps } from '../../types/injectedPropsType';
@@ -22,7 +21,7 @@ import type { DialogProps } from './dialogs/WalletSendConfirmationDialogContaine
 // Hardware Wallet Confirmation
 import HWSendConfirmationDialog from '../../components/wallet/send/HWSendConfirmationDialog';
 
-const messagesLedger: MessageDescriptorMap = defineMessages({
+const messagesLedger = defineMessages({
   infoLine1: {
     id: 'wallet.send.ledger.confirmationDialog.info.line.1',
     defaultMessage: '!!!After connecting your Ledger device to your computer’s USB port, press the Send using Ledger button.',
@@ -37,7 +36,7 @@ const messagesLedger: MessageDescriptorMap = defineMessages({
   },
 });
 
-const messagesTrezor: MessageDescriptorMap = defineMessages({
+const messagesTrezor = defineMessages({
   infoLine1: {
     id: 'wallet.send.trezor.confirmationDialog.info.line.1',
     defaultMessage: '!!!After connecting your Trezor device to your computer, press the Send using Trezor button.',

--- a/app/i18n/LocalizableError.js
+++ b/app/i18n/LocalizableError.js
@@ -2,6 +2,8 @@
 import ExtendableError from 'es6-error';
 import { defineMessages } from 'react-intl';
 
+import type { MessageDescriptor } from 'react-intl';
+
 const messages = defineMessages({
   unknowError: {
     id: 'app.errors.unknowError',
@@ -15,16 +17,21 @@ const messages = defineMessages({
 
 // Base class to allow wrapping a localizable message into an ES6-error
 class LocalizableError extends ExtendableError {
+
+  id: string;
+  defaultMessage: string;
+  values: Object;
+
   constructor(
-    { id, defaultMessage, values = {} }:
-    { id: string, defaultMessage: string, values?: Object}
+    { id, defaultMessage, values }:
+    { ...$Exact<MessageDescriptor>, values?: Object}
   ) {
     if (!id) throw new Error('id:string is required.');
     if (!defaultMessage) throw new Error('defaultMessage:string is required.');
     super(`${id}: ${JSON.stringify(values)}`);
     this.id = id;
     this.defaultMessage = defaultMessage;
-    this.values = values;
+    this.values = values || {};
   }
 }
 
@@ -34,7 +41,7 @@ class UnknowError extends LocalizableError {
   constructor() {
     super({
       id: messages.unknowError.id,
-      defaultMessage: messages.unknowError.defaultMessage,
+      defaultMessage: messages.unknowError.defaultMessage || '',
     });
   }
 }
@@ -43,7 +50,7 @@ export class UnexpectedError extends LocalizableError {
   constructor() {
     super({
       id: messages.unexpectedError.id,
-      defaultMessage: messages.unexpectedError.defaultMessage,
+      defaultMessage: messages.unexpectedError.defaultMessage || '',
     });
   }
 }

--- a/app/stores/ada/DaedalusTransferStore.js
+++ b/app/stores/ada/DaedalusTransferStore.js
@@ -271,7 +271,7 @@ export class TransferFundsError extends LocalizableError {
   constructor() {
     super({
       id: messages.transferFundsError.id,
-      defaultMessage: messages.transferFundsError.defaultMessage,
+      defaultMessage: messages.transferFundsError.defaultMessage || '',
       description: messages.transferFundsError.description,
     });
   }
@@ -281,7 +281,7 @@ export class NoTransferTxError extends LocalizableError {
   constructor() {
     super({
       id: messages.noTransferTxError.id,
-      defaultMessage: messages.noTransferTxError.defaultMessage,
+      defaultMessage: messages.noTransferTxError.defaultMessage || '',
       description: messages.noTransferTxError.description,
     });
   }
@@ -291,7 +291,7 @@ export class WebSocketRestoreError extends LocalizableError {
   constructor() {
     super({
       id: messages.webSocketRestoreError.id,
-      defaultMessage: messages.webSocketRestoreError.defaultMessage,
+      defaultMessage: messages.webSocketRestoreError.defaultMessage || '',
       description: messages.webSocketRestoreError.description,
     });
   }

--- a/app/stores/lib/Request.js
+++ b/app/stores/lib/Request.js
@@ -149,7 +149,7 @@ export class ApiMethodNotYetImplementedError extends LocalizableError {
   constructor() {
     super({
       id: messages.apiMethodNotYetImplementedError.id,
-      defaultMessage: messages.apiMethodNotYetImplementedError.defaultMessage,
+      defaultMessage: messages.apiMethodNotYetImplementedError.defaultMessage || '',
     });
   }
 }
@@ -158,7 +158,7 @@ export class NotExecutedYetError extends LocalizableError {
   constructor() {
     super({
       id: messages.apiMethodNotYetImplementedError.id,
-      defaultMessage: messages.apiMethodNotYetImplementedError.defaultMessage,
+      defaultMessage: messages.apiMethodNotYetImplementedError.defaultMessage || '',
     });
   }
 }

--- a/app/types/i18nTypes.js
+++ b/app/types/i18nTypes.js
@@ -1,6 +1,0 @@
-// @flow
-export type ReactIntlMessage = {
-  id: string,
-  defaultMessage: string,
-  description: string,
-};

--- a/app/types/notificationType.js
+++ b/app/types/notificationType.js
@@ -1,9 +1,9 @@
 // @flow
-import type { ReactIntlMessage } from './i18nTypes';
+import type { MessageDescriptor } from 'react-intl';
 
 export type Notification = {
   id: string,
-  message: ReactIntlMessage,
+  message: MessageDescriptor,
   duration: ?number,
   secondsTimerInterval?: ?IntervalID,
 }

--- a/flow-typed/npm/axios_v0.18.x.js
+++ b/flow-typed/npm/axios_v0.18.x.js
@@ -1,0 +1,165 @@
+// flow-typed signature: 74afec89c50ce53778988cf95042cca4
+// flow-typed version: 7ffaa2ca07/axios_v0.18.x/flow_>=v0.80.x <=v0.92.x
+
+declare module 'axios' {
+  declare interface AxiosTransformer<T> {
+    (data: T, headers?: Object): Object;
+  }
+  declare interface ProxyConfig {
+    host: string;
+    port: number;
+    auth?: {
+      username: string,
+      password: string,
+    };
+  }
+  declare interface Cancel {
+    constructor(message?: string): Cancel;
+    message: string;
+  }
+  declare interface Canceler {
+    (message?: string): void;
+  }
+  declare interface CancelTokenSource {
+    token: CancelToken;
+    cancel: Canceler;
+  }
+  declare class CancelToken {
+    constructor(executor: (cancel: Canceler) => void): CancelToken;
+    static source(): CancelTokenSource;
+    promise: Promise<Cancel>;
+    reason?: Cancel;
+    throwIfRequested(): void;
+  }
+  declare interface AxiosXHRConfigBase<T, R = T> {
+    adapter?: <T, R>(config: AxiosXHRConfig<T, R>) => Promise<AxiosXHR<T, R>>;
+    auth?: {
+      username: string,
+      password: string,
+    };
+    baseURL?: string;
+    cancelToken?: CancelToken;
+    headers?: Object;
+    httpAgent?: mixed; // Missing the type in the core flow node libdef
+    httpsAgent?: mixed; // Missing the type in the core flow node libdef
+    maxContentLength?: number;
+    maxRedirects?: number;
+    params?: Object;
+    paramsSerializer?: (params: Object) => string;
+    onUploadProgress?: (progressEvent: ProgressEvent) => void;
+    onDownloadProgress?: (progressEvent: ProgressEvent) => void;
+    proxy?: ProxyConfig | false;
+    responseType?:
+      | 'arraybuffer'
+      | 'blob'
+      | 'document'
+      | 'json'
+      | 'text'
+      | 'stream';
+    timeout?: number;
+    transformRequest?: AxiosTransformer<T> | Array<AxiosTransformer<T>>;
+    transformResponse?: AxiosTransformer<R> | Array<AxiosTransformer<R>>;
+    validateStatus?: (status: number) => boolean;
+    withCredentials?: boolean;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+  }
+  declare type $AxiosXHRConfigBase<T, R = T> = AxiosXHRConfigBase<T, R>;
+  declare interface AxiosXHRConfig<T, R = T> extends AxiosXHRConfigBase<T, R> {
+    data?: T;
+    method?: string;
+    url?: string;
+  }
+  declare type $AxiosXHRConfig<T, R = T> = AxiosXHRConfig<T, R>;
+  declare class AxiosXHR<T, R = T> {
+    config: AxiosXHRConfig<T, R>;
+    data: R;
+    headers?: Object;
+    status: number;
+    statusText: string;
+    request: http$ClientRequest<> | XMLHttpRequest;
+  }
+  declare type $AxiosXHR<T, R = T> = AxiosXHR<T, R>;
+  declare type AxiosInterceptorIdent = number;
+  declare class AxiosRequestInterceptor<T, R = T> {
+    use(
+      successHandler: ?(
+        response: AxiosXHRConfig<T, R>
+      ) => Promise<AxiosXHRConfig<*, *>> | AxiosXHRConfig<*, *>,
+      errorHandler: ?(error: mixed) => mixed
+    ): AxiosInterceptorIdent;
+    eject(ident: AxiosInterceptorIdent): void;
+  }
+  declare class AxiosResponseInterceptor<T, R = T> {
+    use(
+      successHandler: ?(response: AxiosXHR<T, R>) => mixed,
+      errorHandler: ?(error: $AxiosError<any>) => mixed
+    ): AxiosInterceptorIdent;
+    eject(ident: AxiosInterceptorIdent): void;
+  }
+  declare type AxiosPromise<T, R = T> = Promise<AxiosXHR<T, R>>;
+  declare class Axios {
+    <T, R>(
+      config: AxiosXHRConfig<T, R> | string,
+      config?: AxiosXHRConfig<T, R>
+    ): AxiosPromise<T, R>;
+    constructor<T, R>(config?: AxiosXHRConfigBase<T, R>): void;
+    request<T, R>(config: AxiosXHRConfig<T, R>): AxiosPromise<T, R>;
+    delete<T, R>(
+      url: string,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
+    get<T, R>(
+      url: string,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
+    head<T, R>(
+      url: string,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
+    post<T, R>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
+    put<T, R>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
+    patch<T, R>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
+    interceptors: {
+      request: AxiosRequestInterceptor<mixed>,
+      response: AxiosResponseInterceptor<mixed>,
+    };
+    defaults: { headers: Object } & AxiosXHRConfig<*, *>;
+  }
+
+  declare class AxiosError<T, R = T> extends Error {
+    config: AxiosXHRConfig<T, R>;
+    request?: http$ClientRequest<> | XMLHttpRequest;
+    response?: AxiosXHR<T, R>;
+    code?: string;
+  }
+
+  declare type $AxiosError<T, R = T> = AxiosError<T, R>;
+
+  declare interface AxiosExport extends Axios {
+    <T, R>(
+      config: AxiosXHRConfig<T, R> | string,
+      config?: AxiosXHRConfig<T, R>
+    ): AxiosPromise<T, R>;
+    Axios: typeof Axios;
+    Cancel: Class<Cancel>;
+    CancelToken: Class<CancelToken>;
+    isCancel(value: any): boolean;
+    create(config?: AxiosXHRConfigBase<any, any>): Axios;
+    all: typeof Promise.all;
+    spread(callback: Function): (arr: Array<any>) => Function;
+  }
+  declare module.exports: AxiosExport;
+}

--- a/flow-typed/npm/bluebird_v3.x.x.js
+++ b/flow-typed/npm/bluebird_v3.x.x.js
@@ -1,0 +1,329 @@
+// flow-typed signature: e0974d6c2c04803a78c4faa3e848c72a
+// flow-typed version: 34fbdaa6f3/bluebird_v3.x.x/flow_>=v0.70.x
+
+type Bluebird$RangeError = Error;
+type Bluebird$CancellationErrors = Error;
+type Bluebird$TimeoutError = Error;
+type Bluebird$RejectionError = Error;
+type Bluebird$OperationalError = Error;
+
+type Bluebird$ConcurrencyOption = {
+  concurrency: number
+};
+type Bluebird$SpreadOption = {
+  spread: boolean
+};
+type Bluebird$MultiArgsOption = {
+  multiArgs: boolean
+};
+type Bluebird$BluebirdConfig = {
+  warnings?: boolean,
+  longStackTraces?: boolean,
+  cancellation?: boolean,
+  monitoring?: boolean
+};
+
+declare class Bluebird$PromiseInspection<T> {
+  isCancelled(): boolean;
+  isFulfilled(): boolean;
+  isRejected(): boolean;
+  pending(): boolean;
+  reason(): any;
+  value(): T;
+}
+
+type Bluebird$PromisifyOptions = {|
+  multiArgs?: boolean,
+  context: any
+|};
+
+declare type Bluebird$PromisifyAllOptions = {
+  suffix?: string,
+  filter?: (
+    name: string,
+    func: Function,
+    target?: any,
+    passesDefaultFilter?: boolean
+  ) => boolean,
+  // The promisifier gets a reference to the original method and should return a function which returns a promise
+  promisifier?: (originalMethod: Function) => () => Bluebird$Promise<any>
+};
+
+declare type $Promisable<T> = Promise<T> | T;
+
+declare class Bluebird$Disposable<R> {}
+
+declare class Bluebird$Promise<+R> extends Promise<R> {
+  static RangeError: Class<Bluebird$RangeError>;
+  static CancellationErrors: Class<Bluebird$CancellationErrors>;
+  static TimeoutError: Class<Bluebird$TimeoutError>;
+  static RejectionError: Class<Bluebird$RejectionError>;
+  static OperationalError: Class<Bluebird$OperationalError>;
+
+  static Defer: Class<Bluebird$Defer>;
+  static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
+
+  static all<T>(
+    Promises: $Promisable<Iterable<$Promisable<T>>>
+  ): Bluebird$Promise<Array<T>>;
+  static props(
+    input: Object | Map<*, *> | $Promisable<Object | Map<*, *>>
+  ): Bluebird$Promise<*>;
+  static any<T, Elem: $Promisable<T>>(
+    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>
+  ): Bluebird$Promise<T>;
+  static race<T, Elem: $Promisable<T>>(
+    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>
+  ): Bluebird$Promise<T>;
+  static reject<T>(error?: any): Bluebird$Promise<T>;
+  static resolve<T>(object?: $Promisable<T>): Bluebird$Promise<T>;
+  static some<T, Elem: $Promisable<T>>(
+    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>,
+    count: number
+  ): Bluebird$Promise<Array<T>>;
+  static join<T, A>(
+    value1: $Promisable<A>,
+    handler: (a: A) => $Promisable<T>
+  ): Bluebird$Promise<T>;
+  static join<T, A, B>(
+    value1: $Promisable<A>,
+    value2: $Promisable<B>,
+    handler: (a: A, b: B) => $Promisable<T>
+  ): Bluebird$Promise<T>;
+  static join<T, A, B, C>(
+    value1: $Promisable<A>,
+    value2: $Promisable<B>,
+    value3: $Promisable<C>,
+    handler: (a: A, b: B, c: C) => $Promisable<T>
+  ): Bluebird$Promise<T>;
+  static map<T, U, Elem: $Promisable<T>>(
+    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>,
+    mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>,
+    options?: Bluebird$ConcurrencyOption
+  ): Bluebird$Promise<Array<U>>;
+  static mapSeries<T, U, Elem: $Promisable<T>>(
+    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>,
+    mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>
+  ): Bluebird$Promise<Array<U>>;
+  static reduce<T, U, Elem: $Promisable<T>>(
+    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>,
+    reducer: (
+      total: U,
+      current: T,
+      index: number,
+      arrayLength: number
+    ) => $Promisable<U>,
+    initialValue?: $Promisable<U>
+  ): Bluebird$Promise<U>;
+  static filter<T, Elem: $Promisable<T>>(
+    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>,
+    filterer: (
+      item: T,
+      index: number,
+      arrayLength: number
+    ) => $Promisable<boolean>,
+    option?: Bluebird$ConcurrencyOption
+  ): Bluebird$Promise<Array<T>>;
+  static each<T, Elem: $Promisable<T>>(
+    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>,
+    iterator: (
+      item: T,
+      index: number,
+      arrayLength: number
+    ) => $Promisable<mixed>
+  ): Bluebird$Promise<Array<T>>;
+  static try<T>(
+    fn: () => $Promisable<T>,
+    args: ?Array<any>,
+    ctx: ?any
+  ): Bluebird$Promise<T>;
+  static attempt<T>(
+    fn: () => $Promisable<T>,
+    args: ?Array<any>,
+    ctx: ?any
+  ): Bluebird$Promise<T>;
+  static delay<T>(ms: number, value: $Promisable<T>): Bluebird$Promise<T>;
+  static delay(ms: number): Bluebird$Promise<void>;
+  static config(config: Bluebird$BluebirdConfig): void;
+
+  static defer(): Bluebird$Defer;
+  static setScheduler(
+    scheduler: (callback: (...args: Array<any>) => void) => void
+  ): void;
+  static promisify(
+    nodeFunction: Function,
+    receiver?: Bluebird$PromisifyOptions
+  ): Function;
+  static promisifyAll(
+    target: Object | Array<Object>,
+    options?: Bluebird$PromisifyAllOptions
+  ): void;
+
+  static coroutine(generatorFunction: Function): Function;
+  static spawn<T>(generatorFunction: Function): Promise<T>;
+
+  // It doesn't seem possible to have type-generics for a variable number of arguments.
+  // Handle up to 3 arguments, then just give up and accept 'any'.
+  static method<T, R: $Promisable<T>>(fn: () => R): () => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A>(
+    fn: (a: A) => R
+  ): (a: A) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A, B>(
+    fn: (a: A, b: B) => R
+  ): (a: A, b: B) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A, B, C>(
+    fn: (a: A, b: B, c: C) => R
+  ): (a: A, b: B, c: C) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>>(
+    fn: (...args: any) => R
+  ): (...args: any) => Bluebird$Promise<T>;
+
+  static cast<T>(value: $Promisable<T>): Bluebird$Promise<T>;
+  // static bind(ctx: any): Bluebird$Promise<void>;
+  static is(value: any): boolean;
+  static longStackTraces(): void;
+
+  static onPossiblyUnhandledRejection(handler: (reason: any) => any): void;
+  static fromCallback<T>(
+    resolver: (fn: (error: ?Error, value?: T) => any) => any,
+    options?: Bluebird$MultiArgsOption
+  ): Bluebird$Promise<T>;
+
+  constructor(
+    callback: (
+      resolve: (result?: $Promisable<R>) => void,
+      reject: (error?: any) => void,
+      onCancel?: (fn?: () => void) => void,
+    ) => mixed
+  ): void;
+  then(onFulfill: null | void, onReject: null | void): Bluebird$Promise<R>;
+  then<U>(
+    onFulfill: null | void,
+    onReject: (error: any) => Promise<U> | U
+  ): Bluebird$Promise<R | U>;
+  then<U>(
+    onFulfill: (value: R) => Promise<U> | U,
+    onReject: null | void | ((error: any) => Promise<U> | U)
+  ): Bluebird$Promise<U>;
+  catch(onReject: null | void): Promise<R>;
+  catch<U>(onReject?: (error: any) => $Promisable<U>): Bluebird$Promise<U>;
+  catch<U, ErrorT: Error>(
+    err: Class<ErrorT>,
+    onReject: (error: ErrorT) => $Promisable<U>
+  ): Bluebird$Promise<U>;
+  catch<U, ErrorT: Error>(
+    err1: Class<ErrorT>,
+    err2: Class<ErrorT>,
+    onReject: (error: ErrorT) => $Promisable<U>
+  ): Bluebird$Promise<U>;
+  catch<U, ErrorT: Error>(
+    err1: Class<ErrorT>,
+    err2: Class<ErrorT>,
+    err3: Class<ErrorT>,
+    onReject: (error: ErrorT) => $Promisable<U>
+  ): Bluebird$Promise<U>;
+  caught<U, ErrorT: Error>(
+    err: Class<ErrorT>,
+    onReject: (error: Error) => $Promisable<U>
+  ): Bluebird$Promise<U>;
+  caught<U, ErrorT: Error>(
+    err1: Class<ErrorT>,
+    err2: Class<ErrorT>,
+    onReject: (error: ErrorT) => $Promisable<U>
+  ): Bluebird$Promise<U>;
+  caught<U, ErrorT: Error>(
+    err1: Class<ErrorT>,
+    err2: Class<ErrorT>,
+    err3: Class<ErrorT>,
+    onReject: (error: ErrorT) => $Promisable<U>
+  ): Bluebird$Promise<U>;
+  caught<U>(onReject: (error: any) => $Promisable<U>): Bluebird$Promise<U>;
+
+  error<U>(onReject?: (error: any) => ?$Promisable<U>): Bluebird$Promise<U>;
+  done<U>(
+    onFulfill?: (value: R) => mixed,
+    onReject?: (error: any) => mixed
+  ): void;
+  finally<T>(onDone?: (value: R) => mixed): Bluebird$Promise<T>;
+  lastly<T>(onDone?: (value: R) => mixed): Bluebird$Promise<T>;
+  tap<T>(onDone?: (value: R) => mixed): Bluebird$Promise<T>;
+  delay(ms: number): Bluebird$Promise<R>;
+  timeout(ms: number, message?: string): Bluebird$Promise<R>;
+  cancel(): void;
+
+  // bind(ctx: any): Bluebird$Promise<R>;
+  call(propertyName: string, ...args: Array<any>): Bluebird$Promise<any>;
+  throw(reason: Error): Bluebird$Promise<R>;
+  thenThrow(reason: Error): Bluebird$Promise<R>;
+  all<T>(): Bluebird$Promise<Array<T>>;
+  any<T>(): Bluebird$Promise<T>;
+  some<T>(count: number): Bluebird$Promise<Array<T>>;
+  race<T>(): Bluebird$Promise<T>;
+  map<T, U>(
+    mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>,
+    options?: Bluebird$ConcurrencyOption
+  ): Bluebird$Promise<Array<U>>;
+  mapSeries<T, U>(
+    mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>
+  ): Bluebird$Promise<Array<U>>;
+  reduce<T, U>(
+    reducer: (
+      total: T,
+      item: U,
+      index: number,
+      arrayLength: number
+    ) => $Promisable<T>,
+    initialValue?: $Promisable<T>
+  ): Bluebird$Promise<T>;
+  filter<T>(
+    filterer: (
+      item: T,
+      index: number,
+      arrayLength: number
+    ) => $Promisable<boolean>,
+    options?: Bluebird$ConcurrencyOption
+  ): Bluebird$Promise<Array<T>>;
+  each<T, U>(
+    iterator: (item: T, index: number, arrayLength: number) => $Promisable<U>
+  ): Bluebird$Promise<Array<T>>;
+  asCallback<T>(
+    callback: (error: ?any, value?: T) => any,
+    options?: Bluebird$SpreadOption
+  ): void;
+  return<T>(value: T): Bluebird$Promise<T>;
+  thenReturn<T>(value: T): Bluebird$Promise<T>;
+  spread<T>(...args: Array<T>): Bluebird$Promise<*>;
+
+  reflect(): Bluebird$Promise<Bluebird$PromiseInspection<*>>;
+
+  isFulfilled(): boolean;
+  isRejected(): boolean;
+  isPending(): boolean;
+  isResolved(): boolean;
+
+  value(): R;
+  reason(): any;
+
+  disposer(
+    disposer: (value: R, promise: Promise<*>) => void
+  ): Bluebird$Disposable<R>;
+
+  static using<T, A>(
+    disposable: Bluebird$Disposable<T>,
+    handler: (value: T) => $Promisable<A>
+  ): Bluebird$Promise<A>;
+
+  suppressUnhandledRejections(): void;
+}
+
+declare class Bluebird$Defer {
+  promise: Bluebird$Promise<*>;
+  resolve: (value: any) => any;
+  reject: (value: any) => any;
+}
+
+declare module "bluebird" {
+  declare module.exports: typeof Bluebird$Promise;
+
+  declare type Disposable<T> = Bluebird$Disposable<T>;
+}

--- a/flow-typed/npm/classnames_v2.x.x.js
+++ b/flow-typed/npm/classnames_v2.x.x.js
@@ -1,0 +1,23 @@
+// flow-typed signature: cf86673cc32d185bdab1d2ea90578d37
+// flow-typed version: 614bf49aa8/classnames_v2.x.x/flow_>=v0.25.x
+
+type $npm$classnames$Classes =
+  | string
+  | { [className: string]: * }
+  | false
+  | void
+  | null;
+
+declare module "classnames" {
+  declare module.exports: (
+    ...classes: Array<$npm$classnames$Classes | $npm$classnames$Classes[]>
+  ) => string;
+}
+
+declare module "classnames/bind" {
+  declare module.exports: $Exports<"classnames">;
+}
+
+declare module "classnames/dedupe" {
+  declare module.exports: $Exports<"classnames">;
+}

--- a/flow-typed/npm/es6-error_v4.x.x.js
+++ b/flow-typed/npm/es6-error_v4.x.x.js
@@ -1,0 +1,8 @@
+// flow-typed signature: 59598aa3b00e126e674391832ba298ce
+// flow-typed version: da30fe6876/es6-error_v4.x.x/flow_>=v0.32.x
+
+declare module "es6-error" {
+  declare class ExtendableError extends Error {}
+
+  declare module.exports: Class<ExtendableError>;
+}

--- a/flow-typed/npm/lodash_v4.x.x.js
+++ b/flow-typed/npm/lodash_v4.x.x.js
@@ -1,0 +1,6086 @@
+// flow-typed signature: 11c59ec61b55e07f727745ac1ee4a664
+// flow-typed version: 418c2af657/lodash_v4.x.x/flow_>=v0.63.x
+
+declare module "lodash" {
+  declare type Path = $ReadOnlyArray<string | number> | string | number;
+  declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
+  declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>;
+
+  declare type __CurriedFunction2<A, B, R, AA: A, BB: B> = ((
+    ...r: [AA]
+  ) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB]) => R);
+  declare type CurriedFunction2<A, B, R> = __CurriedFunction2<A, B, R, *, *>;
+
+  declare type __CurriedFunction3<A, B, C, R, AA: A, BB: B, CC: C> = ((
+    ...r: [AA]
+  ) => CurriedFunction2<BB, CC, R>) &
+    ((...r: [AA, BB]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC]) => R);
+  declare type CurriedFunction3<A, B, C, R> = __CurriedFunction3<
+    A,
+    B,
+    C,
+    R,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D
+  > = ((...r: [AA]) => CurriedFunction3<BB, CC, DD, R>) &
+    ((...r: [AA, BB]) => CurriedFunction2<CC, DD, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction1<DD, R>) &
+    ((...r: [AA, BB, CC, DD]) => R);
+  declare type CurriedFunction4<A, B, C, D, R> = __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E
+  > = ((...r: [AA]) => CurriedFunction4<BB, CC, DD, EE, R>) &
+    ((...r: [AA, BB]) => CurriedFunction3<CC, DD, EE, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction2<DD, EE, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction1<EE, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => R);
+  declare type CurriedFunction5<A, B, C, D, E, R> = __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E,
+    FF: F
+  > = ((...r: [AA]) => CurriedFunction5<BB, CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB]) => CurriedFunction4<CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction3<DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction2<EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => CurriedFunction1<FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE, FF]) => R);
+  declare type CurriedFunction6<A, B, C, D, E, F, R> = __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type Curry = (<A, R>((...r: [A]) => R) => CurriedFunction1<A, R>) &
+    (<A, B, R>((...r: [A, B]) => R) => CurriedFunction2<A, B, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R) => CurriedFunction3<A, B, C, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R
+    ) => CurriedFunction4<A, B, C, D, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R
+    ) => CurriedFunction5<A, B, C, D, E, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R
+    ) => CurriedFunction6<A, B, C, D, E, F, R>);
+
+  declare type UnaryFn<A, R> = (a: A) => R;
+
+  declare type TemplateSettings = {
+    escape?: RegExp,
+    evaluate?: RegExp,
+    imports?: Object,
+    interpolate?: RegExp,
+    variable?: string
+  };
+
+  declare type TruncateOptions = {
+    length?: number,
+    omission?: string,
+    separator?: RegExp | string
+  };
+
+  declare type DebounceOptions = {
+    leading?: boolean,
+    maxWait?: number,
+    trailing?: boolean
+  };
+
+  declare type ThrottleOptions = {
+    leading?: boolean,
+    trailing?: boolean
+  };
+
+  declare type NestedArray<T> = Array<Array<T>>;
+
+  declare type matchesIterateeShorthand = {[key: any]: any};
+  declare type matchesPropertyIterateeShorthand = [string, any];
+  declare type propertyIterateeShorthand = string;
+
+  declare type OPredicate<A, O> =
+    | ((value: A, key: string, object: O) => any)
+    | matchesIterateeShorthand
+    | matchesPropertyIterateeShorthand
+    | propertyIterateeShorthand;
+
+  declare type OIterateeWithResult<V, O, R> =
+    | Object
+    | string
+    | ((value: V, key: string, object: O) => R);
+  declare type OIteratee<O> = OIterateeWithResult<any, O, any>;
+  declare type OFlatMapIteratee<T, U> = OIterateeWithResult<any, T, Array<U>>;
+
+  declare type Predicate<T> =
+    | ((value: T, index: number, array: Array<T>) => any)
+    | matchesIterateeShorthand
+    | matchesPropertyIterateeShorthand
+    | propertyIterateeShorthand;
+
+  declare type _ValueOnlyIteratee<T> = (value: T) => mixed;
+  declare type ValueOnlyIteratee<T> = _ValueOnlyIteratee<T> | string;
+  declare type _Iteratee<T> = (
+    item: T,
+    index: number,
+    array: ?Array<T>
+  ) => mixed;
+  declare type Iteratee<T> = _Iteratee<T> | Object | string;
+  declare type FlatMapIteratee<T, U> =
+    | ((item: T, index: number, array: ?$ReadOnlyArray<T>) => Array<U>)
+    | Object
+    | string;
+  declare type Comparator<T> = (item: T, item2: T) => boolean;
+
+  declare type MapIterator<T, U> =
+    | ((item: T, index: number, array: Array<T>) => U)
+    | propertyIterateeShorthand;
+
+  declare type ReadOnlyMapIterator<T, U> =
+    | ((item: T, index: number, array: $ReadOnlyArray<T>) => U)
+    | propertyIterateeShorthand;
+
+  declare type OMapIterator<T, O, U> =
+    | ((item: T, key: string, object: O) => U)
+    | propertyIterateeShorthand;
+
+  declare class Lodash {
+    // Array
+    chunk<T>(array?: ?Array<T>, size?: ?number): Array<Array<T>>;
+    compact<T, N: ?T>(array?: ?Array<N>): Array<T>;
+    concat<T>(
+      base?: ?$ReadOnlyArray<T>,
+      ...elements: Array<any>
+    ): Array<T | any>;
+    difference<T>(
+      array?: ?$ReadOnlyArray<T>,
+      ...values: Array<?$ReadOnlyArray<T>>
+    ): Array<T>;
+    differenceBy<T>(
+      array?: ?$ReadOnlyArray<T>,
+      values?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): T[];
+    differenceWith<T>(
+      array?: ?$ReadOnlyArray<T>,
+      values?: ?$ReadOnlyArray<T>,
+      comparator?: ?Comparator<T>
+    ): T[];
+    drop<T>(array?: ?Array<T>, n?: ?number): Array<T>;
+    dropRight<T>(array?: ?Array<T>, n?: ?number): Array<T>;
+    dropRightWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
+    dropWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
+    fill<T, U>(
+      array?: ?Array<T>,
+      value?: ?U,
+      start?: ?number,
+      end?: ?number
+    ): Array<T | U>;
+    findIndex<T>(
+      array: $ReadOnlyArray<T>,
+      predicate?: ?Predicate<T>,
+      fromIndex?: ?number
+    ): number;
+    findIndex<T>(
+      array: void | null,
+      predicate?: ?Predicate<T>,
+      fromIndex?: ?number
+    ): -1;
+    findLastIndex<T>(
+      array: $ReadOnlyArray<T>,
+      predicate?: ?Predicate<T>,
+      fromIndex?: ?number
+    ): number;
+    findLastIndex<T>(
+      array: void | null,
+      predicate?: ?Predicate<T>,
+      fromIndex?: ?number
+    ): -1;
+    // alias of _.head
+    first<T>(array: ?$ReadOnlyArray<T>): T;
+    flatten<T, X>(array?: ?Array<Array<T> | X>): Array<T | X>;
+    flattenDeep<T>(array?: ?(any[])): Array<T>;
+    flattenDepth(array?: ?(any[]), depth?: ?number): any[];
+    fromPairs<A, B>(pairs?: ?Array<[A, B]>): { [key: A]: B };
+    head<T>(array: ?$ReadOnlyArray<T>): T;
+    indexOf<T>(array: Array<T>, value: T, fromIndex?: number): number;
+    indexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
+    initial<T>(array: ?Array<T>): Array<T>;
+    intersection<T>(...arrays?: Array<$ReadOnlyArray<T>>): Array<T>;
+    //Workaround until (...parameter: T, parameter2: U) works
+    intersectionBy<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
+    intersectionBy<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      a2?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
+    intersectionBy<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      a2?: ?$ReadOnlyArray<T>,
+      a3?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
+    intersectionBy<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      a2?: ?$ReadOnlyArray<T>,
+      a3?: ?$ReadOnlyArray<T>,
+      a4?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
+    //Workaround until (...parameter: T, parameter2: U) works
+    intersectionWith<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      comparator?: ?Comparator<T>
+    ): Array<T>;
+    intersectionWith<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      a2?: ?$ReadOnlyArray<T>,
+      comparator?: ?Comparator<T>
+    ): Array<T>;
+    intersectionWith<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      a2?: ?$ReadOnlyArray<T>,
+      a3?: ?$ReadOnlyArray<T>,
+      comparator?: ?Comparator<T>
+    ): Array<T>;
+    intersectionWith<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      a2?: ?$ReadOnlyArray<T>,
+      a3?: ?$ReadOnlyArray<T>,
+      a4?: ?$ReadOnlyArray<T>,
+      comparator?: ?Comparator<T>
+    ): Array<T>;
+    join<T>(array: Array<T>, separator?: ?string): string;
+    join<T>(array: void | null, separator?: ?string): "";
+    last<T>(array: ?$ReadOnlyArray<T>): T;
+    lastIndexOf<T>(array: Array<T>, value?: ?T, fromIndex?: ?number): number;
+    lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
+    nth<T>(array: T[], n?: ?number): T;
+    nth(array: void | null, n?: ?number): void;
+    pull<T>(array: Array<T>, ...values?: Array<?T>): Array<T>;
+    pull<T: void | null>(array: T, ...values?: Array<?any>): T;
+    pullAll<T>(array: Array<T>, values?: ?Array<T>): Array<T>;
+    pullAll<T: void | null>(array: T, values?: ?Array<any>): T;
+    pullAllBy<T>(
+      array: Array<T>,
+      values?: ?Array<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
+    pullAllBy<T: void | null>(
+      array: T,
+      values?: ?Array<any>,
+      iteratee?: ?ValueOnlyIteratee<any>
+    ): T;
+    pullAllWith<T>(array: T[], values?: ?(T[]), comparator?: ?Function): T[];
+    pullAllWith<T: void | null>(
+      array: T,
+      values?: ?Array<any>,
+      comparator?: ?Function
+    ): T;
+    pullAt<T>(array?: ?Array<T>, ...indexed?: Array<?number>): Array<T>;
+    pullAt<T>(array?: ?Array<T>, indexed?: ?Array<number>): Array<T>;
+    remove<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
+    reverse<T>(array: Array<T>): Array<T>;
+    reverse<T: void | null>(array: T): T;
+    slice<T>(
+      array?: ?$ReadOnlyArray<T>,
+      start?: ?number,
+      end?: ?number
+    ): Array<T>;
+    sortedIndex<T>(array: Array<T>, value: T): number;
+    sortedIndex<T>(array: void | null, value: ?T): 0;
+    sortedIndexBy<T>(
+      array: Array<T>,
+      value?: ?T,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): number;
+    sortedIndexBy<T>(
+      array: void | null,
+      value?: ?T,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): 0;
+    sortedIndexOf<T>(array: Array<T>, value: T): number;
+    sortedIndexOf<T>(array: void | null, value?: ?T): -1;
+    sortedLastIndex<T>(array: Array<T>, value: T): number;
+    sortedLastIndex<T>(array: void | null, value?: ?T): 0;
+    sortedLastIndexBy<T>(
+      array: Array<T>,
+      value: T,
+      iteratee?: ValueOnlyIteratee<T>
+    ): number;
+    sortedLastIndexBy<T>(
+      array: void | null,
+      value?: ?T,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): 0;
+    sortedLastIndexOf<T>(array: Array<T>, value: T): number;
+    sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
+    sortedUniq<T>(array?: ?Array<T>): Array<T>;
+    sortedUniqBy<T>(
+      array?: ?Array<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
+    tail<T>(array?: ?Array<T>): Array<T>;
+    take<T>(array?: ?$ReadOnlyArray<T>, n?: ?number): Array<T>;
+    takeRight<T>(array?: ?$ReadOnlyArray<T>, n?: ?number): Array<T>;
+    takeRightWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
+    takeWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
+    union<T>(...arrays?: Array<$ReadOnlyArray<T>>): Array<T>;
+    //Workaround until (...parameter: T, parameter2: U) works
+    unionBy<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
+    unionBy<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      iteratee?: ValueOnlyIteratee<T>
+    ): Array<T>;
+    unionBy<T>(
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      a3: $ReadOnlyArray<T>,
+      iteratee?: ValueOnlyIteratee<T>
+    ): Array<T>;
+    unionBy<T>(
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      a3: $ReadOnlyArray<T>,
+      a4: $ReadOnlyArray<T>,
+      iteratee?: ValueOnlyIteratee<T>
+    ): Array<T>;
+    //Workaround until (...parameter: T, parameter2: U) works
+    unionWith<T>(a1?: ?Array<T>, comparator?: ?Comparator<T>): Array<T>;
+    unionWith<T>(
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      comparator?: Comparator<T>
+    ): Array<T>;
+    unionWith<T>(
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      a3: $ReadOnlyArray<T>,
+      comparator?: Comparator<T>
+    ): Array<T>;
+    unionWith<T>(
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      a3: $ReadOnlyArray<T>,
+      a4: $ReadOnlyArray<T>,
+      comparator?: Comparator<T>
+    ): Array<T>;
+    uniq<T>(array?: ?$ReadOnlyArray<T>): Array<T>;
+    uniqBy<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
+    uniqWith<T>(array?: ?$ReadOnlyArray<T>, comparator?: ?Comparator<T>): Array<T>;
+    unzip<T>(array?: ?Array<T>): Array<T>;
+    unzipWith<T>(array: ?Array<T>, iteratee?: ?Iteratee<T>): Array<T>;
+    without<T>(array?: ?$ReadOnlyArray<T>, ...values?: Array<?T>): Array<T>;
+    xor<T>(...array: Array<Array<T>>): Array<T>;
+    //Workaround until (...parameter: T, parameter2: U) works
+    xorBy<T>(a1?: ?Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
+    xorBy<T>(
+      a1: Array<T>,
+      a2: Array<T>,
+      iteratee?: ValueOnlyIteratee<T>
+    ): Array<T>;
+    xorBy<T>(
+      a1: Array<T>,
+      a2: Array<T>,
+      a3: Array<T>,
+      iteratee?: ValueOnlyIteratee<T>
+    ): Array<T>;
+    xorBy<T>(
+      a1: Array<T>,
+      a2: Array<T>,
+      a3: Array<T>,
+      a4: Array<T>,
+      iteratee?: ValueOnlyIteratee<T>
+    ): Array<T>;
+    //Workaround until (...parameter: T, parameter2: U) works
+    xorWith<T>(a1?: ?Array<T>, comparator?: ?Comparator<T>): Array<T>;
+    xorWith<T>(
+      a1: Array<T>,
+      a2: Array<T>,
+      comparator?: Comparator<T>
+    ): Array<T>;
+    xorWith<T>(
+      a1: Array<T>,
+      a2: Array<T>,
+      a3: Array<T>,
+      comparator?: Comparator<T>
+    ): Array<T>;
+    xorWith<T>(
+      a1: Array<T>,
+      a2: Array<T>,
+      a3: Array<T>,
+      a4: Array<T>,
+      comparator?: Comparator<T>
+    ): Array<T>;
+    zip<A, B>(a1?: ?(A[]), a2?: ?(B[])): Array<[A, B]>;
+    zip<A, B, C>(a1: A[], a2: B[], a3: C[]): Array<[A, B, C]>;
+    zip<A, B, C, D>(a1: A[], a2: B[], a3: C[], a4: D[]): Array<[A, B, C, D]>;
+    zip<A, B, C, D, E>(
+      a1: A[],
+      a2: B[],
+      a3: C[],
+      a4: D[],
+      a5: E[]
+    ): Array<[A, B, C, D, E]>;
+
+    zipObject<K, V>(props: Array<K>, values?: ?Array<V>): { [key: K]: V };
+    zipObject<K, V>(props: void | null, values?: ?Array<V>): {};
+    zipObjectDeep(props: any[], values?: ?any): Object;
+    zipObjectDeep(props: void | null, values?: ?any): {};
+
+    zipWith<A>(a1?: ?Array<A>): Array<[A]>;
+    zipWith<T, A>(a1: Array<A>, iteratee: (A) => T): Array<T>;
+
+    zipWith<A, B>(a1: Array<A>, a2: Array<B>): Array<[A, B]>;
+    zipWith<T, A, B>(
+      a1: Array<A>,
+      a2: Array<B>,
+      iteratee: (A, B) => T
+    ): Array<T>;
+
+    zipWith<A, B, C>(
+      a1: Array<A>,
+      a2: Array<B>,
+      a3: Array<C>
+    ): Array<[A, B, C]>;
+    zipWith<T, A, B, C>(
+      a1: Array<A>,
+      a2: Array<B>,
+      a3: Array<C>,
+      iteratee: (A, B, C) => T
+    ): Array<T>;
+
+    zipWith<A, B, C, D>(
+      a1: Array<A>,
+      a2: Array<B>,
+      a3: Array<C>,
+      a4: Array<D>
+    ): Array<[A, B, C, D]>;
+    zipWith<T, A, B, C, D>(
+      a1: Array<A>,
+      a2: Array<B>,
+      a3: Array<C>,
+      a4: Array<D>,
+      iteratee: (A, B, C, D) => T
+    ): Array<T>;
+
+    // Collection
+    countBy<T>(array: Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Object;
+    countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {};
+    countBy<T: Object>(object: T, iteratee?: ?ValueOnlyIteratee<T>): Object;
+    // alias of _.forEach
+    each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
+    each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    each<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
+    // alias of _.forEachRight
+    eachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
+    eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    eachRight<T: Object>(object: T, iteratee?: OIteratee<T>): T;
+    every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
+    every<T: Object>(object: T, iteratee?: OIteratee<T>): boolean;
+    filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
+    filter<A, T: { [id: any]: A }>(
+      object: T,
+      predicate?: OPredicate<A, T>
+    ): Array<A>;
+    find<T>(
+      array: $ReadOnlyArray<T>,
+      predicate?: ?Predicate<T>,
+      fromIndex?: ?number
+    ): T | void;
+    find<T>(
+      array: void | null,
+      predicate?: ?Predicate<T>,
+      fromIndex?: ?number
+    ): void;
+    find<V, A, T: { [id: any]: A }>(
+      object: T,
+      predicate?: OPredicate<A, T>,
+      fromIndex?: number
+    ): V;
+    findLast<T>(
+      array: ?$ReadOnlyArray<T>,
+      predicate?: ?Predicate<T>,
+      fromIndex?: ?number
+    ): T | void;
+    findLast<V, A, T: { [id: any]: A }>(
+      object: T,
+      predicate?: ?OPredicate<A, T>
+    ): V;
+    flatMap<T, U>(
+      array?: ?$ReadOnlyArray<T>,
+      iteratee?: ?FlatMapIteratee<T, U>
+    ): Array<U>;
+    flatMap<T: Object, U>(
+      object: T,
+      iteratee?: OFlatMapIteratee<T, U>
+    ): Array<U>;
+    flatMapDeep<T, U>(
+      array?: ?$ReadOnlyArray<T>,
+      iteratee?: ?FlatMapIteratee<T, U>
+    ): Array<U>;
+    flatMapDeep<T: Object, U>(
+      object: T,
+      iteratee?: ?OFlatMapIteratee<T, U>
+    ): Array<U>;
+    flatMapDepth<T, U>(
+      array?: ?Array<T>,
+      iteratee?: ?FlatMapIteratee<T, U>,
+      depth?: ?number
+    ): Array<U>;
+    flatMapDepth<T: Object, U>(
+      object: T,
+      iteratee?: OFlatMapIteratee<T, U>,
+      depth?: number
+    ): Array<U>;
+    forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
+    forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEach<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
+    forEachRight<T>(
+      array: $ReadOnlyArray<T>,
+      iteratee?: ?Iteratee<T>
+    ): Array<T>;
+    forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEachRight<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
+    groupBy<V, T>(
+      array: $ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): { [key: V]: Array<T> };
+    groupBy(array: void | null, iteratee?: ?ValueOnlyIteratee<any>): {};
+    groupBy<V, A, T: { [id: any]: A }>(
+      object: T,
+      iteratee?: ValueOnlyIteratee<A>
+    ): { [key: V]: Array<A> };
+    includes<T>(
+      array: $ReadOnlyArray<T>,
+      value: T,
+      fromIndex?: ?number
+    ): boolean;
+    includes<T>(array: void | null, value?: ?T, fromIndex?: ?number): false;
+    includes<T: Object>(object: T, value: any, fromIndex?: number): boolean;
+    includes(str: string, value: string, fromIndex?: number): boolean;
+    invokeMap<T>(
+      array?: ?$ReadOnlyArray<T>,
+      path?: ?((value: T) => Path) | Path,
+      ...args?: Array<any>
+    ): Array<any>;
+    invokeMap<T: Object>(
+      object: T,
+      path: ((value: any) => Path) | Path,
+      ...args?: Array<any>
+    ): Array<any>;
+    keyBy<T, V>(
+      array: $ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): { [key: V]: T };
+    keyBy(array: void | null, iteratee?: ?ValueOnlyIteratee<*>): {};
+    keyBy<V, A, I, T: { [id: I]: A }>(
+      object: T,
+      iteratee?: ?ValueOnlyIteratee<A>
+    ): { [key: V]: A };
+    map<T, U>(array?: ?Array<T>, iteratee?: ?MapIterator<T, U>): Array<U>;
+    map<T, U>(
+      array: ?$ReadOnlyArray<T>,
+      iteratee?: ReadOnlyMapIterator<T, U>
+    ): Array<U>;
+    map<V, T: Object, U>(
+      object: ?T,
+      iteratee?: OMapIterator<V, T, U>
+    ): Array<U>;
+    map(
+      str: ?string,
+      iteratee?: (char: string, index: number, str: string) => any
+    ): string;
+    orderBy<T>(
+      array: $ReadOnlyArray<T>,
+      iteratees?: ?$ReadOnlyArray<Iteratee<T>> | ?string,
+      orders?: ?$ReadOnlyArray<"asc" | "desc"> | ?string
+    ): Array<T>;
+    orderBy<T>(
+      array: null | void,
+      iteratees?: ?$ReadOnlyArray<Iteratee<T>> | ?string,
+      orders?: ?$ReadOnlyArray<"asc" | "desc"> | ?string
+    ): Array<T>;
+    orderBy<V, T: {}>(
+      object: T,
+      iteratees?: $ReadOnlyArray<OIteratee<*>> | string,
+      orders?: $ReadOnlyArray<"asc" | "desc"> | string
+    ): Array<V>;
+    partition<T>(
+      array?: ?$ReadOnlyArray<T>,
+      predicate?: ?Predicate<T>
+    ): [Array<T>, Array<T>];
+    partition<V, A, T: { [id: any]: A }>(
+      object: T,
+      predicate?: OPredicate<A, T>
+    ): [Array<V>, Array<V>];
+    reduce<T, U>(
+      array: $ReadOnlyArray<T>,
+      iteratee?: (
+        accumulator: U,
+        value: T,
+        index: number,
+        array: ?Array<T>
+      ) => U,
+      accumulator?: U
+    ): U;
+    reduce<T, U>(
+      array: void | null,
+      iteratee?: ?(
+        accumulator: U,
+        value: T,
+        index: number,
+        array: ?Array<T>
+      ) => U,
+      accumulator?: ?U
+    ): void | null;
+    reduce<T: Object, U>(
+      object: T,
+      iteratee?: (accumulator: U, value: any, key: string, object: T) => U,
+      accumulator?: U
+    ): U;
+    reduceRight<T, U>(
+      array: void | null,
+      iteratee?: ?(
+        accumulator: U,
+        value: T,
+        index: number,
+        array: ?Array<T>
+      ) => U,
+      accumulator?: ?U
+    ): void | null;
+    reduceRight<T, U>(
+      array: $ReadOnlyArray<T>,
+      iteratee?: ?(
+        accumulator: U,
+        value: T,
+        index: number,
+        array: ?Array<T>
+      ) => U,
+      accumulator?: ?U
+    ): U;
+    reduceRight<T: Object, U>(
+      object: T,
+      iteratee?: ?(accumulator: U, value: any, key: string, object: T) => U,
+      accumulator?: ?U
+    ): U;
+    reject<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): Array<T>;
+    reject<V: Object, A, T: { [id: any]: A }>(
+      object?: ?T,
+      predicate?: ?OPredicate<A, T>
+    ): Array<V>;
+    sample<T>(array: ?Array<T>): T;
+    sample<V, T: Object>(object: T): V;
+    sampleSize<T>(array?: ?Array<T>, n?: ?number): Array<T>;
+    sampleSize<V, T: Object>(object: T, n?: number): Array<V>;
+    shuffle<T>(array: ?Array<T>): Array<T>;
+    shuffle<V, T: Object>(object: T): Array<V>;
+    size(collection: $ReadOnlyArray<any> | Object | string): number;
+    some<T>(array: void | null, predicate?: ?Predicate<T>): false;
+    some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
+    some<A, T: { [id: any]: A }>(
+      object?: ?T,
+      predicate?: OPredicate<A, T>
+    ): boolean;
+    sortBy<T>(
+      array: ?$ReadOnlyArray<T>,
+      ...iteratees?: $ReadOnlyArray<Iteratee<T>>
+    ): Array<T>;
+    sortBy<T>(
+      array: ?$ReadOnlyArray<T>,
+      iteratees?: $ReadOnlyArray<Iteratee<T>>
+    ): Array<T>;
+    sortBy<V, T: Object>(
+      object: T,
+      ...iteratees?: Array<OIteratee<T>>
+    ): Array<V>;
+    sortBy<V, T: Object>(
+      object: T,
+      iteratees?: $ReadOnlyArray<OIteratee<T>>
+    ): Array<V>;
+
+    // Date
+    now(): number;
+
+    // Function
+    after(n: number, fn: Function): Function;
+    ary(func: Function, n?: number): Function;
+    before(n: number, fn: Function): Function;
+    bind<F:(...any[]) => any>(func: F, thisArg: any, ...partials: Array<any>): F;
+    bindKey(obj?: ?Object, key?: ?string, ...partials?: Array<?any>): Function;
+    curry: Curry;
+    curry(func: Function, arity?: number): Function;
+    curryRight(func: Function, arity?: number): Function;
+    debounce<F: (...any[]) => any>(func: F, wait?: number, options?: DebounceOptions): F;
+    defer(func: (...any[]) => any, ...args?: Array<any>): TimeoutID;
+    delay(func: Function, wait: number, ...args?: Array<any>): TimeoutID;
+    flip<R>(func: (...any[]) => R): (...any[]) => R;
+    memoize<A, R>(func: (...A) => R, resolver?: (...A) => any): (...A) => R;
+    negate<A, R>(predicate: (...A) => R): (...A) => boolean;
+    once<F: (...any[]) => any>(func: F): F;
+    overArgs(func?: ?Function, ...transforms?: Array<Function>): Function;
+    overArgs(func?: ?Function, transforms?: ?Array<Function>): Function;
+    partial<R>(func: (...any[]) => R, ...partials: any[]): (...any[]) => R;
+    partialRight<R>(func: (...any[]) => R, ...partials: Array<any>): (...any[]) => R;
+    partialRight<R>(func: (...any[]) => R, partials: Array<any>): (...any[]) => R;
+    rearg(func: Function, ...indexes: Array<number>): Function;
+    rearg(func: Function, indexes: Array<number>): Function;
+    rest(func: Function, start?: number): Function;
+    spread(func: Function): Function;
+    throttle<F: (...any[]) => any>(
+      func: F,
+      wait?: number,
+      options?: ThrottleOptions
+    ): F;
+    unary<F: (...any[]) => any>(func: F): F;
+    wrap(value?: any, wrapper?: ?Function): Function;
+
+    // Lang
+    castArray(value: *): any[];
+    clone<T>(value: T): T;
+    cloneDeep<T>(value: T): T;
+    cloneDeepWith<T, U>(
+      value: T,
+      customizer?: ?(value: T, key: number | string, object: T, stack: any) => U
+    ): U;
+    cloneWith<T, U>(
+      value: T,
+      customizer?: ?(value: T, key: number | string, object: T, stack: any) => U
+    ): U;
+    conformsTo<T: { [key: string]: mixed }>(
+      source: T,
+      predicates: T & { [key: string]: (x: any) => boolean }
+    ): boolean;
+    eq(value: any, other: any): boolean;
+    gt(value: any, other: any): boolean;
+    gte(value: any, other: any): boolean;
+    isArguments(value: void | null): false;
+    isArguments(value: any): boolean;
+    isArray(value: Array<any>): true;
+    isArray(value: any): false;
+    isArrayBuffer(value: ArrayBuffer): true;
+    isArrayBuffer(value: any): false;
+    isArrayLike(value: Array<any> | string | { length: number }): true;
+    isArrayLike(value: any): false;
+    isArrayLikeObject(value: { length: number } | Array<any>): true;
+    isArrayLikeObject(value: any): false;
+    isBoolean(value: boolean): true;
+    isBoolean(value: any): false;
+    isBuffer(value: void | null): false;
+    isBuffer(value: any): boolean;
+    isDate(value: Date): true;
+    isDate(value: any): false;
+    isElement(value: Element): true;
+    isElement(value: any): false;
+    isEmpty(value: void | null | "" | {} | [] | number | boolean): true;
+    isEmpty(value: any): boolean;
+    isEqual(value: any, other: any): boolean;
+    isEqualWith<T, U>(
+      value?: ?T,
+      other?: ?U,
+      customizer?: ?(
+        objValue: any,
+        otherValue: any,
+        key: number | string,
+        object: T,
+        other: U,
+        stack: any
+      ) => boolean | void
+    ): boolean;
+    isError(value: Error): true;
+    isError(value: any): false;
+    isFinite(value: number): boolean;
+    isFinite(value: any): false;
+    isFunction(value: Function): true;
+    isFunction(value: any): false;
+    isInteger(value: number): boolean;
+    isInteger(value: any): false;
+    isLength(value: void | null): false;
+    isLength(value: any): boolean;
+    isMap(value: Map<any, any>): true;
+    isMap(value: any): false;
+    isMatch(object?: ?Object, source?: ?Object): boolean;
+    isMatchWith<T: Object, U: Object>(
+      object?: ?T,
+      source?: ?U,
+      customizer?: ?(
+        objValue: any,
+        srcValue: any,
+        key: number | string,
+        object: T,
+        source: U
+      ) => boolean | void
+    ): boolean;
+    isNaN(value: number): boolean;
+    isNaN(value: any): false;
+    isNative(value: number | string | void | null | Object): false;
+    isNative(value: any): boolean;
+    isNil(value: void | null): true;
+    isNil(value: any): false;
+    isNull(value: null): true;
+    isNull(value: any): false;
+    isNumber(value: number): true;
+    isNumber(value: any): false;
+    isObject(value: any): boolean;
+    isObjectLike(value: void | null): false;
+    isObjectLike(value: any): boolean;
+    isPlainObject(value: any): boolean;
+    isRegExp(value: RegExp): true;
+    isRegExp(value: any): false;
+    isSafeInteger(value: number): boolean;
+    isSafeInteger(value: any): false;
+    isSet(value: Set<any>): true;
+    isSet(value: any): false;
+    isString(value: string): true;
+    isString(value: any): false;
+    isSymbol(value: Symbol): true;
+    isSymbol(value: any): false;
+    isTypedArray(value: $TypedArray): true;
+    isTypedArray(value: any): false;
+    isUndefined(value: void): true;
+    isUndefined(value: any): false;
+    isWeakMap(value: WeakMap<any, any>): true;
+    isWeakMap(value: any): false;
+    isWeakSet(value: WeakSet<any>): true;
+    isWeakSet(value: any): false;
+    lt(value: any, other: any): boolean;
+    lte(value: any, other: any): boolean;
+    toArray(value: any): Array<any>;
+    toFinite(value: void | null): 0;
+    toFinite(value: any): number;
+    toInteger(value: void | null): 0;
+    toInteger(value: any): number;
+    toLength(value: void | null): 0;
+    toLength(value: any): number;
+    toNumber(value: void | null): 0;
+    toNumber(value: any): number;
+    toPlainObject(value: any): Object;
+    toSafeInteger(value: void | null): 0;
+    toSafeInteger(value: any): number;
+    toString(value: void | null): "";
+    toString(value: any): string;
+
+    // Math
+    add(augend: number, addend: number): number;
+    ceil(number: number, precision?: number): number;
+    divide(dividend: number, divisor: number): number;
+    floor(number: number, precision?: number): number;
+    max<T>(array: ?Array<T>): T;
+    maxBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T;
+    mean(array: Array<*>): number;
+    meanBy<T>(array: Array<T>, iteratee?: Iteratee<T>): number;
+    min<T>(array: ?Array<T>): T;
+    minBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T;
+    multiply(multiplier: number, multiplicand: number): number;
+    round(number: number, precision?: number): number;
+    subtract(minuend: number, subtrahend: number): number;
+    sum(array: Array<*>): number;
+    sumBy<T>(array: $ReadOnlyArray<T>, iteratee?: Iteratee<T>): number;
+
+    // number
+    clamp(number?: number, lower?: ?number, upper?: ?number): number;
+    clamp(number: ?number, lower?: ?number, upper?: ?number): 0;
+    inRange(number: number, start?: number, end: number): boolean;
+    random(lower?: number, upper?: number, floating?: boolean): number;
+
+    // Object
+    assign(object?: ?Object, ...sources?: Array<?Object>): Object;
+    assignIn(): {};
+    assignIn<A, B>(a: A, b: B): A & B;
+    assignIn<A, B, C>(a: A, b: B, c: C): A & B & C;
+    assignIn<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D;
+    assignIn<A, B, C, D, E>(a: A, b: B, c: C, d: D, e: E): A & B & C & D & E;
+    assignInWith(): {};
+    assignInWith<T: Object, A: Object>(
+      object: T,
+      s1: A,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void
+    ): Object;
+    assignInWith<T: Object, A: Object, B: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B
+      ) => any | void
+    ): Object;
+    assignInWith<T: Object, A: Object, B: Object, C: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      s3: C,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B | C
+      ) => any | void
+    ): Object;
+    assignInWith<T: Object, A: Object, B: Object, C: Object, D: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      s3: C,
+      s4: D,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B | C | D
+      ) => any | void
+    ): Object;
+    assignWith(): {};
+    assignWith<T: Object, A: Object>(
+      object: T,
+      s1: A,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void
+    ): Object;
+    assignWith<T: Object, A: Object, B: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B
+      ) => any | void
+    ): Object;
+    assignWith<T: Object, A: Object, B: Object, C: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      s3: C,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B | C
+      ) => any | void
+    ): Object;
+    assignWith<T: Object, A: Object, B: Object, C: Object, D: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      s3: C,
+      s4: D,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B | C | D
+      ) => any | void
+    ): Object;
+    at(object?: ?Object, ...paths: Array<string>): Array<any>;
+    at(object?: ?Object, paths: Array<string>): Array<any>;
+    create(prototype: void | null, properties: void | null): {};
+    create<T>(prototype: T, properties: Object): T;
+    create(prototype: any, properties: void | null): {};
+    defaults(object?: ?Object, ...sources?: Array<?Object>): Object;
+    defaultsDeep(object?: ?Object, ...sources?: Array<?Object>): Object;
+    // alias for _.toPairs
+    entries(object?: ?Object): Array<[string, any]>;
+    // alias for _.toPairsIn
+    entriesIn(object?: ?Object): Array<[string, any]>;
+    // alias for _.assignIn
+    extend<A, B>(a?: ?A, b?: ?B): A & B;
+    extend<A, B, C>(a: A, b: B, c: C): A & B & C;
+    extend<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D;
+    extend<A, B, C, D, E>(a: A, b: B, c: C, d: D, e: E): A & B & C & D & E;
+    // alias for _.assignInWith
+    extendWith<T: Object, A: Object>(
+      object?: ?T,
+      s1?: ?A,
+      customizer?: ?(
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void
+    ): Object;
+    extendWith<T: Object, A: Object, B: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B
+      ) => any | void
+    ): Object;
+    extendWith<T: Object, A: Object, B: Object, C: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      s3: C,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B | C
+      ) => any | void
+    ): Object;
+    extendWith<T: Object, A: Object, B: Object, C: Object, D: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      s3: C,
+      s4: D,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B | C | D
+      ) => any | void
+    ): Object;
+    findKey<A, T: { [id: any]: A }>(
+      object: T,
+      predicate?: ?OPredicate<A, T>
+    ): string | void;
+    findKey<A, T: { [id: any]: A }>(
+      object: void | null,
+      predicate?: ?OPredicate<A, T>
+    ): void;
+    findLastKey<A, T: { [id: any]: A }>(
+      object: T,
+      predicate?: ?OPredicate<A, T>
+    ): string | void;
+    findLastKey<A, T: { [id: any]: A }>(
+      object: void | null,
+      predicate?: ?OPredicate<A, T>
+    ): void;
+    forIn(object: Object, iteratee?: ?OIteratee<*>): Object;
+    forIn(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forInRight(object: Object, iteratee?: ?OIteratee<*>): Object;
+    forInRight(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forOwn(object: Object, iteratee?: ?OIteratee<*>): Object;
+    forOwn(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forOwnRight(object: Object, iteratee?: ?OIteratee<*>): Object;
+    forOwnRight(object: void | null, iteratee?: ?OIteratee<*>): null;
+    functions(object?: ?Object): Array<string>;
+    functionsIn(object?: ?Object): Array<string>;
+    get(
+      object?: ?Object | ?$ReadOnlyArray<any> | void | null,
+      path?: ?Path,
+      defaultValue?: any
+    ): any;
+    has(object: Object, path: Path): boolean;
+    has(object: Object, path: void | null): false;
+    has(object: void | null, path?: ?Path): false;
+    hasIn(object: Object, path: Path): boolean;
+    hasIn(object: Object, path: void | null): false;
+    hasIn(object: void | null, path?: ?Path): false;
+    invert(object: Object, multiVal?: ?boolean): Object;
+    invert(object: void | null, multiVal?: ?boolean): {};
+    invertBy(object: Object, iteratee?: ?Function): Object;
+    invertBy(object: void | null, iteratee?: ?Function): {};
+    invoke(
+      object?: ?Object,
+      path?: ?Path,
+      ...args?: Array<any>
+    ): any;
+    keys<K>(object?: ?{ [key: K]: any }): Array<K>;
+    keys(object?: ?Object): Array<string>;
+    keysIn(object?: ?Object): Array<string>;
+    mapKeys(object: Object, iteratee?: ?OIteratee<*>): Object;
+    mapKeys(object: void | null, iteratee?: ?OIteratee<*>): {};
+    mapValues(object: Object, iteratee?: ?OIteratee<*>): Object;
+    mapValues(object: void | null, iteratee?: ?OIteratee<*>): {};
+    merge(object?: ?Object, ...sources?: Array<?Object>): Object;
+    mergeWith(): {};
+    mergeWith<T: Object, A: Object>(
+      object: T,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void
+    ): Object;
+    mergeWith<T: Object, A: Object, B: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B
+      ) => any | void
+    ): Object;
+    mergeWith<T: Object, A: Object, B: Object, C: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      s3: C,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B | C
+      ) => any | void
+    ): Object;
+    mergeWith<T: Object, A: Object, B: Object, C: Object, D: Object>(
+      object: T,
+      s1: A,
+      s2: B,
+      s3: C,
+      s4: D,
+      customizer?: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B | C | D
+      ) => any | void
+    ): Object;
+    omit(object?: ?Object, ...props: Array<string>): Object;
+    omit(object?: ?Object, props: Array<string>): Object;
+    omitBy<A, T: { [id: any]: A } | { [id: number]: A }>(
+      object: T,
+      predicate?: ?OPredicate<A, T>
+    ): Object;
+    omitBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {};
+    pick(object?: ?Object, ...props: Array<string>): Object;
+    pick(object?: ?Object, props: Array<string>): Object;
+    pickBy<A, T: { [id: any]: A } | { [id: number]: A }>(
+      object: T,
+      predicate?: ?OPredicate<A, T>
+    ): Object;
+    pickBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {};
+    result(
+      object?: ?Object,
+      path?: ?Path,
+      defaultValue?: any
+    ): any;
+    set(object: Object, path?: ?Path, value: any): Object;
+    set<T: void | null>(
+      object: T,
+      path?: ?Path,
+      value?: ?any
+    ): T;
+    setWith<T>(
+      object: T,
+      path?: ?Path,
+      value: any,
+      customizer?: (nsValue: any, key: string, nsObject: T) => any
+    ): Object;
+    setWith<T: void | null>(
+      object: T,
+      path?: ?Path,
+      value?: ?any,
+      customizer?: ?(nsValue: any, key: string, nsObject: T) => any
+    ): T;
+    toPairs(object?: ?Object | Array<*>): Array<[string, any]>;
+    toPairsIn(object?: ?Object): Array<[string, any]>;
+    transform(
+      collection: Object | $ReadOnlyArray<any>,
+      iteratee?: ?OIteratee<*>,
+      accumulator?: any
+    ): any;
+    transform(
+      collection: void | null,
+      iteratee?: ?OIteratee<*>,
+      accumulator?: ?any
+    ): {};
+    unset(object: void | null, path?: ?Path): true;
+    unset(object: Object, path?: ?Path): boolean;
+    update(object: Object, path: Path, updater: Function): Object;
+    update<T: void | null>(
+      object: T,
+      path?: ?Path,
+      updater?: ?Function
+    ): T;
+    updateWith(
+      object: Object,
+      path?: ?Path,
+      updater?: ?Function,
+      customizer?: ?Function
+    ): Object;
+    updateWith<T: void | null>(
+      object: T,
+      path?: ?Path,
+      updater?: ?Function,
+      customizer?: ?Function
+    ): T;
+    values(object?: ?Object): Array<any>;
+    valuesIn(object?: ?Object): Array<any>;
+
+    // Seq
+    // harder to read, but this is _()
+    (value: any): any;
+    chain<T>(value: T): any;
+    tap<T>(value: T, interceptor: (value: T) => any): T;
+    thru<T1, T2>(value: T1, interceptor: (value: T1) => T2): T2;
+    // TODO: _.prototype.*
+
+    // String
+    camelCase(string: string): string;
+    camelCase(string: void | null): "";
+    capitalize(string: string): string;
+    capitalize(string: void | null): "";
+    deburr(string: string): string;
+    deburr(string: void | null): "";
+    endsWith(string: string, target?: string, position?: ?number): boolean;
+    endsWith(string: void | null, target?: ?string, position?: ?number): false;
+    escape(string: string): string;
+    escape(string: void | null): "";
+    escapeRegExp(string: string): string;
+    escapeRegExp(string: void | null): "";
+    kebabCase(string: string): string;
+    kebabCase(string: void | null): "";
+    lowerCase(string: string): string;
+    lowerCase(string: void | null): "";
+    lowerFirst(string: string): string;
+    lowerFirst(string: void | null): "";
+    pad(string?: ?string, length?: ?number, chars?: ?string): string;
+    padEnd(string?: ?string, length?: ?number, chars?: ?string): string;
+    padStart(string?: ?string, length?: ?number, chars?: ?string): string;
+    parseInt(string: string, radix?: ?number): number;
+    repeat(string: string, n?: ?number): string;
+    repeat(string: void | null, n?: ?number): "";
+    replace(
+      string: string,
+      pattern: RegExp | string,
+      replacement: ((string: string) => string) | string
+    ): string;
+    replace(
+      string: void | null,
+      pattern?: ?RegExp | ?string,
+      replacement: ?((string: string) => string) | ?string
+    ): "";
+    snakeCase(string: string): string;
+    snakeCase(string: void | null): "";
+    split(
+      string?: ?string,
+      separator?: ?RegExp | ?string,
+      limit?: ?number
+    ): Array<string>;
+    startCase(string: string): string;
+    startCase(string: void | null): "";
+    startsWith(string: string, target?: string, position?: number): boolean;
+    startsWith(
+      string: void | null,
+      target?: ?string,
+      position?: ?number
+    ): false;
+    template(string?: ?string, options?: ?TemplateSettings): Function;
+    toLower(string: string): string;
+    toLower(string: void | null): "";
+    toUpper(string: string): string;
+    toUpper(string: void | null): "";
+    trim(string: string, chars?: string): string;
+    trim(string: void | null, chars?: ?string): "";
+    trimEnd(string: string, chars?: ?string): string;
+    trimEnd(string: void | null, chars?: ?string): "";
+    trimStart(string: string, chars?: ?string): string;
+    trimStart(string: void | null, chars?: ?string): "";
+    truncate(string: string, options?: TruncateOptions): string;
+    truncate(string: void | null, options?: ?TruncateOptions): "";
+    unescape(string: string): string;
+    unescape(string: void | null): "";
+    upperCase(string: string): string;
+    upperCase(string: void | null): "";
+    upperFirst(string: string): string;
+    upperFirst(string: void | null): "";
+    words(string?: ?string, pattern?: ?RegExp | ?string): Array<string>;
+
+    // Util
+    attempt(func: Function, ...args: Array<any>): any;
+    bindAll(object: Object, methodNames?: ?Array<string>): Object;
+    bindAll<T: void | null>(object: T, methodNames?: ?Array<string>): T;
+    bindAll(object: Object, ...methodNames: Array<string>): Object;
+    cond(pairs?: ?NestedArray<Function>): Function;
+    conforms(source?: ?Object): Function;
+    constant<T>(value: T): () => T;
+    defaultTo<T1: void | null, T2>(value: T1, defaultValue: T2): T2;
+    defaultTo<T1: string | boolean, T2>(
+      value: T1,
+      defaultValue: T2
+    ): T1;
+    // NaN is a number instead of its own type, otherwise it would behave like null/void
+    defaultTo<T1: number, T2>(value: T1, defaultValue: T2): T1 | T2;
+    flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    flowRight: $Compose & ((funcs: Array<Function>) => Function);
+    identity<T>(value: T): T;
+    iteratee(func?: any): Function;
+    matches(source?: ?Object): Function;
+    matchesProperty(path?: ?Path, srcValue: any): Function;
+    method(path?: ?Path, ...args?: Array<any>): Function;
+    methodOf(object?: ?Object, ...args?: Array<any>): Function;
+    mixin<T: Function | Object>(
+      object?: T,
+      source: Object,
+      options?: { chain: boolean }
+    ): T;
+    noConflict(): Lodash;
+    noop(...args: Array<mixed>): void;
+    nthArg(n?: ?number): Function;
+    over(...iteratees: Array<Function>): Function;
+    over(iteratees: Array<Function>): Function;
+    overEvery(...predicates: Array<Function>): Function;
+    overEvery(predicates: Array<Function>): Function;
+    overSome(...predicates: Array<Function>): Function;
+    overSome(predicates: Array<Function>): Function;
+    property(path?: ?Path): Function;
+    propertyOf(object?: ?Object): Function;
+    range(start: number, end: number, step?: number): Array<number>;
+    range(end: number, step?: number): Array<number>;
+    rangeRight(start?: ?number, end?: ?number, step?: ?number): Array<number>;
+    rangeRight(end?: ?number, step?: ?number): Array<number>;
+    runInContext(context?: ?Object): Function;
+
+    stubArray(): Array<*>;
+    stubFalse(): false;
+    stubObject(): {};
+    stubString(): "";
+    stubTrue(): true;
+    times(n?: ?number, ...rest?: Array<void | null>): Array<number>;
+    times<T>(n: number, iteratee: (i: number) => T): Array<T>;
+    toPath(value: any): Array<string>;
+    uniqueId(prefix?: ?string): string;
+
+    // Properties
+    VERSION: string;
+    templateSettings: TemplateSettings;
+  }
+
+  declare module.exports: Lodash;
+}
+
+declare module "lodash/fp" {
+  declare type Path = $ReadOnlyArray<string | number> | string | number;
+  declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
+  declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>;
+
+  declare type __CurriedFunction2<A, B, R, AA: A, BB: B> = ((
+    ...r: [AA]
+  ) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB]) => R);
+  declare type CurriedFunction2<A, B, R> = __CurriedFunction2<A, B, R, *, *>;
+
+  declare type __CurriedFunction3<A, B, C, R, AA: A, BB: B, CC: C> = ((
+    ...r: [AA]
+  ) => CurriedFunction2<BB, CC, R>) &
+    ((...r: [AA, BB]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC]) => R);
+  declare type CurriedFunction3<A, B, C, R> = __CurriedFunction3<
+    A,
+    B,
+    C,
+    R,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D
+  > = ((...r: [AA]) => CurriedFunction3<BB, CC, DD, R>) &
+    ((...r: [AA, BB]) => CurriedFunction2<CC, DD, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction1<DD, R>) &
+    ((...r: [AA, BB, CC, DD]) => R);
+  declare type CurriedFunction4<A, B, C, D, R> = __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E
+  > = ((...r: [AA]) => CurriedFunction4<BB, CC, DD, EE, R>) &
+    ((...r: [AA, BB]) => CurriedFunction3<CC, DD, EE, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction2<DD, EE, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction1<EE, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => R);
+  declare type CurriedFunction5<A, B, C, D, E, R> = __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E,
+    FF: F
+  > = ((...r: [AA]) => CurriedFunction5<BB, CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB]) => CurriedFunction4<CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction3<DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction2<EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => CurriedFunction1<FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE, FF]) => R);
+  declare type CurriedFunction6<A, B, C, D, E, F, R> = __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type Curry = (<A, R>((...r: [A]) => R) => CurriedFunction1<A, R>) &
+    (<A, B, R>((...r: [A, B]) => R) => CurriedFunction2<A, B, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R) => CurriedFunction3<A, B, C, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R
+    ) => CurriedFunction4<A, B, C, D, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R
+    ) => CurriedFunction5<A, B, C, D, E, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R
+    ) => CurriedFunction6<A, B, C, D, E, F, R>);
+
+  declare type UnaryFn<A, R> = (a: A) => R;
+
+  declare type TemplateSettings = {
+    escape?: RegExp,
+    evaluate?: RegExp,
+    imports?: Object,
+    interpolate?: RegExp,
+    variable?: string
+  };
+
+  declare type TruncateOptions = {
+    length?: number,
+    omission?: string,
+    separator?: RegExp | string
+  };
+
+  declare type DebounceOptions = {
+    leading?: boolean,
+    maxWait?: number,
+    trailing?: boolean
+  };
+
+  declare type ThrottleOptions = {
+    leading?: boolean,
+    trailing?: boolean
+  };
+
+  declare type NestedArray<T> = Array<Array<T>>;
+
+  declare type matchesIterateeShorthand = {[string | number]: any};
+  declare type matchesPropertyIterateeShorthand = [string, any];
+  declare type propertyIterateeShorthand = string;
+
+  declare type OPredicate<A> =
+    | ((value: A) => any)
+    | matchesIterateeShorthand
+    | matchesPropertyIterateeShorthand
+    | propertyIterateeShorthand;
+
+  declare type OIterateeWithResult<V, R> = Object | string | ((value: V) => R);
+  declare type OIteratee<O> = OIterateeWithResult<any, any>;
+  declare type OFlatMapIteratee<T, U> = OIterateeWithResult<any, Array<U>>;
+
+  declare type Predicate<T> =
+    | ((value: T) => any)
+    | matchesIterateeShorthand
+    | matchesPropertyIterateeShorthand
+    | propertyIterateeShorthand;
+
+  declare type _ValueOnlyIteratee<T> = (value: T) => mixed;
+  declare type ValueOnlyIteratee<T> = _ValueOnlyIteratee<T> | string;
+  declare type _Iteratee<T> = (item: T) => mixed;
+  declare type Iteratee<T> = _Iteratee<T> | Object | string;
+  declare type FlatMapIteratee<T, U> =
+    | ((item: T) => Array<U>)
+    | Object
+    | string;
+  declare type Comparator<T> = (item: T, item2: T) => boolean;
+
+  declare type MapIterator<T, U> = ((item: T) => U) | propertyIterateeShorthand;
+
+  declare type OMapIterator<T, U> =
+    | ((item: T) => U)
+    | propertyIterateeShorthand;
+
+  declare class Lodash {
+    // Array
+    chunk<T>(size: number): (array: Array<T>) => Array<Array<T>>;
+    chunk<T>(size: number, array: Array<T>): Array<Array<T>>;
+    compact<T, N: ?T>(array?: ?$ReadOnlyArray<N>): Array<T>;
+    concat<T, U, A: Array<T> | T, B: Array<U> | U>(
+      base: A
+    ): (elements: B) => Array<T | U>;
+    concat<T, U, A: Array<T> | T, B: Array<U> | U>(
+      base: A,
+      elements: B
+    ): Array<T | U>;
+    difference<T>(values: $ReadOnlyArray<T>): (array: $ReadOnlyArray<T>) => T[];
+    difference<T>(values: $ReadOnlyArray<T>, array: $ReadOnlyArray<T>): T[];
+    differenceBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): ((values: $ReadOnlyArray<T>) => (array: $ReadOnlyArray<T>) => T[]) &
+      ((values: $ReadOnlyArray<T>, array: $ReadOnlyArray<T>) => T[]);
+    differenceBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      values: $ReadOnlyArray<T>
+    ): (array: $ReadOnlyArray<T>) => T[];
+    differenceBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      values: $ReadOnlyArray<T>,
+      array: $ReadOnlyArray<T>
+    ): T[];
+    differenceWith<T>(
+      comparator: Comparator<T>
+    ): ((first: $ReadOnly<T>) => (second: $ReadOnly<T>) => T[]) &
+      ((first: $ReadOnly<T>, second: $ReadOnly<T>) => T[]);
+    differenceWith<T>(
+      comparator: Comparator<T>,
+      first: $ReadOnly<T>
+    ): (second: $ReadOnly<T>) => T[];
+    differenceWith<T>(
+      comparator: Comparator<T>,
+      first: $ReadOnly<T>,
+      second: $ReadOnly<T>
+    ): T[];
+    drop<T>(n: number): (array: Array<T>) => Array<T>;
+    drop<T>(n: number, array: Array<T>): Array<T>;
+    dropLast<T>(n: number): (array: Array<T>) => Array<T>;
+    dropLast<T>(n: number, array: Array<T>): Array<T>;
+    dropRight<T>(n: number): (array: Array<T>) => Array<T>;
+    dropRight<T>(n: number, array: Array<T>): Array<T>;
+    dropRightWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
+    dropRightWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
+    dropWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
+    dropWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
+    dropLastWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
+    dropLastWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
+    fill<T, U>(
+      start: number
+    ): ((
+      end: number
+    ) => ((value: U) => (array: Array<T>) => Array<T | U>) &
+      ((value: U, array: Array<T>) => Array<T | U>)) &
+      ((end: number, value: U) => (array: Array<T>) => Array<T | U>) &
+      ((end: number, value: U, array: Array<T>) => Array<T | U>);
+    fill<T, U>(
+      start: number,
+      end: number
+    ): ((value: U) => (array: Array<T>) => Array<T | U>) &
+      ((value: U, array: Array<T>) => Array<T | U>);
+    fill<T, U>(
+      start: number,
+      end: number,
+      value: U
+    ): (array: Array<T>) => Array<T | U>;
+    fill<T, U>(
+      start: number,
+      end: number,
+      value: U,
+      array: Array<T>
+    ): Array<T | U>;
+    findIndex<T>(predicate: Predicate<T>): (array: $ReadOnlyArray<T>) => number;
+    findIndex<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): number;
+    findIndexFrom<T>(
+      predicate: Predicate<T>
+    ): ((fromIndex: number) => (array: $ReadOnlyArray<T>) => number) &
+      ((fromIndex: number, array: $ReadOnlyArray<T>) => number);
+    findIndexFrom<T>(
+      predicate: Predicate<T>,
+      fromIndex: number
+    ): (array: $ReadOnlyArray<T>) => number;
+    findIndexFrom<T>(
+      predicate: Predicate<T>,
+      fromIndex: number,
+      array: $ReadOnlyArray<T>
+    ): number;
+    findLastIndex<T>(
+      predicate: Predicate<T>
+    ): (array: $ReadOnlyArray<T>) => number;
+    findLastIndex<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): number;
+    findLastIndexFrom<T>(
+      predicate: Predicate<T>
+    ): ((fromIndex: number) => (array: $ReadOnlyArray<T>) => number) &
+      ((fromIndex: number, array: $ReadOnlyArray<T>) => number);
+    findLastIndexFrom<T>(
+      predicate: Predicate<T>,
+      fromIndex: number
+    ): (array: $ReadOnlyArray<T>) => number;
+    findLastIndexFrom<T>(
+      predicate: Predicate<T>,
+      fromIndex: number,
+      array: $ReadOnlyArray<T>
+    ): number;
+    // alias of _.head
+    first<T>(array: $ReadOnlyArray<T>): T;
+    flatten<T, X>(array: Array<Array<T> | X>): Array<T | X>;
+    unnest<T, X>(array: Array<Array<T> | X>): Array<T | X>;
+    flattenDeep<T>(array: any[]): Array<T>;
+    flattenDepth(depth: number): (array: any[]) => any[];
+    flattenDepth(depth: number, array: any[]): any[];
+    fromPairs<A, B>(pairs: Array<[A, B]>): { [key: A]: B };
+    head<T>(array: $ReadOnlyArray<T>): T;
+    indexOf<T>(value: T): (array: Array<T>) => number;
+    indexOf<T>(value: T, array: Array<T>): number;
+    indexOfFrom<T>(
+      value: T
+    ): ((fromIndex: number) => (array: Array<T>) => number) &
+      ((fromIndex: number, array: Array<T>) => number);
+    indexOfFrom<T>(value: T, fromIndex: number): (array: Array<T>) => number;
+    indexOfFrom<T>(value: T, fromIndex: number, array: Array<T>): number;
+    initial<T>(array: Array<T>): Array<T>;
+    init<T>(array: Array<T>): Array<T>;
+    intersection<T>(a1: Array<T>): (a2: Array<T>) => Array<T>;
+    intersection<T>(a1: Array<T>, a2: Array<T>): Array<T>;
+    intersectionBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
+      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    intersectionBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      a1: Array<T>
+    ): (a2: Array<T>) => Array<T>;
+    intersectionBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      a1: Array<T>,
+      a2: Array<T>
+    ): Array<T>;
+    intersectionWith<T>(
+      comparator: Comparator<T>
+    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
+      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    intersectionWith<T>(
+      comparator: Comparator<T>,
+      a1: Array<T>
+    ): (a2: Array<T>) => Array<T>;
+    intersectionWith<T>(
+      comparator: Comparator<T>,
+      a1: Array<T>,
+      a2: Array<T>
+    ): Array<T>;
+    join<T>(separator: string): (array: Array<T>) => string;
+    join<T>(separator: string, array: Array<T>): string;
+    last<T>(array: Array<T>): T;
+    lastIndexOf<T>(value: T): (array: Array<T>) => number;
+    lastIndexOf<T>(value: T, array: Array<T>): number;
+    lastIndexOfFrom<T>(
+      value: T
+    ): ((fromIndex: number) => (array: Array<T>) => number) &
+      ((fromIndex: number, array: Array<T>) => number);
+    lastIndexOfFrom<T>(
+      value: T,
+      fromIndex: number
+    ): (array: Array<T>) => number;
+    lastIndexOfFrom<T>(value: T, fromIndex: number, array: Array<T>): number;
+    nth<T>(n: number): (array: T[]) => T;
+    nth<T>(n: number, array: T[]): T;
+    pull<T>(value: T): (array: Array<T>) => Array<T>;
+    pull<T>(value: T, array: Array<T>): Array<T>;
+    pullAll<T>(values: Array<T>): (array: Array<T>) => Array<T>;
+    pullAll<T>(values: Array<T>, array: Array<T>): Array<T>;
+    pullAllBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): ((values: Array<T>) => (array: Array<T>) => Array<T>) &
+      ((values: Array<T>, array: Array<T>) => Array<T>);
+    pullAllBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      values: Array<T>
+    ): (array: Array<T>) => Array<T>;
+    pullAllBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      values: Array<T>,
+      array: Array<T>
+    ): Array<T>;
+    pullAllWith<T>(
+      comparator: Function
+    ): ((values: T[]) => (array: T[]) => T[]) &
+      ((values: T[], array: T[]) => T[]);
+    pullAllWith<T>(comparator: Function, values: T[]): (array: T[]) => T[];
+    pullAllWith<T>(comparator: Function, values: T[], array: T[]): T[];
+    pullAt<T>(indexed: Array<number>): (array: Array<T>) => Array<T>;
+    pullAt<T>(indexed: Array<number>, array: Array<T>): Array<T>;
+    remove<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
+    remove<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
+    reverse<T>(array: Array<T>): Array<T>;
+    slice<T>(
+      start: number
+    ): ((end: number) => (array: Array<T>) => Array<T>) &
+      ((end: number, array: Array<T>) => Array<T>);
+    slice<T>(start: number, end: number): (array: Array<T>) => Array<T>;
+    slice<T>(start: number, end: number, array: Array<T>): Array<T>;
+    sortedIndex<T>(value: T): (array: Array<T>) => number;
+    sortedIndex<T>(value: T, array: Array<T>): number;
+    sortedIndexBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): ((value: T) => (array: Array<T>) => number) &
+      ((value: T, array: Array<T>) => number);
+    sortedIndexBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      value: T
+    ): (array: Array<T>) => number;
+    sortedIndexBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      value: T,
+      array: Array<T>
+    ): number;
+    sortedIndexOf<T>(value: T): (array: Array<T>) => number;
+    sortedIndexOf<T>(value: T, array: Array<T>): number;
+    sortedLastIndex<T>(value: T): (array: Array<T>) => number;
+    sortedLastIndex<T>(value: T, array: Array<T>): number;
+    sortedLastIndexBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): ((value: T) => (array: Array<T>) => number) &
+      ((value: T, array: Array<T>) => number);
+    sortedLastIndexBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      value: T
+    ): (array: Array<T>) => number;
+    sortedLastIndexBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      value: T,
+      array: Array<T>
+    ): number;
+    sortedLastIndexOf<T>(value: T): (array: Array<T>) => number;
+    sortedLastIndexOf<T>(value: T, array: Array<T>): number;
+    sortedUniq<T>(array: Array<T>): Array<T>;
+    sortedUniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: Array<T>): Array<T>;
+    tail<T>(array: Array<T>): Array<T>;
+    take<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    take<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
+    takeRight<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    takeRight<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
+    takeLast<T>(n: number): (array: Array<T>) => Array<T>;
+    takeLast<T>(n: number, array: Array<T>): Array<T>;
+    takeRightWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
+    takeRightWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
+    takeLastWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
+    takeLastWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
+    takeWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
+    takeWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
+    union<T>(a1: Array<T>): (a2: Array<T>) => Array<T>;
+    union<T>(a1: Array<T>, a2: Array<T>): Array<T>;
+    unionBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
+      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    unionBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      a1: Array<T>
+    ): (a2: Array<T>) => Array<T>;
+    unionBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      a1: Array<T>,
+      a2: Array<T>
+    ): Array<T>;
+    unionWith<T>(
+      comparator: Comparator<T>
+    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
+      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    unionWith<T>(
+      comparator: Comparator<T>,
+      a1: Array<T>
+    ): (a2: Array<T>) => Array<T>;
+    unionWith<T>(
+      comparator: Comparator<T>,
+      a1: Array<T>,
+      a2: Array<T>
+    ): Array<T>;
+    uniq<T>(array: Array<T>): Array<T>;
+    uniqBy<T>(iteratee: ValueOnlyIteratee<T>): (array: Array<T>) => Array<T>;
+    uniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: Array<T>): Array<T>;
+    uniqWith<T>(comparator: Comparator<T>): (array: Array<T>) => Array<T>;
+    uniqWith<T>(comparator: Comparator<T>, array: Array<T>): Array<T>;
+    unzip<T>(array: Array<T>): Array<T>;
+    unzipWith<T>(iteratee: Iteratee<T>): (array: Array<T>) => Array<T>;
+    unzipWith<T>(iteratee: Iteratee<T>, array: Array<T>): Array<T>;
+    without<T>(values: Array<T>): (array: Array<T>) => Array<T>;
+    without<T>(values: Array<T>, array: Array<T>): Array<T>;
+    xor<T>(a1: Array<T>): (a2: Array<T>) => Array<T>;
+    xor<T>(a1: Array<T>, a2: Array<T>): Array<T>;
+    symmetricDifference<T>(a1: Array<T>): (a2: Array<T>) => Array<T>;
+    symmetricDifference<T>(a1: Array<T>, a2: Array<T>): Array<T>;
+    xorBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
+      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    xorBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      a1: Array<T>
+    ): (a2: Array<T>) => Array<T>;
+    xorBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      a1: Array<T>,
+      a2: Array<T>
+    ): Array<T>;
+    symmetricDifferenceBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
+      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    symmetricDifferenceBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      a1: Array<T>
+    ): (a2: Array<T>) => Array<T>;
+    symmetricDifferenceBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      a1: Array<T>,
+      a2: Array<T>
+    ): Array<T>;
+    xorWith<T>(
+      comparator: Comparator<T>
+    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
+      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    xorWith<T>(
+      comparator: Comparator<T>,
+      a1: Array<T>
+    ): (a2: Array<T>) => Array<T>;
+    xorWith<T>(comparator: Comparator<T>, a1: Array<T>, a2: Array<T>): Array<T>;
+    symmetricDifferenceWith<T>(
+      comparator: Comparator<T>
+    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
+      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    symmetricDifferenceWith<T>(
+      comparator: Comparator<T>,
+      a1: Array<T>
+    ): (a2: Array<T>) => Array<T>;
+    symmetricDifferenceWith<T>(
+      comparator: Comparator<T>,
+      a1: Array<T>,
+      a2: Array<T>
+    ): Array<T>;
+    zip<A, B>(a1: A[]): (a2: B[]) => Array<[A, B]>;
+    zip<A, B>(a1: A[], a2: B[]): Array<[A, B]>;
+    zipAll(arrays: Array<Array<any>>): Array<any>;
+    zipObject<K, V>(props?: Array<K>): (values?: Array<V>) => { [key: K]: V };
+    zipObject<K, V>(props?: Array<K>, values?: Array<V>): { [key: K]: V };
+    zipObj(props: Array<any>): (values: Array<any>) => Object;
+    zipObj(props: Array<any>, values: Array<any>): Object;
+    zipObjectDeep(props: any[]): (values: any) => Object;
+    zipObjectDeep(props: any[], values: any): Object;
+    zipWith<T>(
+      iteratee: Iteratee<T>
+    ): ((a1: NestedArray<T>) => (a2: NestedArray<T>) => Array<T>) &
+      ((a1: NestedArray<T>, a2: NestedArray<T>) => Array<T>);
+    zipWith<T>(
+      iteratee: Iteratee<T>,
+      a1: NestedArray<T>
+    ): (a2: NestedArray<T>) => Array<T>;
+    zipWith<T>(
+      iteratee: Iteratee<T>,
+      a1: NestedArray<T>,
+      a2: NestedArray<T>
+    ): Array<T>;
+    // Collection
+    countBy<T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): (collection: Array<T> | { [id: any]: T }) => { [string]: number };
+    countBy<T>(
+      iteratee: ValueOnlyIteratee<T>,
+      collection: Array<T> | { [id: any]: T }
+    ): { [string]: number };
+    // alias of _.forEach
+    each<T>(
+      iteratee: Iteratee<T> | OIteratee<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>;
+    each<T>(
+      iteratee: Iteratee<T> | OIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): Array<T>;
+    // alias of _.forEachRight
+    eachRight<T>(
+      iteratee: Iteratee<T> | OIteratee<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>;
+    eachRight<T>(
+      iteratee: Iteratee<T> | OIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): Array<T>;
+    every<T>(
+      iteratee: Iteratee<T> | OIteratee<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => boolean;
+    every<T>(
+      iteratee: Iteratee<T> | OIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): boolean;
+    all<T>(
+      iteratee: Iteratee<T> | OIteratee<T>
+    ): (collection: Array<T> | { [id: any]: T }) => boolean;
+    all<T>(
+      iteratee: Iteratee<T> | OIteratee<T>,
+      collection: Array<T> | { [id: any]: T }
+    ): boolean;
+    filter<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>;
+    filter<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): Array<T>;
+    find<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void;
+    find<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): T | void;
+    findFrom<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): ((
+      fromIndex: number
+    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void) &
+      ((
+        fromIndex: number,
+        collection: $ReadOnlyArray<T> | { [id: any]: T }
+      ) => T | void);
+    findFrom<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      fromIndex: number
+    ): (collection: Array<T> | { [id: any]: T }) => T | void;
+    findFrom<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      fromIndex: number,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): T | void;
+    findLast<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void;
+    findLast<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): T | void;
+    findLastFrom<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): ((
+      fromIndex: number
+    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void) &
+      ((
+        fromIndex: number,
+        collection: $ReadOnlyArray<T> | { [id: any]: T }
+      ) => T | void);
+    findLastFrom<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      fromIndex: number
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void;
+    findLastFrom<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      fromIndex: number,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): T | void;
+    flatMap<T, U>(
+      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
+    ): (collection: Array<T> | { [id: any]: T }) => Array<U>;
+    flatMap<T, U>(
+      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
+      collection: Array<T> | { [id: any]: T }
+    ): Array<U>;
+    flatMapDeep<T, U>(
+      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
+    ): (collection: Array<T> | { [id: any]: T }) => Array<U>;
+    flatMapDeep<T, U>(
+      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
+      collection: Array<T> | { [id: any]: T }
+    ): Array<U>;
+    flatMapDepth<T, U>(
+      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
+    ): ((
+      depth: number
+    ) => (collection: Array<T> | { [id: any]: T }) => Array<U>) &
+      ((depth: number, collection: Array<T> | { [id: any]: T }) => Array<U>);
+    flatMapDepth<T, U>(
+      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
+      depth: number
+    ): (collection: Array<T> | { [id: any]: T }) => Array<U>;
+    flatMapDepth<T, U>(
+      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
+      depth: number,
+      collection: Array<T> | { [id: any]: T }
+    ): Array<U>;
+    forEach<T>(
+      iteratee: Iteratee<T> | OIteratee<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>;
+    forEach<T>(
+      iteratee: Iteratee<T> | OIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): Array<T>;
+    forEachRight<T>(
+      iteratee: Iteratee<T> | OIteratee<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>;
+    forEachRight<T>(
+      iteratee: Iteratee<T> | OIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): Array<T>;
+    groupBy<V, T>(
+      iteratee: ValueOnlyIteratee<T>
+    ): (
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ) => { [key: V]: Array<T> };
+    groupBy<V, T>(
+      iteratee: ValueOnlyIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): { [key: V]: Array<T> };
+    includes<T>(value: T): (collection: Array<T> | { [id: any]: T }) => boolean;
+    includes<T>(value: T, collection: Array<T> | { [id: any]: T }): boolean;
+    includes(value: string): (str: string) => boolean;
+    includes(value: string, str: string): boolean;
+    contains(value: string): (str: string) => boolean;
+    contains(value: string, str: string): boolean;
+    contains<T>(value: T): (collection: Array<T> | { [id: any]: T }) => boolean;
+    contains<T>(value: T, collection: Array<T> | { [id: any]: T }): boolean;
+    includesFrom(
+      value: string
+    ): ((fromIndex: number) => (str: string) => boolean) &
+      ((fromIndex: number, str: string) => boolean);
+    includesFrom(value: string, fromIndex: number): (str: string) => boolean;
+    includesFrom(value: string, fromIndex: number, str: string): boolean;
+    includesFrom<T>(
+      value: T
+    ): ((fromIndex: number) => (collection: Array<T>) => boolean) &
+      ((fromIndex: number, collection: Array<T>) => boolean);
+    includesFrom<T>(
+      value: T,
+      fromIndex: number
+    ): (collection: Array<T>) => boolean;
+    includesFrom<T>(value: T, fromIndex: number, collection: Array<T>): boolean;
+    invokeMap<T>(
+      path: ((value: T) => Path) | Path
+    ): (collection: Array<T> | { [id: any]: T }) => Array<any>;
+    invokeMap<T>(
+      path: ((value: T) => Path) | Path,
+      collection: Array<T> | { [id: any]: T }
+    ): Array<any>;
+    invokeArgsMap<T>(
+      path: ((value: T) => Path) | Path
+    ): ((
+      collection: Array<T> | { [id: any]: T }
+    ) => (args: Array<any>) => Array<any>) &
+      ((
+        collection: Array<T> | { [id: any]: T },
+        args: Array<any>
+      ) => Array<any>);
+    invokeArgsMap<T>(
+      path: ((value: T) => Path) | Path,
+      collection: Array<T> | { [id: any]: T }
+    ): (args: Array<any>) => Array<any>;
+    invokeArgsMap<T>(
+      path: ((value: T) => Path) | Path,
+      collection: Array<T> | { [id: any]: T },
+      args: Array<any>
+    ): Array<any>;
+    keyBy<T, V>(
+      iteratee: ValueOnlyIteratee<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => { [key: V]: T };
+    keyBy<T, V>(
+      iteratee: ValueOnlyIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): { [key: V]: T };
+    indexBy<T, V>(
+      iteratee: ValueOnlyIteratee<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => { [key: V]: T };
+    indexBy<T, V>(
+      iteratee: ValueOnlyIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): { [key: V]: T };
+    map<T, U>(
+      iteratee: MapIterator<T, U> | OMapIterator<T, U>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<U>;
+    map<T, U>(
+      iteratee: MapIterator<T, U> | OMapIterator<T, U>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): Array<U>;
+    map(iteratee: (char: string) => any): (str: string) => string;
+    map(iteratee: (char: string) => any, str: string): string;
+    pluck<T, U>(
+      iteratee: MapIterator<T, U> | OMapIterator<T, U>
+    ): (collection: Array<T> | { [id: any]: T }) => Array<U>;
+    pluck<T, U>(
+      iteratee: MapIterator<T, U> | OMapIterator<T, U>,
+      collection: Array<T> | { [id: any]: T }
+    ): Array<U>;
+    pluck(iteratee: (char: string) => any): (str: string) => string;
+    pluck(iteratee: (char: string) => any, str: string): string;
+    orderBy<T>(
+      iteratees: $ReadOnlyArray<Iteratee<T> | OIteratee<*>> | string
+    ): ((
+      orders: $ReadOnlyArray<"asc" | "desc"> | string
+    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>) &
+      ((
+        orders: $ReadOnlyArray<"asc" | "desc"> | string,
+        collection: $ReadOnlyArray<T> | { [id: any]: T }
+      ) => Array<T>);
+    orderBy<T>(
+      iteratees: $ReadOnlyArray<Iteratee<T> | OIteratee<*>> | string,
+      orders: $ReadOnlyArray<"asc" | "desc"> | string
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>;
+    orderBy<T>(
+      iteratees: $ReadOnlyArray<Iteratee<T> | OIteratee<*>> | string,
+      orders: $ReadOnlyArray<"asc" | "desc"> | string,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): Array<T>;
+    partition<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): (collection: Array<T> | { [id: any]: T }) => [Array<T>, Array<T>];
+    partition<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      collection: Array<T> | { [id: any]: T }
+    ): [Array<T>, Array<T>];
+    reduce<T, U>(
+      iteratee: (accumulator: U, value: T) => U
+    ): ((accumulator: U) => (collection: Array<T> | { [id: any]: T }) => U) &
+      ((accumulator: U, collection: Array<T> | { [id: any]: T }) => U);
+    reduce<T, U>(
+      iteratee: (accumulator: U, value: T) => U,
+      accumulator: U
+    ): (collection: Array<T> | { [id: any]: T }) => U;
+    reduce<T, U>(
+      iteratee: (accumulator: U, value: T) => U,
+      accumulator: U,
+      collection: Array<T> | { [id: any]: T }
+    ): U;
+    reduceRight<T, U>(
+      iteratee: (value: T, accumulator: U) => U
+    ): ((accumulator: U) => (collection: Array<T> | { [id: any]: T }) => U) &
+      ((accumulator: U, collection: Array<T> | { [id: any]: T }) => U);
+    reduceRight<T, U>(
+      iteratee: (value: T, accumulator: U) => U,
+      accumulator: U
+    ): (collection: Array<T> | { [id: any]: T }) => U;
+    reduceRight<T, U>(
+      iteratee: (value: T, accumulator: U) => U,
+      accumulator: U,
+      collection: Array<T> | { [id: any]: T }
+    ): U;
+    reject<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): (collection: Array<T> | { [id: any]: T }) => Array<T>;
+    reject<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      collection: Array<T> | { [id: any]: T }
+    ): Array<T>;
+    sample<T>(collection: Array<T> | { [id: any]: T }): T;
+    sampleSize<T>(
+      n: number
+    ): (collection: Array<T> | { [id: any]: T }) => Array<T>;
+    sampleSize<T>(n: number, collection: Array<T> | { [id: any]: T }): Array<T>;
+    shuffle<T>(collection: Array<T> | { [id: any]: T }): Array<T>;
+    size(collection: $ReadOnlyArray<any> | Object | string): number;
+    some<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => boolean;
+    some<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): boolean;
+    any<T>(
+      predicate: Predicate<T> | OPredicate<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => boolean;
+    any<T>(
+      predicate: Predicate<T> | OPredicate<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): boolean;
+    sortBy<T>(
+      iteratees:
+        | $ReadOnlyArray<Iteratee<T> | OIteratee<T>>
+        | Iteratee<T>
+        | OIteratee<T>
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>;
+    sortBy<T>(
+      iteratees:
+        | $ReadOnlyArray<Iteratee<T> | OIteratee<T>>
+        | Iteratee<T>
+        | OIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
+    ): Array<T>;
+
+    // Date
+    now(): number;
+
+    // Function
+    after(fn: Function): (n: number) => Function;
+    after(fn: Function, n: number): Function;
+    ary(func: Function): Function;
+    nAry(n: number): (func: Function) => Function;
+    nAry(n: number, func: Function): Function;
+    before(fn: Function): (n: number) => Function;
+    before(fn: Function, n: number): Function;
+    bind(func: Function): (thisArg: any) => Function;
+    bind(func: Function, thisArg: any): Function;
+    bindKey(obj: Object): (key: string) => Function;
+    bindKey(obj: Object, key: string): Function;
+    curry: Curry;
+    curryN(arity: number): (func: Function) => Function;
+    curryN(arity: number, func: Function): Function;
+    curryRight(func: Function): Function;
+    curryRightN(arity: number): (func: Function) => Function;
+    curryRightN(arity: number, func: Function): Function;
+    debounce(wait: number): <A, R>(func: (...A) => R) => (...A) => R;
+    debounce<A, R>(wait: number, func: (...A) => R): (...A) => R;
+    defer(func: (...any[]) => any): TimeoutID;
+    delay(wait: number): (func: Function) => TimeoutID;
+    delay(wait: number, func: Function): TimeoutID;
+    flip(func: Function): Function;
+    memoize<F: Function>(func: F): F;
+    negate<A, R>(predicate: (...A) => R): (...A) => boolean;
+    complement(predicate: Function): Function;
+    once(func: Function): Function;
+    overArgs(func: Function): (transforms: Array<Function>) => Function;
+    overArgs(func: Function, transforms: Array<Function>): Function;
+    useWith(func: Function): (transforms: Array<Function>) => Function;
+    useWith(func: Function, transforms: Array<Function>): Function;
+    partial(func: Function): (partials: any[]) => Function;
+    partial(func: Function, partials: any[]): Function;
+    partialRight(func: Function): (partials: Array<any>) => Function;
+    partialRight(func: Function, partials: Array<any>): Function;
+    rearg(indexes: Array<number>): (func: Function) => Function;
+    rearg(indexes: Array<number>, func: Function): Function;
+    rest(func: Function): Function;
+    unapply(func: Function): Function;
+    restFrom(start: number): (func: Function) => Function;
+    restFrom(start: number, func: Function): Function;
+    spread(func: Function): Function;
+    apply(func: Function): Function;
+    spreadFrom(start: number): (func: Function) => Function;
+    spreadFrom(start: number, func: Function): Function;
+    throttle<A, R>(wait: number): (func: (...A) => R) => (...A) => R;
+    throttle<A, R>(wait: number, func: (...A) => R): (...A) => R;
+    unary<T, R>(func: (T, ...any[]) => R): (T) => R;
+    wrap(wrapper: Function): (value: any) => Function;
+    wrap(wrapper: Function, value: any): Function;
+
+    // Lang
+    castArray(value: *): any[];
+    clone<T>(value: T): T;
+    cloneDeep<T>(value: T): T;
+    cloneDeepWith<T, U>(
+      customizer: (value: T, key: number | string, object: T, stack: any) => U
+    ): (value: T) => U;
+    cloneDeepWith<T, U>(
+      customizer: (value: T, key: number | string, object: T, stack: any) => U,
+      value: T
+    ): U;
+    cloneWith<T, U>(
+      customizer: (value: T, key: number | string, object: T, stack: any) => U
+    ): (value: T) => U;
+    cloneWith<T, U>(
+      customizer: (value: T, key: number | string, object: T, stack: any) => U,
+      value: T
+    ): U;
+    conformsTo<T: { [key: string]: mixed }>(
+      predicates: T & { [key: string]: (x: any) => boolean }
+    ): (source: T) => boolean;
+    conformsTo<T: { [key: string]: mixed }>(
+      predicates: T & { [key: string]: (x: any) => boolean },
+      source: T
+    ): boolean;
+    where<T: { [key: string]: mixed }>(
+      predicates: T & { [key: string]: (x: any) => boolean }
+    ): (source: T) => boolean;
+    where<T: { [key: string]: mixed }>(
+      predicates: T & { [key: string]: (x: any) => boolean },
+      source: T
+    ): boolean;
+    conforms<T: { [key: string]: mixed }>(
+      predicates: T & { [key: string]: (x: any) => boolean }
+    ): (source: T) => boolean;
+    conforms<T: { [key: string]: mixed }>(
+      predicates: T & { [key: string]: (x: any) => boolean },
+      source: T
+    ): boolean;
+    eq(value: any): (other: any) => boolean;
+    eq(value: any, other: any): boolean;
+    identical(value: any): (other: any) => boolean;
+    identical(value: any, other: any): boolean;
+    gt(value: any): (other: any) => boolean;
+    gt(value: any, other: any): boolean;
+    gte(value: any): (other: any) => boolean;
+    gte(value: any, other: any): boolean;
+    isArguments(value: any): boolean;
+    isArray(value: any): boolean;
+    isArrayBuffer(value: any): boolean;
+    isArrayLike(value: any): boolean;
+    isArrayLikeObject(value: any): boolean;
+    isBoolean(value: any): boolean;
+    isBuffer(value: any): boolean;
+    isDate(value: any): boolean;
+    isElement(value: any): boolean;
+    isEmpty(value: any): boolean;
+    isEqual(value: any): (other: any) => boolean;
+    isEqual(value: any, other: any): boolean;
+    equals(value: any): (other: any) => boolean;
+    equals(value: any, other: any): boolean;
+    isEqualWith<T, U>(
+      customizer: (
+        objValue: any,
+        otherValue: any,
+        key: number | string,
+        object: T,
+        other: U,
+        stack: any
+      ) => boolean | void
+    ): ((value: T) => (other: U) => boolean) &
+      ((value: T, other: U) => boolean);
+    isEqualWith<T, U>(
+      customizer: (
+        objValue: any,
+        otherValue: any,
+        key: number | string,
+        object: T,
+        other: U,
+        stack: any
+      ) => boolean | void,
+      value: T
+    ): (other: U) => boolean;
+    isEqualWith<T, U>(
+      customizer: (
+        objValue: any,
+        otherValue: any,
+        key: number | string,
+        object: T,
+        other: U,
+        stack: any
+      ) => boolean | void,
+      value: T,
+      other: U
+    ): boolean;
+    isError(value: any): boolean;
+    isFinite(value: any): boolean;
+    isFunction(value: any): boolean;
+    isInteger(value: any): boolean;
+    isLength(value: any): boolean;
+    isMap(value: any): boolean;
+    isMatch(source: Object): (object: Object) => boolean;
+    isMatch(source: Object, object: Object): boolean;
+    whereEq(source: Object): (object: Object) => boolean;
+    whereEq(source: Object, object: Object): boolean;
+    isMatchWith<T: Object, U: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: number | string,
+        object: T,
+        source: U
+      ) => boolean | void
+    ): ((source: U) => (object: T) => boolean) &
+      ((source: U, object: T) => boolean);
+    isMatchWith<T: Object, U: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: number | string,
+        object: T,
+        source: U
+      ) => boolean | void,
+      source: U
+    ): (object: T) => boolean;
+    isMatchWith<T: Object, U: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: number | string,
+        object: T,
+        source: U
+      ) => boolean | void,
+      source: U,
+      object: T
+    ): boolean;
+    isNaN(value: any): boolean;
+    isNative(value: any): boolean;
+    isNil(value: any): boolean;
+    isNull(value: any): boolean;
+    isNumber(value: any): boolean;
+    isObject(value: any): boolean;
+    isObjectLike(value: any): boolean;
+    isPlainObject(value: any): boolean;
+    isRegExp(value: any): boolean;
+    isSafeInteger(value: any): boolean;
+    isSet(value: any): boolean;
+    isString(value: string): true;
+    isString(value: any): false;
+    isSymbol(value: any): boolean;
+    isTypedArray(value: any): boolean;
+    isUndefined(value: any): boolean;
+    isWeakMap(value: any): boolean;
+    isWeakSet(value: any): boolean;
+    lt(value: any): (other: any) => boolean;
+    lt(value: any, other: any): boolean;
+    lte(value: any): (other: any) => boolean;
+    lte(value: any, other: any): boolean;
+    toArray(value: any): Array<any>;
+    toFinite(value: any): number;
+    toInteger(value: any): number;
+    toLength(value: any): number;
+    toNumber(value: any): number;
+    toPlainObject(value: any): Object;
+    toSafeInteger(value: any): number;
+    toString(value: any): string;
+
+    // Math
+    add(augend: number): (addend: number) => number;
+    add(augend: number, addend: number): number;
+    ceil(number: number): number;
+    divide(dividend: number): (divisor: number) => number;
+    divide(dividend: number, divisor: number): number;
+    floor(number: number): number;
+    max<T>(array: Array<T>): T;
+    maxBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => T;
+    maxBy<T>(iteratee: Iteratee<T>, array: Array<T>): T;
+    mean(array: Array<*>): number;
+    meanBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => number;
+    meanBy<T>(iteratee: Iteratee<T>, array: Array<T>): number;
+    min<T>(array: Array<T>): T;
+    minBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => T;
+    minBy<T>(iteratee: Iteratee<T>, array: Array<T>): T;
+    multiply(multiplier: number): (multiplicand: number) => number;
+    multiply(multiplier: number, multiplicand: number): number;
+    round(number: number): number;
+    subtract(minuend: number): (subtrahend: number) => number;
+    subtract(minuend: number, subtrahend: number): number;
+    sum(array: Array<*>): number;
+    sumBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => number;
+    sumBy<T>(iteratee: Iteratee<T>, array: Array<T>): number;
+
+    // number
+    clamp(
+      lower: number
+    ): ((upper: number) => (number: number) => number) &
+      ((upper: number, number: number) => number);
+    clamp(lower: number, upper: number): (number: number) => number;
+    clamp(lower: number, upper: number, number: number): number;
+    inRange(
+      start: number
+    ): ((end: number) => (number: number) => boolean) &
+      ((end: number, number: number) => boolean);
+    inRange(start: number, end: number): (number: number) => boolean;
+    inRange(start: number, end: number, number: number): boolean;
+    random(lower: number): (upper: number) => number;
+    random(lower: number, upper: number): number;
+
+    // Object
+    assign(object: Object): (source: Object) => Object;
+    assign(object: Object, source: Object): Object;
+    assignAll(objects: Array<Object>): Object;
+    assignInAll(objects: Array<Object>): Object;
+    extendAll(objects: Array<Object>): Object;
+    assignIn<A, B>(a: A): (b: B) => A & B;
+    assignIn<A, B>(a: A, b: B): A & B;
+    assignInWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void
+    ): ((object: T) => (s1: A) => Object) & ((object: T, s1: A) => Object);
+    assignInWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void,
+      object: T
+    ): (s1: A) => Object;
+    assignInWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void,
+      object: T,
+      s1: A
+    ): Object;
+    assignWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void
+    ): ((object: T) => (s1: A) => Object) & ((object: T, s1: A) => Object);
+    assignWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void,
+      object: T
+    ): (s1: A) => Object;
+    assignWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void,
+      object: T,
+      s1: A
+    ): Object;
+    assignInAllWith(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: Object,
+        source: Object
+      ) => any | void
+    ): (objects: Array<Object>) => Object;
+    assignInAllWith(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: Object,
+        source: Object
+      ) => any | void,
+      objects: Array<Object>
+    ): Object;
+    extendAllWith(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: Object,
+        source: Object
+      ) => any | void
+    ): (objects: Array<Object>) => Object;
+    extendAllWith(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: Object,
+        source: Object
+      ) => any | void,
+      objects: Array<Object>
+    ): Object;
+    assignAllWith(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: Object,
+        source: Object
+      ) => any | void
+    ): (objects: Array<Object>) => Object;
+    assignAllWith(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: Object,
+        source: Object
+      ) => any | void,
+      objects: Array<Object>
+    ): Object;
+    at(paths: Array<string>): (object: Object) => Array<any>;
+    at(paths: Array<string>, object: Object): Array<any>;
+    props(paths: Array<string>): (object: Object) => Array<any>;
+    props(paths: Array<string>, object: Object): Array<any>;
+    paths(paths: Array<string>): (object: Object) => Array<any>;
+    paths(paths: Array<string>, object: Object): Array<any>;
+    create<T>(prototype: T): T;
+    defaults(source: Object): (object: Object) => Object;
+    defaults(source: Object, object: Object): Object;
+    defaultsAll(objects: Array<Object>): Object;
+    defaultsDeep(source: Object): (object: Object) => Object;
+    defaultsDeep(source: Object, object: Object): Object;
+    defaultsDeepAll(objects: Array<Object>): Object;
+    // alias for _.toPairs
+    entries(object: Object): Array<[string, any]>;
+    // alias for _.toPairsIn
+    entriesIn(object: Object): Array<[string, any]>;
+    // alias for _.assignIn
+    extend<A, B>(a: A): (b: B) => A & B;
+    extend<A, B>(a: A, b: B): A & B;
+    // alias for _.assignInWith
+    extendWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void
+    ): ((object: T) => (s1: A) => Object) & ((object: T, s1: A) => Object);
+    extendWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void,
+      object: T
+    ): (s1: A) => Object;
+    extendWith<T: Object, A: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A
+      ) => any | void,
+      object: T,
+      s1: A
+    ): Object;
+    findKey<A, T: { [id: any]: A }>(
+      predicate: OPredicate<A>
+    ): (object: T) => string | void;
+    findKey<A, T: { [id: any]: A }>(
+      predicate: OPredicate<A>,
+      object: T
+    ): string | void;
+    findLastKey<A, T: { [id: any]: A }>(
+      predicate: OPredicate<A>
+    ): (object: T) => string | void;
+    findLastKey<A, T: { [id: any]: A }>(
+      predicate: OPredicate<A>,
+      object: T
+    ): string | void;
+    forIn(iteratee: OIteratee<*>): (object: Object) => Object;
+    forIn(iteratee: OIteratee<*>, object: Object): Object;
+    forInRight(iteratee: OIteratee<*>): (object: Object) => Object;
+    forInRight(iteratee: OIteratee<*>, object: Object): Object;
+    forOwn(iteratee: OIteratee<*>): (object: Object) => Object;
+    forOwn(iteratee: OIteratee<*>, object: Object): Object;
+    forOwnRight(iteratee: OIteratee<*>): (object: Object) => Object;
+    forOwnRight(iteratee: OIteratee<*>, object: Object): Object;
+    functions(object: Object): Array<string>;
+    functionsIn(object: Object): Array<string>;
+    get(
+      path: Path
+    ): (object: Object | $ReadOnlyArray<any> | void | null) => any;
+    get(
+      path: Path,
+      object: Object | $ReadOnlyArray<any> | void | null
+    ): any;
+    prop(path: Path): (object: Object | Array<any>) => any;
+    prop(path: Path, object: Object | Array<any>): any;
+    path(path: Path): (object: Object | Array<any>) => any;
+    path(path: Path, object: Object | Array<any>): any;
+    getOr(
+      defaultValue: any
+    ): ((
+      path: Path
+    ) => (object: Object | Array<any>) => any) &
+      ((
+        path: Path,
+        object: Object | $ReadOnlyArray<any> | void | null
+      ) => any);
+    getOr(
+      defaultValue: any,
+      path: Path
+    ): (object: Object | $ReadOnlyArray<any> | void | null) => any;
+    getOr(
+      defaultValue: any,
+      path: Path,
+      object: Object | $ReadOnlyArray<any> | void | null
+    ): any;
+    propOr(
+      defaultValue: any
+    ): ((
+      path: Path
+    ) => (object: Object | Array<any>) => any) &
+      ((path: Path, object: Object | Array<any>) => any);
+    propOr(
+      defaultValue: any,
+      path: Path
+    ): (object: Object | Array<any>) => any;
+    propOr(
+      defaultValue: any,
+      path: Path,
+      object: Object | Array<any>
+    ): any;
+    pathOr(
+      defaultValue: any
+    ): ((
+      path: Path
+    ) => (object: Object | Array<any>) => any) &
+      ((path: Path, object: Object | Array<any>) => any);
+    pathOr(
+      defaultValue: any,
+      path: Path
+    ): (object: Object | Array<any>) => any;
+    pathOr(
+      defaultValue: any,
+      path: Path,
+      object: Object | Array<any>
+    ): any;
+    has(path: Path): (object: Object) => boolean;
+    has(path: Path, object: Object): boolean;
+    hasIn(path: Path): (object: Object) => boolean;
+    hasIn(path: Path, object: Object): boolean;
+    invert(object: Object): Object;
+    invertObj(object: Object): Object;
+    invertBy(iteratee: Function): (object: Object) => Object;
+    invertBy(iteratee: Function, object: Object): Object;
+    invoke(path: Path): (object: Object) => any;
+    invoke(path: Path, object: Object): any;
+    invokeArgs(
+      path: Path
+    ): ((object: Object) => (args: Array<any>) => any) &
+      ((object: Object, args: Array<any>) => any);
+    invokeArgs(
+      path: Path,
+      object: Object
+    ): (args: Array<any>) => any;
+    invokeArgs(
+      path: Path,
+      object: Object,
+      args: Array<any>
+    ): any;
+    keys<K>(object: { [key: K]: any }): Array<K>;
+    keys(object: Object): Array<string>;
+    keysIn(object: Object): Array<string>;
+    mapKeys(iteratee: OIteratee<*>): (object: Object) => Object;
+    mapKeys(iteratee: OIteratee<*>, object: Object): Object;
+    mapValues(iteratee: OIteratee<*>): (object: Object) => Object;
+    mapValues(iteratee: OIteratee<*>, object: Object): Object;
+    merge(object: Object): (source: Object) => Object;
+    merge(object: Object, source: Object): Object;
+    mergeAll(objects: Array<Object>): Object;
+    mergeWith<T: Object, A: Object, B: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B
+      ) => any | void
+    ): ((object: T) => (s1: A) => Object) & ((object: T, s1: A) => Object);
+    mergeWith<T: Object, A: Object, B: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B
+      ) => any | void,
+      object: T
+    ): (s1: A) => Object;
+    mergeWith<T: Object, A: Object, B: Object>(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: T,
+        source: A | B
+      ) => any | void,
+      object: T,
+      s1: A
+    ): Object;
+    mergeAllWith(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: Object,
+        source: Object
+      ) => any | void
+    ): (objects: Array<Object>) => Object;
+    mergeAllWith(
+      customizer: (
+        objValue: any,
+        srcValue: any,
+        key: string,
+        object: Object,
+        source: Object
+      ) => any | void,
+      objects: Array<Object>
+    ): Object;
+    omit(props: Array<string>): (object: Object) => Object;
+    omit(props: Array<string>, object: Object): Object;
+    omitAll(props: Array<string>): (object: Object) => Object;
+    omitAll(props: Array<string>, object: Object): Object;
+    omitBy<A, T: { [id: any]: A }>(
+      predicate: OPredicate<A>
+    ): (object: T) => Object;
+    omitBy<A, T: { [id: any]: A }>(predicate: OPredicate<A>, object: T): Object;
+    pick(props: Array<string>): (object: Object) => Object;
+    pick(props: Array<string>, object: Object): Object;
+    pickAll(props: Array<string>): (object: Object) => Object;
+    pickAll(props: Array<string>, object: Object): Object;
+    pickBy<A, T: { [id: any]: A }>(
+      predicate: OPredicate<A>
+    ): (object: T) => Object;
+    pickBy<A, T: { [id: any]: A }>(predicate: OPredicate<A>, object: T): Object;
+    result(path: Path): (object: Object) => any;
+    result(path: Path, object: Object): any;
+    set(
+      path: Path
+    ): ((value: any) => (object: Object) => Object) &
+      ((value: any, object: Object) => Object);
+    set(path: Path, value: any): (object: Object) => Object;
+    set(path: Path, value: any, object: Object): Object;
+    assoc(
+      path: Path
+    ): ((value: any) => (object: Object) => Object) &
+      ((value: any, object: Object) => Object);
+    assoc(path: Path, value: any): (object: Object) => Object;
+    assoc(path: Path, value: any, object: Object): Object;
+    assocPath(
+      path: Path
+    ): ((value: any) => (object: Object) => Object) &
+      ((value: any, object: Object) => Object);
+    assocPath(
+      path: Path,
+      value: any
+    ): (object: Object) => Object;
+    assocPath(path: Path, value: any, object: Object): Object;
+    setWith<T>(
+      customizer: (nsValue: any, key: string, nsObject: T) => any
+    ): ((
+      path: Path
+    ) => ((value: any) => (object: T) => Object) &
+      ((value: any, object: T) => Object)) &
+      ((path: Path, value: any) => (object: T) => Object) &
+      ((path: Path, value: any, object: T) => Object);
+    setWith<T>(
+      customizer: (nsValue: any, key: string, nsObject: T) => any,
+      path: Path
+    ): ((value: any) => (object: T) => Object) &
+      ((value: any, object: T) => Object);
+    setWith<T>(
+      customizer: (nsValue: any, key: string, nsObject: T) => any,
+      path: Path,
+      value: any
+    ): (object: T) => Object;
+    setWith<T>(
+      customizer: (nsValue: any, key: string, nsObject: T) => any,
+      path: Path,
+      value: any,
+      object: T
+    ): Object;
+    toPairs(object: Object | Array<*>): Array<[string, any]>;
+    toPairsIn(object: Object): Array<[string, any]>;
+    transform(
+      iteratee: OIteratee<*>
+    ): ((
+      accumulator: any
+    ) => (collection: Object | $ReadOnlyArray<any>) => any) &
+      ((accumulator: any, collection: Object | $ReadOnlyArray<any>) => any);
+    transform(
+      iteratee: OIteratee<*>,
+      accumulator: any
+    ): (collection: Object | $ReadOnlyArray<any>) => any;
+    transform(
+      iteratee: OIteratee<*>,
+      accumulator: any,
+      collection: Object | $ReadOnlyArray<any>
+    ): any;
+    unset(path: Path): (object: Object) => Object;
+    unset(path: Path, object: Object): Object;
+    dissoc(path: Path): (object: Object) => Object;
+    dissoc(path: Path, object: Object): Object;
+    dissocPath(path: Path): (object: Object) => Object;
+    dissocPath(path: Path, object: Object): Object;
+    update(
+      path: Path
+    ): ((updater: Function) => (object: Object) => Object) &
+      ((updater: Function, object: Object) => Object);
+    update(
+      path: Path,
+      updater: Function
+    ): (object: Object) => Object;
+    update(path: Path, updater: Function, object: Object): Object;
+    updateWith(
+      customizer: Function
+    ): ((
+      path: Path
+    ) => ((updater: Function) => (object: Object) => Object) &
+      ((updater: Function, object: Object) => Object)) &
+      ((
+        path: Path,
+        updater: Function
+      ) => (object: Object) => Object) &
+      ((path: Path, updater: Function, object: Object) => Object);
+    updateWith(
+      customizer: Function,
+      path: Path
+    ): ((updater: Function) => (object: Object) => Object) &
+      ((updater: Function, object: Object) => Object);
+    updateWith(
+      customizer: Function,
+      path: Path,
+      updater: Function
+    ): (object: Object) => Object;
+    updateWith(
+      customizer: Function,
+      path: Path,
+      updater: Function,
+      object: Object
+    ): Object;
+    values(object: Object): Array<any>;
+    valuesIn(object: Object): Array<any>;
+
+    tap<T>(interceptor: (value: T) => any): (value: T) => T;
+    tap<T>(interceptor: (value: T) => any, value: T): T;
+    thru<T1, T2>(interceptor: (value: T1) => T2): (value: T1) => T2;
+    thru<T1, T2>(interceptor: (value: T1) => T2, value: T1): T2;
+
+    // String
+    camelCase(string: string): string;
+    capitalize(string: string): string;
+    deburr(string: string): string;
+    endsWith(target: string): (string: string) => boolean;
+    endsWith(target: string, string: string): boolean;
+    escape(string: string): string;
+    escapeRegExp(string: string): string;
+    kebabCase(string: string): string;
+    lowerCase(string: string): string;
+    lowerFirst(string: string): string;
+    pad(length: number): (string: string) => string;
+    pad(length: number, string: string): string;
+    padChars(
+      chars: string
+    ): ((length: number) => (string: string) => string) &
+      ((length: number, string: string) => string);
+    padChars(chars: string, length: number): (string: string) => string;
+    padChars(chars: string, length: number, string: string): string;
+    padEnd(length: number): (string: string) => string;
+    padEnd(length: number, string: string): string;
+    padCharsEnd(
+      chars: string
+    ): ((length: number) => (string: string) => string) &
+      ((length: number, string: string) => string);
+    padCharsEnd(chars: string, length: number): (string: string) => string;
+    padCharsEnd(chars: string, length: number, string: string): string;
+    padStart(length: number): (string: string) => string;
+    padStart(length: number, string: string): string;
+    padCharsStart(
+      chars: string
+    ): ((length: number) => (string: string) => string) &
+      ((length: number, string: string) => string);
+    padCharsStart(chars: string, length: number): (string: string) => string;
+    padCharsStart(chars: string, length: number, string: string): string;
+    parseInt(radix: number): (string: string) => number;
+    parseInt(radix: number, string: string): number;
+    repeat(n: number): (string: string) => string;
+    repeat(n: number, string: string): string;
+    replace(
+      pattern: RegExp | string
+    ): ((
+      replacement: ((string: string) => string) | string
+    ) => (string: string) => string) &
+      ((
+        replacement: ((string: string) => string) | string,
+        string: string
+      ) => string);
+    replace(
+      pattern: RegExp | string,
+      replacement: ((string: string) => string) | string
+    ): (string: string) => string;
+    replace(
+      pattern: RegExp | string,
+      replacement: ((string: string) => string) | string,
+      string: string
+    ): string;
+    snakeCase(string: string): string;
+    split(separator: RegExp | string): (string: string) => Array<string>;
+    split(separator: RegExp | string, string: string): Array<string>;
+    startCase(string: string): string;
+    startsWith(target: string): (string: string) => boolean;
+    startsWith(target: string, string: string): boolean;
+    template(string: string): Function;
+    toLower(string: string): string;
+    toUpper(string: string): string;
+    trim(string: string): string;
+    trimChars(chars: string): (string: string) => string;
+    trimChars(chars: string, string: string): string;
+    trimEnd(string: string): string;
+    trimCharsEnd(chars: string): (string: string) => string;
+    trimCharsEnd(chars: string, string: string): string;
+    trimStart(string: string): string;
+    trimCharsStart(chars: string): (string: string) => string;
+    trimCharsStart(chars: string, string: string): string;
+    truncate(options: TruncateOptions): (string: string) => string;
+    truncate(options: TruncateOptions, string: string): string;
+    unescape(string: string): string;
+    upperCase(string: string): string;
+    upperFirst(string: string): string;
+    words(string: string): Array<string>;
+
+    // Util
+    attempt(func: Function): any;
+    bindAll(methodNames: Array<string>): (object: Object) => Object;
+    bindAll(methodNames: Array<string>, object: Object): Object;
+    cond(pairs: NestedArray<Function>): Function;
+    constant<T>(value: T): () => T;
+    always<T>(value: T): () => T;
+    defaultTo<T1: void | null, T2>(defaultValue: T2): (value: T1) => T2;
+    defaultTo<T1: void | null, T2>(defaultValue: T2, value: T1): T2;
+    defaultTo<T1: string | boolean, T2>(
+      defaultValue: T2
+    ): (value: T1) => T1;
+    defaultTo<T1: string | boolean, T2>(
+      defaultValue: T2,
+      value: T1
+    ): T1;
+    // NaN is a number instead of its own type, otherwise it would behave like null/void
+    defaultTo<T1: number, T2>(defaultValue: T2): (value: T1) => T1 | T2;
+    defaultTo<T1: number, T2>(defaultValue: T2, value: T1): T1 | T2;
+    flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    pipe: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    flowRight: $Compose & ((funcs: Array<Function>) => Function);
+    compose: $Compose & ((funcs: Array<Function>) => Function);
+    compose(funcs: Array<Function>): Function;
+    identity<T>(value: T): T;
+    iteratee(func: any): Function;
+    matches(source: Object): (object: Object) => boolean;
+    matches(source: Object, object: Object): boolean;
+    matchesProperty(path: Path): (srcValue: any) => Function;
+    matchesProperty(path: Path, srcValue: any): Function;
+    propEq(path: Path): (srcValue: any) => Function;
+    propEq(path: Path, srcValue: any): Function;
+    pathEq(path: Path): (srcValue: any) => Function;
+    pathEq(path: Path, srcValue: any): Function;
+    method(path: Path): Function;
+    methodOf(object: Object): Function;
+    mixin<T: Function | Object>(
+      object: T
+    ): ((source: Object) => (options: { chain: boolean }) => T) &
+      ((source: Object, options: { chain: boolean }) => T);
+    mixin<T: Function | Object>(
+      object: T,
+      source: Object
+    ): (options: { chain: boolean }) => T;
+    mixin<T: Function | Object>(
+      object: T,
+      source: Object,
+      options: { chain: boolean }
+    ): T;
+    noConflict(): Lodash;
+    noop(...args: Array<mixed>): void;
+    nthArg(n: number): Function;
+    over(iteratees: Array<Function>): Function;
+    juxt(iteratees: Array<Function>): Function;
+    overEvery(predicates: Array<Function>): Function;
+    allPass(predicates: Array<Function>): Function;
+    overSome(predicates: Array<Function>): Function;
+    anyPass(predicates: Array<Function>): Function;
+    property(
+      path: Path
+    ): (object: Object | Array<any>) => any;
+    property(path: Path, object: Object | Array<any>): any;
+    propertyOf(object: Object): (path: Path) => Function;
+    propertyOf(object: Object, path: Path): Function;
+    range(start: number): (end: number) => Array<number>;
+    range(start: number, end: number): Array<number>;
+    rangeStep(
+      step: number
+    ): ((start: number) => (end: number) => Array<number>) &
+      ((start: number, end: number) => Array<number>);
+    rangeStep(step: number, start: number): (end: number) => Array<number>;
+    rangeStep(step: number, start: number, end: number): Array<number>;
+    rangeRight(start: number): (end: number) => Array<number>;
+    rangeRight(start: number, end: number): Array<number>;
+    rangeStepRight(
+      step: number
+    ): ((start: number) => (end: number) => Array<number>) &
+      ((start: number, end: number) => Array<number>);
+    rangeStepRight(step: number, start: number): (end: number) => Array<number>;
+    rangeStepRight(step: number, start: number, end: number): Array<number>;
+    runInContext(context: Object): Function;
+
+    stubArray(): Array<*>;
+    stubFalse(): false;
+    F(): false;
+    stubObject(): {};
+    stubString(): "";
+    stubTrue(): true;
+    T(): true;
+    times<T>(iteratee: (i: number) => T): (n: number) => Array<T>;
+    times<T>(iteratee: (i: number) => T, n: number): Array<T>;
+    toPath(value: any): Array<string>;
+    uniqueId(prefix: string): string;
+
+    __: any;
+    placeholder: any;
+
+    convert(options: {
+      cap?: boolean,
+      curry?: boolean,
+      fixed?: boolean,
+      immutable?: boolean,
+      rearg?: boolean
+    }): void;
+
+    // Properties
+    VERSION: string;
+    templateSettings: TemplateSettings;
+  }
+
+  declare module.exports: Lodash;
+}
+
+declare module "lodash/chunk" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "chunk">;
+}
+
+declare module "lodash/compact" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "compact">;
+}
+
+declare module "lodash/concat" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "concat">;
+}
+
+declare module "lodash/difference" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "difference">;
+}
+
+declare module "lodash/differenceBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "differenceBy">;
+}
+
+declare module "lodash/differenceWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "differenceWith">;
+}
+
+declare module "lodash/drop" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "drop">;
+}
+
+declare module "lodash/dropRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "dropRight">;
+}
+
+declare module "lodash/dropRightWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "dropRightWhile">;
+}
+
+declare module "lodash/dropWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "dropWhile">;
+}
+
+declare module "lodash/fill" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "fill">;
+}
+
+declare module "lodash/findIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "findIndex">;
+}
+
+declare module "lodash/findLastIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "findLastIndex">;
+}
+
+declare module "lodash/first" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "first">;
+}
+
+declare module "lodash/flatten" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flatten">;
+}
+
+declare module "lodash/flattenDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flattenDeep">;
+}
+
+declare module "lodash/flattenDepth" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flattenDepth">;
+}
+
+declare module "lodash/fromPairs" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "fromPairs">;
+}
+
+declare module "lodash/head" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "head">;
+}
+
+declare module "lodash/indexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "indexOf">;
+}
+
+declare module "lodash/initial" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "initial">;
+}
+
+declare module "lodash/intersection" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "intersection">;
+}
+
+declare module "lodash/intersectionBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "intersectionBy">;
+}
+
+declare module "lodash/intersectionWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "intersectionWith">;
+}
+
+declare module "lodash/join" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "join">;
+}
+
+declare module "lodash/last" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "last">;
+}
+
+declare module "lodash/lastIndexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "lastIndexOf">;
+}
+
+declare module "lodash/nth" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "nth">;
+}
+
+declare module "lodash/pull" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "pull">;
+}
+
+declare module "lodash/pullAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "pullAll">;
+}
+
+declare module "lodash/pullAllBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "pullAllBy">;
+}
+
+declare module "lodash/pullAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "pullAllWith">;
+}
+
+declare module "lodash/pullAt" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "pullAt">;
+}
+
+declare module "lodash/remove" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "remove">;
+}
+
+declare module "lodash/reverse" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "reverse">;
+}
+
+declare module "lodash/slice" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "slice">;
+}
+
+declare module "lodash/sortedIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sortedIndex">;
+}
+
+declare module "lodash/sortedIndexBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sortedIndexBy">;
+}
+
+declare module "lodash/sortedIndexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sortedIndexOf">;
+}
+
+declare module "lodash/sortedLastIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sortedLastIndex">;
+}
+
+declare module "lodash/sortedLastIndexBy" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash">,
+    "sortedLastIndexBy"
+  >;
+}
+
+declare module "lodash/sortedLastIndexOf" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash">,
+    "sortedLastIndexOf"
+  >;
+}
+
+declare module "lodash/sortedUniq" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sortedUniq">;
+}
+
+declare module "lodash/sortedUniqBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sortedUniqBy">;
+}
+
+declare module "lodash/tail" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "tail">;
+}
+
+declare module "lodash/take" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "take">;
+}
+
+declare module "lodash/takeRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "takeRight">;
+}
+
+declare module "lodash/takeRightWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "takeRightWhile">;
+}
+
+declare module "lodash/takeWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "takeWhile">;
+}
+
+declare module "lodash/union" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "union">;
+}
+
+declare module "lodash/unionBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "unionBy">;
+}
+
+declare module "lodash/unionWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "unionWith">;
+}
+
+declare module "lodash/uniq" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "uniq">;
+}
+
+declare module "lodash/uniqBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "uniqBy">;
+}
+
+declare module "lodash/uniqWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "uniqWith">;
+}
+
+declare module "lodash/unzip" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "unzip">;
+}
+
+declare module "lodash/unzipWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "unzipWith">;
+}
+
+declare module "lodash/without" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "without">;
+}
+
+declare module "lodash/xor" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "xor">;
+}
+
+declare module "lodash/xorBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "xorBy">;
+}
+
+declare module "lodash/xorWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "xorWith">;
+}
+
+declare module "lodash/zip" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "zip">;
+}
+
+declare module "lodash/zipObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "zipObject">;
+}
+
+declare module "lodash/zipObjectDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "zipObjectDeep">;
+}
+
+declare module "lodash/zipWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "zipWith">;
+}
+
+declare module "lodash/countBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "countBy">;
+}
+
+declare module "lodash/each" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "each">;
+}
+
+declare module "lodash/eachRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "eachRight">;
+}
+
+declare module "lodash/every" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "every">;
+}
+
+declare module "lodash/filter" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "filter">;
+}
+
+declare module "lodash/find" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "find">;
+}
+
+declare module "lodash/findLast" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "findLast">;
+}
+
+declare module "lodash/flatMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flatMap">;
+}
+
+declare module "lodash/flatMapDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flatMapDeep">;
+}
+
+declare module "lodash/flatMapDepth" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flatMapDepth">;
+}
+
+declare module "lodash/forEach" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "forEach">;
+}
+
+declare module "lodash/forEachRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "forEachRight">;
+}
+
+declare module "lodash/groupBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "groupBy">;
+}
+
+declare module "lodash/includes" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "includes">;
+}
+
+declare module "lodash/invokeMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "invokeMap">;
+}
+
+declare module "lodash/keyBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "keyBy">;
+}
+
+declare module "lodash/map" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "map">;
+}
+
+declare module "lodash/orderBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "orderBy">;
+}
+
+declare module "lodash/partition" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "partition">;
+}
+
+declare module "lodash/reduce" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "reduce">;
+}
+
+declare module "lodash/reduceRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "reduceRight">;
+}
+
+declare module "lodash/reject" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "reject">;
+}
+
+declare module "lodash/sample" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sample">;
+}
+
+declare module "lodash/sampleSize" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sampleSize">;
+}
+
+declare module "lodash/shuffle" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "shuffle">;
+}
+
+declare module "lodash/size" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "size">;
+}
+
+declare module "lodash/some" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "some">;
+}
+
+declare module "lodash/sortBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sortBy">;
+}
+
+declare module "lodash/now" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "now">;
+}
+
+declare module "lodash/after" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "after">;
+}
+
+declare module "lodash/ary" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "ary">;
+}
+
+declare module "lodash/before" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "before">;
+}
+
+declare module "lodash/bind" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "bind">;
+}
+
+declare module "lodash/bindKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "bindKey">;
+}
+
+declare module "lodash/curry" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "curry">;
+}
+
+declare module "lodash/curryRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "curryRight">;
+}
+
+declare module "lodash/debounce" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "debounce">;
+}
+
+declare module "lodash/defer" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "defer">;
+}
+
+declare module "lodash/delay" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "delay">;
+}
+
+declare module "lodash/flip" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flip">;
+}
+
+declare module "lodash/memoize" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "memoize">;
+}
+
+declare module "lodash/negate" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "negate">;
+}
+
+declare module "lodash/once" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "once">;
+}
+
+declare module "lodash/overArgs" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "overArgs">;
+}
+
+declare module "lodash/partial" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "partial">;
+}
+
+declare module "lodash/partialRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "partialRight">;
+}
+
+declare module "lodash/rearg" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "rearg">;
+}
+
+declare module "lodash/rest" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "rest">;
+}
+
+declare module "lodash/spread" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "spread">;
+}
+
+declare module "lodash/throttle" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "throttle">;
+}
+
+declare module "lodash/unary" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "unary">;
+}
+
+declare module "lodash/wrap" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "wrap">;
+}
+
+declare module "lodash/castArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "castArray">;
+}
+
+declare module "lodash/clone" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "clone">;
+}
+
+declare module "lodash/cloneDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "cloneDeep">;
+}
+
+declare module "lodash/cloneDeepWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "cloneDeepWith">;
+}
+
+declare module "lodash/cloneWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "cloneWith">;
+}
+
+declare module "lodash/conformsTo" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "conformsTo">;
+}
+
+declare module "lodash/eq" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "eq">;
+}
+
+declare module "lodash/gt" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "gt">;
+}
+
+declare module "lodash/gte" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "gte">;
+}
+
+declare module "lodash/isArguments" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isArguments">;
+}
+
+declare module "lodash/isArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isArray">;
+}
+
+declare module "lodash/isArrayBuffer" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isArrayBuffer">;
+}
+
+declare module "lodash/isArrayLike" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isArrayLike">;
+}
+
+declare module "lodash/isArrayLikeObject" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash">,
+    "isArrayLikeObject"
+  >;
+}
+
+declare module "lodash/isBoolean" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isBoolean">;
+}
+
+declare module "lodash/isBuffer" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isBuffer">;
+}
+
+declare module "lodash/isDate" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isDate">;
+}
+
+declare module "lodash/isElement" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isElement">;
+}
+
+declare module "lodash/isEmpty" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isEmpty">;
+}
+
+declare module "lodash/isEqual" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isEqual">;
+}
+
+declare module "lodash/isEqualWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isEqualWith">;
+}
+
+declare module "lodash/isError" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isError">;
+}
+
+declare module "lodash/isFinite" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isFinite">;
+}
+
+declare module "lodash/isFunction" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isFunction">;
+}
+
+declare module "lodash/isInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isInteger">;
+}
+
+declare module "lodash/isLength" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isLength">;
+}
+
+declare module "lodash/isMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isMap">;
+}
+
+declare module "lodash/isMatch" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isMatch">;
+}
+
+declare module "lodash/isMatchWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isMatchWith">;
+}
+
+declare module "lodash/isNaN" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isNaN">;
+}
+
+declare module "lodash/isNative" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isNative">;
+}
+
+declare module "lodash/isNil" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isNil">;
+}
+
+declare module "lodash/isNull" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isNull">;
+}
+
+declare module "lodash/isNumber" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isNumber">;
+}
+
+declare module "lodash/isObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isObject">;
+}
+
+declare module "lodash/isObjectLike" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isObjectLike">;
+}
+
+declare module "lodash/isPlainObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isPlainObject">;
+}
+
+declare module "lodash/isRegExp" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isRegExp">;
+}
+
+declare module "lodash/isSafeInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isSafeInteger">;
+}
+
+declare module "lodash/isSet" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isSet">;
+}
+
+declare module "lodash/isString" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isString">;
+}
+
+declare module "lodash/isSymbol" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isSymbol">;
+}
+
+declare module "lodash/isTypedArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isTypedArray">;
+}
+
+declare module "lodash/isUndefined" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isUndefined">;
+}
+
+declare module "lodash/isWeakMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isWeakMap">;
+}
+
+declare module "lodash/isWeakSet" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "isWeakSet">;
+}
+
+declare module "lodash/lt" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "lt">;
+}
+
+declare module "lodash/lte" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "lte">;
+}
+
+declare module "lodash/toArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toArray">;
+}
+
+declare module "lodash/toFinite" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toFinite">;
+}
+
+declare module "lodash/toInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toInteger">;
+}
+
+declare module "lodash/toLength" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toLength">;
+}
+
+declare module "lodash/toNumber" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toNumber">;
+}
+
+declare module "lodash/toPlainObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toPlainObject">;
+}
+
+declare module "lodash/toSafeInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toSafeInteger">;
+}
+
+declare module "lodash/toString" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toString">;
+}
+
+declare module "lodash/add" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "add">;
+}
+
+declare module "lodash/ceil" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "ceil">;
+}
+
+declare module "lodash/divide" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "divide">;
+}
+
+declare module "lodash/floor" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "floor">;
+}
+
+declare module "lodash/max" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "max">;
+}
+
+declare module "lodash/maxBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "maxBy">;
+}
+
+declare module "lodash/mean" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "mean">;
+}
+
+declare module "lodash/meanBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "meanBy">;
+}
+
+declare module "lodash/min" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "min">;
+}
+
+declare module "lodash/minBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "minBy">;
+}
+
+declare module "lodash/multiply" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "multiply">;
+}
+
+declare module "lodash/round" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "round">;
+}
+
+declare module "lodash/subtract" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "subtract">;
+}
+
+declare module "lodash/sum" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sum">;
+}
+
+declare module "lodash/sumBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "sumBy">;
+}
+
+declare module "lodash/clamp" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "clamp">;
+}
+
+declare module "lodash/inRange" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "inRange">;
+}
+
+declare module "lodash/random" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "random">;
+}
+
+declare module "lodash/assign" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "assign">;
+}
+
+declare module "lodash/assignIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "assignIn">;
+}
+
+declare module "lodash/assignInWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "assignInWith">;
+}
+
+declare module "lodash/assignWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "assignWith">;
+}
+
+declare module "lodash/at" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "at">;
+}
+
+declare module "lodash/create" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "create">;
+}
+
+declare module "lodash/defaults" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "defaults">;
+}
+
+declare module "lodash/defaultsDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "defaultsDeep">;
+}
+
+declare module "lodash/entries" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "entries">;
+}
+
+declare module "lodash/entriesIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "entriesIn">;
+}
+
+declare module "lodash/extend" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "extend">;
+}
+
+declare module "lodash/extendWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "extendWith">;
+}
+
+declare module "lodash/findKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "findKey">;
+}
+
+declare module "lodash/findLastKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "findLastKey">;
+}
+
+declare module "lodash/forIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "forIn">;
+}
+
+declare module "lodash/forInRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "forInRight">;
+}
+
+declare module "lodash/forOwn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "forOwn">;
+}
+
+declare module "lodash/forOwnRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "forOwnRight">;
+}
+
+declare module "lodash/functions" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "functions">;
+}
+
+declare module "lodash/functionsIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "functionsIn">;
+}
+
+declare module "lodash/get" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "get">;
+}
+
+declare module "lodash/has" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "has">;
+}
+
+declare module "lodash/hasIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "hasIn">;
+}
+
+declare module "lodash/invert" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "invert">;
+}
+
+declare module "lodash/invertBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "invertBy">;
+}
+
+declare module "lodash/invoke" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "invoke">;
+}
+
+declare module "lodash/keys" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "keys">;
+}
+
+declare module "lodash/keysIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "keysIn">;
+}
+
+declare module "lodash/mapKeys" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "mapKeys">;
+}
+
+declare module "lodash/mapValues" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "mapValues">;
+}
+
+declare module "lodash/merge" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "merge">;
+}
+
+declare module "lodash/mergeWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "mergeWith">;
+}
+
+declare module "lodash/omit" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "omit">;
+}
+
+declare module "lodash/omitBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "omitBy">;
+}
+
+declare module "lodash/pick" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "pick">;
+}
+
+declare module "lodash/pickBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "pickBy">;
+}
+
+declare module "lodash/result" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "result">;
+}
+
+declare module "lodash/set" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "set">;
+}
+
+declare module "lodash/setWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "setWith">;
+}
+
+declare module "lodash/toPairs" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toPairs">;
+}
+
+declare module "lodash/toPairsIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toPairsIn">;
+}
+
+declare module "lodash/transform" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "transform">;
+}
+
+declare module "lodash/unset" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "unset">;
+}
+
+declare module "lodash/update" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "update">;
+}
+
+declare module "lodash/updateWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "updateWith">;
+}
+
+declare module "lodash/values" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "values">;
+}
+
+declare module "lodash/valuesIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "valuesIn">;
+}
+
+declare module "lodash/chain" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "chain">;
+}
+
+declare module "lodash/tap" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "tap">;
+}
+
+declare module "lodash/thru" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "thru">;
+}
+
+declare module "lodash/camelCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "camelCase">;
+}
+
+declare module "lodash/capitalize" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "capitalize">;
+}
+
+declare module "lodash/deburr" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "deburr">;
+}
+
+declare module "lodash/endsWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "endsWith">;
+}
+
+declare module "lodash/escape" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "escape">;
+}
+
+declare module "lodash/escapeRegExp" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "escapeRegExp">;
+}
+
+declare module "lodash/kebabCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "kebabCase">;
+}
+
+declare module "lodash/lowerCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "lowerCase">;
+}
+
+declare module "lodash/lowerFirst" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "lowerFirst">;
+}
+
+declare module "lodash/pad" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "pad">;
+}
+
+declare module "lodash/padEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "padEnd">;
+}
+
+declare module "lodash/padStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "padStart">;
+}
+
+declare module "lodash/parseInt" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "parseInt">;
+}
+
+declare module "lodash/repeat" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "repeat">;
+}
+
+declare module "lodash/replace" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "replace">;
+}
+
+declare module "lodash/snakeCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "snakeCase">;
+}
+
+declare module "lodash/split" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "split">;
+}
+
+declare module "lodash/startCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "startCase">;
+}
+
+declare module "lodash/startsWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "startsWith">;
+}
+
+declare module "lodash/template" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "template">;
+}
+
+declare module "lodash/toLower" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toLower">;
+}
+
+declare module "lodash/toUpper" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toUpper">;
+}
+
+declare module "lodash/trim" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "trim">;
+}
+
+declare module "lodash/trimEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "trimEnd">;
+}
+
+declare module "lodash/trimStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "trimStart">;
+}
+
+declare module "lodash/truncate" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "truncate">;
+}
+
+declare module "lodash/unescape" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "unescape">;
+}
+
+declare module "lodash/upperCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "upperCase">;
+}
+
+declare module "lodash/upperFirst" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "upperFirst">;
+}
+
+declare module "lodash/words" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "words">;
+}
+
+declare module "lodash/attempt" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "attempt">;
+}
+
+declare module "lodash/bindAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "bindAll">;
+}
+
+declare module "lodash/cond" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "cond">;
+}
+
+declare module "lodash/conforms" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "conforms">;
+}
+
+declare module "lodash/constant" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "constant">;
+}
+
+declare module "lodash/defaultTo" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "defaultTo">;
+}
+
+declare module "lodash/flow" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flow">;
+}
+
+declare module "lodash/flowRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "flowRight">;
+}
+
+declare module "lodash/identity" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "identity">;
+}
+
+declare module "lodash/iteratee" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "iteratee">;
+}
+
+declare module "lodash/matches" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "matches">;
+}
+
+declare module "lodash/matchesProperty" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "matchesProperty">;
+}
+
+declare module "lodash/method" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "method">;
+}
+
+declare module "lodash/methodOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "methodOf">;
+}
+
+declare module "lodash/mixin" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "mixin">;
+}
+
+declare module "lodash/noConflict" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "noConflict">;
+}
+
+declare module "lodash/noop" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "noop">;
+}
+
+declare module "lodash/nthArg" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "nthArg">;
+}
+
+declare module "lodash/over" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "over">;
+}
+
+declare module "lodash/overEvery" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "overEvery">;
+}
+
+declare module "lodash/overSome" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "overSome">;
+}
+
+declare module "lodash/property" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "property">;
+}
+
+declare module "lodash/propertyOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "propertyOf">;
+}
+
+declare module "lodash/range" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "range">;
+}
+
+declare module "lodash/rangeRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "rangeRight">;
+}
+
+declare module "lodash/runInContext" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "runInContext">;
+}
+
+declare module "lodash/stubArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "stubArray">;
+}
+
+declare module "lodash/stubFalse" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "stubFalse">;
+}
+
+declare module "lodash/stubObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "stubObject">;
+}
+
+declare module "lodash/stubString" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "stubString">;
+}
+
+declare module "lodash/stubTrue" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "stubTrue">;
+}
+
+declare module "lodash/times" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "times">;
+}
+
+declare module "lodash/toPath" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "toPath">;
+}
+
+declare module "lodash/uniqueId" {
+  declare module.exports: $PropertyType<$Exports<"lodash">, "uniqueId">;
+}
+
+declare module "lodash/fp/chunk" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "chunk">;
+}
+
+declare module "lodash/fp/compact" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "compact">;
+}
+
+declare module "lodash/fp/concat" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "concat">;
+}
+
+declare module "lodash/fp/difference" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "difference">;
+}
+
+declare module "lodash/fp/differenceBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "differenceBy">;
+}
+
+declare module "lodash/fp/differenceWith" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "differenceWith"
+  >;
+}
+
+declare module "lodash/fp/drop" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "drop">;
+}
+
+declare module "lodash/fp/dropLast" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropLast">;
+}
+
+declare module "lodash/fp/dropRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropRight">;
+}
+
+declare module "lodash/fp/dropRightWhile" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "dropRightWhile"
+  >;
+}
+
+declare module "lodash/fp/dropWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropWhile">;
+}
+
+declare module "lodash/fp/dropLastWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropLastWhile">;
+}
+
+declare module "lodash/fp/fill" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "fill">;
+}
+
+declare module "lodash/fp/findIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findIndex">;
+}
+
+declare module "lodash/fp/findIndexFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findIndexFrom">;
+}
+
+declare module "lodash/fp/findLastIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLastIndex">;
+}
+
+declare module "lodash/fp/findLastIndexFrom" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "findLastIndexFrom"
+  >;
+}
+
+declare module "lodash/fp/first" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "first">;
+}
+
+declare module "lodash/fp/flatten" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flatten">;
+}
+
+declare module "lodash/fp/unnest" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unnest">;
+}
+
+declare module "lodash/fp/flattenDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flattenDeep">;
+}
+
+declare module "lodash/fp/flattenDepth" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flattenDepth">;
+}
+
+declare module "lodash/fp/fromPairs" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "fromPairs">;
+}
+
+declare module "lodash/fp/head" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "head">;
+}
+
+declare module "lodash/fp/indexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "indexOf">;
+}
+
+declare module "lodash/fp/indexOfFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "indexOfFrom">;
+}
+
+declare module "lodash/fp/initial" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "initial">;
+}
+
+declare module "lodash/fp/init" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "init">;
+}
+
+declare module "lodash/fp/intersection" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "intersection">;
+}
+
+declare module "lodash/fp/intersectionBy" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "intersectionBy"
+  >;
+}
+
+declare module "lodash/fp/intersectionWith" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "intersectionWith"
+  >;
+}
+
+declare module "lodash/fp/join" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "join">;
+}
+
+declare module "lodash/fp/last" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "last">;
+}
+
+declare module "lodash/fp/lastIndexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lastIndexOf">;
+}
+
+declare module "lodash/fp/lastIndexOfFrom" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "lastIndexOfFrom"
+  >;
+}
+
+declare module "lodash/fp/nth" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "nth">;
+}
+
+declare module "lodash/fp/pull" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pull">;
+}
+
+declare module "lodash/fp/pullAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pullAll">;
+}
+
+declare module "lodash/fp/pullAllBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pullAllBy">;
+}
+
+declare module "lodash/fp/pullAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pullAllWith">;
+}
+
+declare module "lodash/fp/pullAt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pullAt">;
+}
+
+declare module "lodash/fp/remove" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "remove">;
+}
+
+declare module "lodash/fp/reverse" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "reverse">;
+}
+
+declare module "lodash/fp/slice" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "slice">;
+}
+
+declare module "lodash/fp/sortedIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedIndex">;
+}
+
+declare module "lodash/fp/sortedIndexBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedIndexBy">;
+}
+
+declare module "lodash/fp/sortedIndexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedIndexOf">;
+}
+
+declare module "lodash/fp/sortedLastIndex" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "sortedLastIndex"
+  >;
+}
+
+declare module "lodash/fp/sortedLastIndexBy" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "sortedLastIndexBy"
+  >;
+}
+
+declare module "lodash/fp/sortedLastIndexOf" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "sortedLastIndexOf"
+  >;
+}
+
+declare module "lodash/fp/sortedUniq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedUniq">;
+}
+
+declare module "lodash/fp/sortedUniqBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedUniqBy">;
+}
+
+declare module "lodash/fp/tail" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "tail">;
+}
+
+declare module "lodash/fp/take" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "take">;
+}
+
+declare module "lodash/fp/takeRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeRight">;
+}
+
+declare module "lodash/fp/takeLast" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeLast">;
+}
+
+declare module "lodash/fp/takeRightWhile" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "takeRightWhile"
+  >;
+}
+
+declare module "lodash/fp/takeLastWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeLastWhile">;
+}
+
+declare module "lodash/fp/takeWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeWhile">;
+}
+
+declare module "lodash/fp/union" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "union">;
+}
+
+declare module "lodash/fp/unionBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unionBy">;
+}
+
+declare module "lodash/fp/unionWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unionWith">;
+}
+
+declare module "lodash/fp/uniq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniq">;
+}
+
+declare module "lodash/fp/uniqBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniqBy">;
+}
+
+declare module "lodash/fp/uniqWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniqWith">;
+}
+
+declare module "lodash/fp/unzip" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unzip">;
+}
+
+declare module "lodash/fp/unzipWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unzipWith">;
+}
+
+declare module "lodash/fp/without" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "without">;
+}
+
+declare module "lodash/fp/xor" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "xor">;
+}
+
+declare module "lodash/fp/symmetricDifference" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "symmetricDifference"
+  >;
+}
+
+declare module "lodash/fp/xorBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "xorBy">;
+}
+
+declare module "lodash/fp/symmetricDifferenceBy" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "symmetricDifferenceBy"
+  >;
+}
+
+declare module "lodash/fp/xorWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "xorWith">;
+}
+
+declare module "lodash/fp/symmetricDifferenceWith" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "symmetricDifferenceWith"
+  >;
+}
+
+declare module "lodash/fp/zip" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zip">;
+}
+
+declare module "lodash/fp/zipAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipAll">;
+}
+
+declare module "lodash/fp/zipObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipObject">;
+}
+
+declare module "lodash/fp/zipObj" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipObj">;
+}
+
+declare module "lodash/fp/zipObjectDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipObjectDeep">;
+}
+
+declare module "lodash/fp/zipWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipWith">;
+}
+
+declare module "lodash/fp/countBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "countBy">;
+}
+
+declare module "lodash/fp/each" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "each">;
+}
+
+declare module "lodash/fp/eachRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "eachRight">;
+}
+
+declare module "lodash/fp/every" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "every">;
+}
+
+declare module "lodash/fp/all" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "all">;
+}
+
+declare module "lodash/fp/filter" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "filter">;
+}
+
+declare module "lodash/fp/find" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "find">;
+}
+
+declare module "lodash/fp/findFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findFrom">;
+}
+
+declare module "lodash/fp/findLast" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLast">;
+}
+
+declare module "lodash/fp/findLastFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLastFrom">;
+}
+
+declare module "lodash/fp/flatMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flatMap">;
+}
+
+declare module "lodash/fp/flatMapDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flatMapDeep">;
+}
+
+declare module "lodash/fp/flatMapDepth" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flatMapDepth">;
+}
+
+declare module "lodash/fp/forEach" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forEach">;
+}
+
+declare module "lodash/fp/forEachRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forEachRight">;
+}
+
+declare module "lodash/fp/groupBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "groupBy">;
+}
+
+declare module "lodash/fp/includes" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "includes">;
+}
+
+declare module "lodash/fp/contains" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "contains">;
+}
+
+declare module "lodash/fp/includesFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "includesFrom">;
+}
+
+declare module "lodash/fp/invokeMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invokeMap">;
+}
+
+declare module "lodash/fp/invokeArgsMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invokeArgsMap">;
+}
+
+declare module "lodash/fp/keyBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "keyBy">;
+}
+
+declare module "lodash/fp/indexBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "indexBy">;
+}
+
+declare module "lodash/fp/map" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "map">;
+}
+
+declare module "lodash/fp/pluck" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pluck">;
+}
+
+declare module "lodash/fp/orderBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "orderBy">;
+}
+
+declare module "lodash/fp/partition" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "partition">;
+}
+
+declare module "lodash/fp/reduce" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "reduce">;
+}
+
+declare module "lodash/fp/reduceRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "reduceRight">;
+}
+
+declare module "lodash/fp/reject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "reject">;
+}
+
+declare module "lodash/fp/sample" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sample">;
+}
+
+declare module "lodash/fp/sampleSize" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sampleSize">;
+}
+
+declare module "lodash/fp/shuffle" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "shuffle">;
+}
+
+declare module "lodash/fp/size" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "size">;
+}
+
+declare module "lodash/fp/some" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "some">;
+}
+
+declare module "lodash/fp/any" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "any">;
+}
+
+declare module "lodash/fp/sortBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortBy">;
+}
+
+declare module "lodash/fp/now" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "now">;
+}
+
+declare module "lodash/fp/after" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "after">;
+}
+
+declare module "lodash/fp/ary" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "ary">;
+}
+
+declare module "lodash/fp/nAry" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "nAry">;
+}
+
+declare module "lodash/fp/before" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "before">;
+}
+
+declare module "lodash/fp/bind" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "bind">;
+}
+
+declare module "lodash/fp/bindKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "bindKey">;
+}
+
+declare module "lodash/fp/curry" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "curry">;
+}
+
+declare module "lodash/fp/curryN" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "curryN">;
+}
+
+declare module "lodash/fp/curryRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "curryRight">;
+}
+
+declare module "lodash/fp/curryRightN" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "curryRightN">;
+}
+
+declare module "lodash/fp/debounce" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "debounce">;
+}
+
+declare module "lodash/fp/defer" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defer">;
+}
+
+declare module "lodash/fp/delay" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "delay">;
+}
+
+declare module "lodash/fp/flip" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flip">;
+}
+
+declare module "lodash/fp/memoize" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "memoize">;
+}
+
+declare module "lodash/fp/negate" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "negate">;
+}
+
+declare module "lodash/fp/complement" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "complement">;
+}
+
+declare module "lodash/fp/once" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "once">;
+}
+
+declare module "lodash/fp/overArgs" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "overArgs">;
+}
+
+declare module "lodash/fp/useWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "useWith">;
+}
+
+declare module "lodash/fp/partial" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "partial">;
+}
+
+declare module "lodash/fp/partialRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "partialRight">;
+}
+
+declare module "lodash/fp/rearg" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rearg">;
+}
+
+declare module "lodash/fp/rest" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rest">;
+}
+
+declare module "lodash/fp/unapply" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unapply">;
+}
+
+declare module "lodash/fp/restFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "restFrom">;
+}
+
+declare module "lodash/fp/spread" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "spread">;
+}
+
+declare module "lodash/fp/apply" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "apply">;
+}
+
+declare module "lodash/fp/spreadFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "spreadFrom">;
+}
+
+declare module "lodash/fp/throttle" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "throttle">;
+}
+
+declare module "lodash/fp/unary" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unary">;
+}
+
+declare module "lodash/fp/wrap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "wrap">;
+}
+
+declare module "lodash/fp/castArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "castArray">;
+}
+
+declare module "lodash/fp/clone" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "clone">;
+}
+
+declare module "lodash/fp/cloneDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "cloneDeep">;
+}
+
+declare module "lodash/fp/cloneDeepWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "cloneDeepWith">;
+}
+
+declare module "lodash/fp/cloneWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "cloneWith">;
+}
+
+declare module "lodash/fp/conformsTo" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "conformsTo">;
+}
+
+declare module "lodash/fp/where" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "where">;
+}
+
+declare module "lodash/fp/conforms" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "conforms">;
+}
+
+declare module "lodash/fp/eq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "eq">;
+}
+
+declare module "lodash/fp/identical" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "identical">;
+}
+
+declare module "lodash/fp/gt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "gt">;
+}
+
+declare module "lodash/fp/gte" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "gte">;
+}
+
+declare module "lodash/fp/isArguments" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArguments">;
+}
+
+declare module "lodash/fp/isArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArray">;
+}
+
+declare module "lodash/fp/isArrayBuffer" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArrayBuffer">;
+}
+
+declare module "lodash/fp/isArrayLike" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArrayLike">;
+}
+
+declare module "lodash/fp/isArrayLikeObject" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "isArrayLikeObject"
+  >;
+}
+
+declare module "lodash/fp/isBoolean" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isBoolean">;
+}
+
+declare module "lodash/fp/isBuffer" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isBuffer">;
+}
+
+declare module "lodash/fp/isDate" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isDate">;
+}
+
+declare module "lodash/fp/isElement" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isElement">;
+}
+
+declare module "lodash/fp/isEmpty" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isEmpty">;
+}
+
+declare module "lodash/fp/isEqual" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isEqual">;
+}
+
+declare module "lodash/fp/equals" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "equals">;
+}
+
+declare module "lodash/fp/isEqualWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isEqualWith">;
+}
+
+declare module "lodash/fp/isError" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isError">;
+}
+
+declare module "lodash/fp/isFinite" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isFinite">;
+}
+
+declare module "lodash/fp/isFunction" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isFunction">;
+}
+
+declare module "lodash/fp/isInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isInteger">;
+}
+
+declare module "lodash/fp/isLength" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isLength">;
+}
+
+declare module "lodash/fp/isMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isMap">;
+}
+
+declare module "lodash/fp/isMatch" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isMatch">;
+}
+
+declare module "lodash/fp/whereEq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "whereEq">;
+}
+
+declare module "lodash/fp/isMatchWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isMatchWith">;
+}
+
+declare module "lodash/fp/isNaN" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNaN">;
+}
+
+declare module "lodash/fp/isNative" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNative">;
+}
+
+declare module "lodash/fp/isNil" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNil">;
+}
+
+declare module "lodash/fp/isNull" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNull">;
+}
+
+declare module "lodash/fp/isNumber" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNumber">;
+}
+
+declare module "lodash/fp/isObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isObject">;
+}
+
+declare module "lodash/fp/isObjectLike" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isObjectLike">;
+}
+
+declare module "lodash/fp/isPlainObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isPlainObject">;
+}
+
+declare module "lodash/fp/isRegExp" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isRegExp">;
+}
+
+declare module "lodash/fp/isSafeInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isSafeInteger">;
+}
+
+declare module "lodash/fp/isSet" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isSet">;
+}
+
+declare module "lodash/fp/isString" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isString">;
+}
+
+declare module "lodash/fp/isSymbol" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isSymbol">;
+}
+
+declare module "lodash/fp/isTypedArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isTypedArray">;
+}
+
+declare module "lodash/fp/isUndefined" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isUndefined">;
+}
+
+declare module "lodash/fp/isWeakMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isWeakMap">;
+}
+
+declare module "lodash/fp/isWeakSet" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isWeakSet">;
+}
+
+declare module "lodash/fp/lt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lt">;
+}
+
+declare module "lodash/fp/lte" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lte">;
+}
+
+declare module "lodash/fp/toArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toArray">;
+}
+
+declare module "lodash/fp/toFinite" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toFinite">;
+}
+
+declare module "lodash/fp/toInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toInteger">;
+}
+
+declare module "lodash/fp/toLength" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toLength">;
+}
+
+declare module "lodash/fp/toNumber" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toNumber">;
+}
+
+declare module "lodash/fp/toPlainObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toPlainObject">;
+}
+
+declare module "lodash/fp/toSafeInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toSafeInteger">;
+}
+
+declare module "lodash/fp/toString" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toString">;
+}
+
+declare module "lodash/fp/add" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "add">;
+}
+
+declare module "lodash/fp/ceil" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "ceil">;
+}
+
+declare module "lodash/fp/divide" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "divide">;
+}
+
+declare module "lodash/fp/floor" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "floor">;
+}
+
+declare module "lodash/fp/max" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "max">;
+}
+
+declare module "lodash/fp/maxBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "maxBy">;
+}
+
+declare module "lodash/fp/mean" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mean">;
+}
+
+declare module "lodash/fp/meanBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "meanBy">;
+}
+
+declare module "lodash/fp/min" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "min">;
+}
+
+declare module "lodash/fp/minBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "minBy">;
+}
+
+declare module "lodash/fp/multiply" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "multiply">;
+}
+
+declare module "lodash/fp/round" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "round">;
+}
+
+declare module "lodash/fp/subtract" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "subtract">;
+}
+
+declare module "lodash/fp/sum" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sum">;
+}
+
+declare module "lodash/fp/sumBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sumBy">;
+}
+
+declare module "lodash/fp/clamp" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "clamp">;
+}
+
+declare module "lodash/fp/inRange" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "inRange">;
+}
+
+declare module "lodash/fp/random" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "random">;
+}
+
+declare module "lodash/fp/assign" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assign">;
+}
+
+declare module "lodash/fp/assignAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignAll">;
+}
+
+declare module "lodash/fp/assignInAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignInAll">;
+}
+
+declare module "lodash/fp/extendAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "extendAll">;
+}
+
+declare module "lodash/fp/assignIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignIn">;
+}
+
+declare module "lodash/fp/assignInWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignInWith">;
+}
+
+declare module "lodash/fp/assignWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignWith">;
+}
+
+declare module "lodash/fp/assignInAllWith" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "assignInAllWith"
+  >;
+}
+
+declare module "lodash/fp/extendAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "extendAllWith">;
+}
+
+declare module "lodash/fp/assignAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignAllWith">;
+}
+
+declare module "lodash/fp/at" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "at">;
+}
+
+declare module "lodash/fp/props" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "props">;
+}
+
+declare module "lodash/fp/paths" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "paths">;
+}
+
+declare module "lodash/fp/create" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "create">;
+}
+
+declare module "lodash/fp/defaults" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaults">;
+}
+
+declare module "lodash/fp/defaultsAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaultsAll">;
+}
+
+declare module "lodash/fp/defaultsDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaultsDeep">;
+}
+
+declare module "lodash/fp/defaultsDeepAll" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "defaultsDeepAll"
+  >;
+}
+
+declare module "lodash/fp/entries" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "entries">;
+}
+
+declare module "lodash/fp/entriesIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "entriesIn">;
+}
+
+declare module "lodash/fp/extend" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "extend">;
+}
+
+declare module "lodash/fp/extendWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "extendWith">;
+}
+
+declare module "lodash/fp/findKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findKey">;
+}
+
+declare module "lodash/fp/findLastKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLastKey">;
+}
+
+declare module "lodash/fp/forIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forIn">;
+}
+
+declare module "lodash/fp/forInRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forInRight">;
+}
+
+declare module "lodash/fp/forOwn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forOwn">;
+}
+
+declare module "lodash/fp/forOwnRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forOwnRight">;
+}
+
+declare module "lodash/fp/functions" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "functions">;
+}
+
+declare module "lodash/fp/functionsIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "functionsIn">;
+}
+
+declare module "lodash/fp/get" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "get">;
+}
+
+declare module "lodash/fp/prop" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "prop">;
+}
+
+declare module "lodash/fp/path" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "path">;
+}
+
+declare module "lodash/fp/getOr" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "getOr">;
+}
+
+declare module "lodash/fp/propOr" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "propOr">;
+}
+
+declare module "lodash/fp/pathOr" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pathOr">;
+}
+
+declare module "lodash/fp/has" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "has">;
+}
+
+declare module "lodash/fp/hasIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "hasIn">;
+}
+
+declare module "lodash/fp/invert" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invert">;
+}
+
+declare module "lodash/fp/invertObj" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invertObj">;
+}
+
+declare module "lodash/fp/invertBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invertBy">;
+}
+
+declare module "lodash/fp/invoke" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invoke">;
+}
+
+declare module "lodash/fp/invokeArgs" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invokeArgs">;
+}
+
+declare module "lodash/fp/keys" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "keys">;
+}
+
+declare module "lodash/fp/keysIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "keysIn">;
+}
+
+declare module "lodash/fp/mapKeys" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mapKeys">;
+}
+
+declare module "lodash/fp/mapValues" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mapValues">;
+}
+
+declare module "lodash/fp/merge" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "merge">;
+}
+
+declare module "lodash/fp/mergeAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mergeAll">;
+}
+
+declare module "lodash/fp/mergeWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mergeWith">;
+}
+
+declare module "lodash/fp/mergeAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mergeAllWith">;
+}
+
+declare module "lodash/fp/omit" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "omit">;
+}
+
+declare module "lodash/fp/omitAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "omitAll">;
+}
+
+declare module "lodash/fp/omitBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "omitBy">;
+}
+
+declare module "lodash/fp/pick" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pick">;
+}
+
+declare module "lodash/fp/pickAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pickAll">;
+}
+
+declare module "lodash/fp/pickBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pickBy">;
+}
+
+declare module "lodash/fp/result" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "result">;
+}
+
+declare module "lodash/fp/set" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "set">;
+}
+
+declare module "lodash/fp/assoc" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assoc">;
+}
+
+declare module "lodash/fp/assocPath" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assocPath">;
+}
+
+declare module "lodash/fp/setWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "setWith">;
+}
+
+declare module "lodash/fp/toPairs" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toPairs">;
+}
+
+declare module "lodash/fp/toPairsIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toPairsIn">;
+}
+
+declare module "lodash/fp/transform" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "transform">;
+}
+
+declare module "lodash/fp/unset" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unset">;
+}
+
+declare module "lodash/fp/dissoc" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dissoc">;
+}
+
+declare module "lodash/fp/dissocPath" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dissocPath">;
+}
+
+declare module "lodash/fp/update" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "update">;
+}
+
+declare module "lodash/fp/updateWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "updateWith">;
+}
+
+declare module "lodash/fp/values" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "values">;
+}
+
+declare module "lodash/fp/valuesIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "valuesIn">;
+}
+
+declare module "lodash/fp/tap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "tap">;
+}
+
+declare module "lodash/fp/thru" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "thru">;
+}
+
+declare module "lodash/fp/camelCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "camelCase">;
+}
+
+declare module "lodash/fp/capitalize" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "capitalize">;
+}
+
+declare module "lodash/fp/deburr" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "deburr">;
+}
+
+declare module "lodash/fp/endsWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "endsWith">;
+}
+
+declare module "lodash/fp/escape" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "escape">;
+}
+
+declare module "lodash/fp/escapeRegExp" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "escapeRegExp">;
+}
+
+declare module "lodash/fp/kebabCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "kebabCase">;
+}
+
+declare module "lodash/fp/lowerCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lowerCase">;
+}
+
+declare module "lodash/fp/lowerFirst" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lowerFirst">;
+}
+
+declare module "lodash/fp/pad" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pad">;
+}
+
+declare module "lodash/fp/padChars" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padChars">;
+}
+
+declare module "lodash/fp/padEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padEnd">;
+}
+
+declare module "lodash/fp/padCharsEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padCharsEnd">;
+}
+
+declare module "lodash/fp/padStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padStart">;
+}
+
+declare module "lodash/fp/padCharsStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padCharsStart">;
+}
+
+declare module "lodash/fp/parseInt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "parseInt">;
+}
+
+declare module "lodash/fp/repeat" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "repeat">;
+}
+
+declare module "lodash/fp/replace" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "replace">;
+}
+
+declare module "lodash/fp/snakeCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "snakeCase">;
+}
+
+declare module "lodash/fp/split" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "split">;
+}
+
+declare module "lodash/fp/startCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "startCase">;
+}
+
+declare module "lodash/fp/startsWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "startsWith">;
+}
+
+declare module "lodash/fp/template" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "template">;
+}
+
+declare module "lodash/fp/toLower" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toLower">;
+}
+
+declare module "lodash/fp/toUpper" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toUpper">;
+}
+
+declare module "lodash/fp/trim" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trim">;
+}
+
+declare module "lodash/fp/trimChars" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimChars">;
+}
+
+declare module "lodash/fp/trimEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimEnd">;
+}
+
+declare module "lodash/fp/trimCharsEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimCharsEnd">;
+}
+
+declare module "lodash/fp/trimStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimStart">;
+}
+
+declare module "lodash/fp/trimCharsStart" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "trimCharsStart"
+  >;
+}
+
+declare module "lodash/fp/truncate" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "truncate">;
+}
+
+declare module "lodash/fp/unescape" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unescape">;
+}
+
+declare module "lodash/fp/upperCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "upperCase">;
+}
+
+declare module "lodash/fp/upperFirst" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "upperFirst">;
+}
+
+declare module "lodash/fp/words" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "words">;
+}
+
+declare module "lodash/fp/attempt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "attempt">;
+}
+
+declare module "lodash/fp/bindAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "bindAll">;
+}
+
+declare module "lodash/fp/cond" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "cond">;
+}
+
+declare module "lodash/fp/constant" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "constant">;
+}
+
+declare module "lodash/fp/always" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "always">;
+}
+
+declare module "lodash/fp/defaultTo" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaultTo">;
+}
+
+declare module "lodash/fp/flow" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flow">;
+}
+
+declare module "lodash/fp/pipe" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pipe">;
+}
+
+declare module "lodash/fp/flowRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flowRight">;
+}
+
+declare module "lodash/fp/compose" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "compose">;
+}
+
+declare module "lodash/fp/identity" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "identity">;
+}
+
+declare module "lodash/fp/iteratee" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "iteratee">;
+}
+
+declare module "lodash/fp/matches" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "matches">;
+}
+
+declare module "lodash/fp/matchesProperty" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "matchesProperty"
+  >;
+}
+
+declare module "lodash/fp/propEq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "propEq">;
+}
+
+declare module "lodash/fp/pathEq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pathEq">;
+}
+
+declare module "lodash/fp/method" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "method">;
+}
+
+declare module "lodash/fp/methodOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "methodOf">;
+}
+
+declare module "lodash/fp/mixin" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mixin">;
+}
+
+declare module "lodash/fp/noConflict" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "noConflict">;
+}
+
+declare module "lodash/fp/noop" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "noop">;
+}
+
+declare module "lodash/fp/nthArg" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "nthArg">;
+}
+
+declare module "lodash/fp/over" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "over">;
+}
+
+declare module "lodash/fp/juxt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "juxt">;
+}
+
+declare module "lodash/fp/overEvery" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "overEvery">;
+}
+
+declare module "lodash/fp/allPass" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "allPass">;
+}
+
+declare module "lodash/fp/overSome" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "overSome">;
+}
+
+declare module "lodash/fp/anyPass" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "anyPass">;
+}
+
+declare module "lodash/fp/property" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "property">;
+}
+
+declare module "lodash/fp/propertyOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "propertyOf">;
+}
+
+declare module "lodash/fp/range" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "range">;
+}
+
+declare module "lodash/fp/rangeStep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rangeStep">;
+}
+
+declare module "lodash/fp/rangeRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rangeRight">;
+}
+
+declare module "lodash/fp/rangeStepRight" {
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "rangeStepRight"
+  >;
+}
+
+declare module "lodash/fp/runInContext" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "runInContext">;
+}
+
+declare module "lodash/fp/stubArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubArray">;
+}
+
+declare module "lodash/fp/stubFalse" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubFalse">;
+}
+
+declare module "lodash/fp/F" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "F">;
+}
+
+declare module "lodash/fp/stubObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubObject">;
+}
+
+declare module "lodash/fp/stubString" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubString">;
+}
+
+declare module "lodash/fp/stubTrue" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubTrue">;
+}
+
+declare module "lodash/fp/T" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "T">;
+}
+
+declare module "lodash/fp/times" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "times">;
+}
+
+declare module "lodash/fp/toPath" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toPath">;
+}
+
+declare module "lodash/fp/uniqueId" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniqueId">;
+}

--- a/flow-typed/npm/react-copy-to-clipboard_v5.x.x.js
+++ b/flow-typed/npm/react-copy-to-clipboard_v5.x.x.js
@@ -1,0 +1,21 @@
+// flow-typed signature: 3062f7aa14a5184b59450ae0a632f210
+// flow-typed version: 149b8d2e6d/react-copy-to-clipboard_v5.x.x/flow_>=v0.25.x
+
+// @flow
+
+declare module 'react-copy-to-clipboard' {
+  declare export type CopyToClipboardOptions = {
+    debug: boolean,
+    message: string
+  };
+
+  declare export type CopyToClipboardProps = {
+    text: string,
+    onCopy?: (text: string, result: boolean) => void,
+    options?: CopyToClipboardOptions,
+    children?: React$Node
+  };
+
+  declare export class CopyToClipboard extends React$Component<CopyToClipboardProps> {}
+  declare export default class CopyToClipboard extends React$Component<CopyToClipboardProps> {}
+}

--- a/flow-typed/npm/react-intl_v2.x.x.js
+++ b/flow-typed/npm/react-intl_v2.x.x.js
@@ -1,0 +1,262 @@
+// flow-typed signature: 3902298e28ed22d8cd8d49828801a760
+// flow-typed version: eb50783110/react-intl_v2.x.x/flow_>=v0.63.x
+
+/**
+ * Original implementation of this file by @marudor at https://github.com/marudor/flowInterfaces
+ * Copied here based on intention to merge with flow-typed expressed here:
+ * https://github.com/marudor/flowInterfaces/issues/6
+ */
+// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-api
+declare module "react-intl" {
+  import type { Element, ChildrenArray } from "react";
+
+  declare type $npm$ReactIntl$LocaleData = {
+    locale: string,
+    [key: string]: any
+  };
+
+  declare type $npm$ReactIntl$MessageDescriptor = {
+    id: string,
+    description?: string,
+    defaultMessage?: string
+  };
+
+  declare type $npm$ReactIntl$IntlConfig = {
+    locale: string,
+    formats: Object,
+    messages: { [id: string]: string },
+
+    defaultLocale?: string,
+    defaultFormats?: Object
+  };
+
+  declare type $npm$ReactIntl$IntlProviderConfig = {
+    locale?: string,
+    formats?: Object,
+    messages?: { [id: string]: string },
+
+    defaultLocale?: string,
+    defaultFormats?: Object
+  };
+
+  declare type $npm$ReactIntl$IntlFormat = {
+    formatDate: (value: any, options?: Object) => string,
+    formatTime: (value: any, options?: Object) => string,
+    formatRelative: (value: any, options?: Object) => string,
+    formatNumber: (value: any, options?: Object) => string,
+    formatPlural: (value: any, options?: Object) => string,
+    formatMessage: (
+      messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+      values?: Object
+    ) => string,
+    formatHTMLMessage: (
+      messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+      values?: Object
+    ) => string
+  };
+
+  declare type $npm$ReactIntl$IntlShape = $npm$ReactIntl$IntlConfig &
+    $npm$ReactIntl$IntlFormat & { now: () => number };
+
+  declare type $npm$ReactIntl$DateTimeFormatOptions = {
+    localeMatcher?: "best fit" | "lookup",
+    formatMatcher?: "basic" | "best fit",
+
+    timeZone?: string,
+    hour12?: boolean,
+
+    weekday?: "narrow" | "short" | "long",
+    era?: "narrow" | "short" | "long",
+    year?: "numeric" | "2-digit",
+    month?: "numeric" | "2-digit" | "narrow" | "short" | "long",
+    day?: "numeric" | "2-digit",
+    hour?: "numeric" | "2-digit",
+    minute?: "numeric" | "2-digit",
+    second?: "numeric" | "2-digit",
+    timeZoneName?: "short" | "long"
+  };
+
+  declare type $npm$ReactIntl$RelativeFormatOptions = {
+    style?: "best fit" | "numeric",
+    units?: "second" | "minute" | "hour" | "day" | "month" | "year"
+  };
+
+  declare type $npm$ReactIntl$NumberFormatOptions = {
+    localeMatcher?: "best fit" | "lookup",
+
+    style?: "decimal" | "currency" | "percent",
+
+    currency?: string,
+    currencyDisplay?: "symbol" | "code" | "name",
+
+    useGrouping?: boolean,
+
+    minimumIntegerDigits?: number,
+    minimumFractionDigits?: number,
+    maximumFractionDigits?: number,
+    minimumSignificantDigits?: number,
+    maximumSignificantDigits?: number
+  };
+
+  declare type $npm$ReactIntl$PluralFormatOptions = {
+    style?: "cardinal" | "ordinal"
+  };
+
+  declare type $npm$ReactIntl$PluralCategoryString =
+    | "zero"
+    | "one"
+    | "two"
+    | "few"
+    | "many"
+    | "other";
+
+  declare type $npm$ReactIntl$DateParseable = number | string | Date;
+  // PropType checker
+  declare function intlShape(
+    props: Object,
+    propName: string,
+    componentName: string
+  ): void;
+  declare function addLocaleData(
+    data: $npm$ReactIntl$LocaleData | Array<$npm$ReactIntl$LocaleData>
+  ): void;
+  declare function defineMessages<
+    T: { [key: string]: $Exact<$npm$ReactIntl$MessageDescriptor> }
+  >(
+    messageDescriptors: T
+  ): T;
+
+  declare type InjectIntlProvidedProps = {
+    intl: $npm$ReactIntl$IntlShape
+  }
+
+  declare type InjectIntlVoidProps = {
+    intl: $npm$ReactIntl$IntlShape | void
+  }
+
+  declare type ComponentWithDefaultProps<DefaultProps: {}, Props: {}> =
+    | React$ComponentType<Props>
+    | React$StatelessFunctionalComponent<Props>
+    | ChildrenArray<void | null | boolean | string | number | Element<any>>;
+
+  declare type InjectIntlOptions = {
+    intlPropName?: string,
+    withRef?: boolean
+  }
+
+  declare class IntlInjectedComponent<TOwnProps, TDefaultProps> extends React$Component<TOwnProps> {
+    static WrappedComponent: Class<React$Component<TOwnProps & InjectIntlProvidedProps>>,
+    static defaultProps: TDefaultProps,
+    props: TOwnProps
+  }
+
+  declare type IntlInjectedComponentClass<TOwnProps, TDefaultProps: {} = {}> = Class<
+    IntlInjectedComponent<TOwnProps, TDefaultProps>
+  >;
+
+  declare function injectIntl<P: {}, Component: React$ComponentType<P>>(
+    WrappedComponent: Component,
+    options?: InjectIntlOptions,
+  ): React$ComponentType<
+    $Diff<React$ElementConfig<Component>, InjectIntlVoidProps>
+  >;
+
+  declare function formatMessage(
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatHTMLMessage(
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatDate(
+    value: any,
+    options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatTime(
+    value: any,
+    options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatRelative(
+    value: any,
+    options?: $npm$ReactIntl$RelativeFormatOptions & {
+      format: string,
+      now: any
+    }
+  ): string;
+  declare function formatNumber(
+    value: any,
+    options?: $npm$ReactIntl$NumberFormatOptions & { format: string }
+  ): string;
+  declare function formatPlural(
+    value: any,
+    options?: $npm$ReactIntl$PluralFormatOptions
+  ): $npm$ReactIntl$PluralCategoryString;
+
+  declare class FormattedMessage extends React$Component<
+    $npm$ReactIntl$MessageDescriptor & {
+      values?: Object,
+      tagName?: string,
+      children?:
+        | ((...formattedMessage: Array<React$Node>) => React$Node)
+        | (string => React$Node)
+    }
+  > {}
+  declare class FormattedHTMLMessage extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      values?: Object,
+      tagName?: string,
+      children?: (...formattedMessage: Array<React$Node>) => React$Node
+    }
+  > {}
+  declare class FormattedDate extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedTime extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedRelative extends React$Component<
+    $npm$ReactIntl$RelativeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      updateInterval?: number,
+      initialNow?: $npm$ReactIntl$DateParseable,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedNumber extends React$Component<
+    $npm$ReactIntl$NumberFormatOptions & {
+      value: number | string,
+      format?: string,
+      children?: (formattedNumber: string) => React$Node
+    }
+  > {}
+  declare class FormattedPlural extends React$Component<
+    $npm$ReactIntl$PluralFormatOptions & {
+      value: number | string,
+      other: React$Node,
+      zero?: React$Node,
+      one?: React$Node,
+      two?: React$Node,
+      few?: React$Node,
+      many?: React$Node,
+      children?: (formattedPlural: React$Node) => React$Node
+    }
+  > {}
+  declare class IntlProvider extends React$Component<
+    $npm$ReactIntl$IntlProviderConfig & {
+      children?: React$Node,
+      initialNow?: $npm$ReactIntl$DateParseable
+    }
+  > {}
+  declare type IntlShape = $npm$ReactIntl$IntlShape;
+  declare type MessageDescriptor = $npm$ReactIntl$MessageDescriptor;
+}

--- a/flow-typed/npm/react-router_v4.x.x.js
+++ b/flow-typed/npm/react-router_v4.x.x.js
@@ -1,0 +1,134 @@
+// flow-typed signature: 5b443aa1cb3cb5a26ac1be467cc2944e
+// flow-typed version: be05cd918c/react-router_v4.x.x/flow_>=v0.63.x
+
+declare module "react-router" {
+  // NOTE: many of these are re-exported by react-router-dom and
+  // react-router-native, so when making changes, please be sure to update those
+  // as well.
+  declare export type Location = {
+    pathname: string,
+    search: string,
+    hash: string,
+    state?: any,
+    key?: string
+  };
+
+  declare export type LocationShape = {
+    pathname?: string,
+    search?: string,
+    hash?: string,
+    state?: any
+  };
+
+  declare export type HistoryAction = "PUSH" | "REPLACE" | "POP";
+
+  declare export type RouterHistory = {
+    length: number,
+    location: Location,
+    action: HistoryAction,
+    listen(
+      callback: (location: Location, action: HistoryAction) => void
+    ): () => void,
+    push(path: string | LocationShape, state?: any): void,
+    replace(path: string | LocationShape, state?: any): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
+    canGo?: (n: number) => boolean,
+    block(
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
+    // createMemoryHistory
+    index?: number,
+    entries?: Array<Location>
+  };
+
+  declare export type Match = {
+    params: { [key: string]: ?string },
+    isExact: boolean,
+    path: string,
+    url: string
+  };
+
+  declare export type ContextRouter = {|
+    history: RouterHistory,
+    location: Location,
+    match: Match,
+    staticContext?: StaticRouterContext
+  |};
+
+  declare export type GetUserConfirmation = (
+    message: string,
+    callback: (confirmed: boolean) => void
+  ) => void;
+
+  declare type StaticRouterContext = {
+    url?: string
+  };
+
+  declare export class StaticRouter extends React$Component<{
+    basename?: string,
+    location?: string | Location,
+    context: StaticRouterContext,
+    children?: React$Node
+  }> {}
+
+  declare export class MemoryRouter extends React$Component<{
+    initialEntries?: Array<LocationShape | string>,
+    initialIndex?: number,
+    getUserConfirmation?: GetUserConfirmation,
+    keyLength?: number,
+    children?: React$Node
+  }> {}
+
+  declare export class Router extends React$Component<{
+    history: RouterHistory,
+    children?: React$Node
+  }> {}
+
+  declare export class Prompt extends React$Component<{
+    message: string | ((location: Location) => string | true),
+    when?: boolean
+  }> {}
+
+  declare export class Redirect extends React$Component<{|
+    to: string | LocationShape,
+    push?: boolean,
+    from?: string,
+    exact?: boolean,
+    strict?: boolean
+  |}> {}
+
+
+  declare export class Route extends React$Component<{|
+    component?: React$ComponentType<*>,
+    render?: (router: ContextRouter) => React$Node,
+    children?: React$ComponentType<ContextRouter> | React$Node,
+    path?: string,
+    exact?: boolean,
+    strict?: boolean,
+    location?: LocationShape,
+    sensitive?: boolean
+  |}> {}
+
+  declare export class Switch extends React$Component<{|
+    children?: React$Node,
+    location?: Location
+  |}> {}
+
+  declare export function withRouter<P>(
+    Component: React$ComponentType<{| ...ContextRouter, ...P |}>
+  ): React$ComponentType<P>;
+
+  declare type MatchPathOptions = {
+    path?: string,
+    exact?: boolean,
+    strict?: boolean,
+    sensitive?: boolean
+  };
+
+  declare export function matchPath(
+    pathname: string,
+    options?: MatchPathOptions | string
+  ): null | Match;
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "compress-keygen": "crx keygen",
     "clean": "rimraf build/ dev/ *.zip *.crx",
     "flow": "flow --show-all-errors .",
+    "flow-install": "flow-typed install",
     "eslint": "eslint app features chrome scripts webpack/*.js",
     "test-unit": "jest",
     "test-prepare": "npm run clean && npm run build -- --env 'test' && npm run compress-e2e-tests",


### PR DESCRIPTION
Mostly I wanted two type definitions:

1) `lodash` because actually using `lodash` in any function right now basically kills Flow for the entire function (everything resolves to `any`) which is really bad
2) `react-intl` because we've made a lot of mistakes with defining messages before

Everything else was a "meh why not" since it didn't take much work to add anyway.