### PR TITLE
Fix Shin/ch962/fix yoroiclassic theme regression bugs-2

### DIFF
--- a/app/components/wallet/hwConnect/common/DialogCommonStyle.scss
+++ b/app/components/wallet/hwConnect/common/DialogCommonStyle.scss
@@ -35,6 +35,17 @@ $opacityCommon: 0.7;
   }
 }
 
+.headerBlockClassic {
+  width: 725px;
+  padding-top: 1em;
+  span {
+    font-family: var(--font-light);
+    line-height: 1.38;
+    font-size: 14px;
+    opacity: $opacityCommon;
+  }
+}
+
 .middleBlockClassic {
   overflow: hidden;  
   background-color: var(--theme-hw-connect-dialog-middle-block-common-background-color);

--- a/app/components/wallet/hwConnect/ledger/AboutDialog.js
+++ b/app/components/wallet/hwConnect/ledger/AboutDialog.js
@@ -83,7 +83,7 @@ export default class AboutDialog extends Component<Props> {
       classicTheme,
     } = this.props;
     const headerBlockClasses = classicTheme
-      ? headerMixin.headerBlockClassic
+      ? classnames([headerMixin.headerBlockClassic, styles.headerBlockClassic])
       : classnames([headerMixin.headerBlock, 'small']);
     const middleBlockClasses = classicTheme
       ? classnames([styles.middleBlockClassic, styles.middleAboutBlockClassic])

--- a/app/components/wallet/hwConnect/ledger/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/ledger/ConnectDialog.js
@@ -66,7 +66,7 @@ export default class ConnectDialog extends Component<Props> {
       goBack, submit, cancel, classicTheme,
     } = this.props;
     const headerBlockClasses = classicTheme
-      ? headerMixin.headerBlockClassic
+      ? classnames([headerMixin.headerBlockClassic, styles.headerBlockClassic])
       : headerMixin.headerBlock;
     const middleBlockClasses = classicTheme ? styles.middleBlockClassic : styles.middleBlock;
     const middleConnectErrorBlockClasses = classicTheme

--- a/app/components/wallet/hwConnect/trezor/AboutDialog.js
+++ b/app/components/wallet/hwConnect/trezor/AboutDialog.js
@@ -83,7 +83,7 @@ export default class AboutDialog extends Component<Props> {
       classicTheme,
     } = this.props;
     const headerBlockClasses = classicTheme
-      ? headerMixin.headerBlockClassic
+      ? classnames([headerMixin.headerBlockClassic, styles.headerBlockClassic])
       : classnames([headerMixin.headerBlock, 'small']);
     const middleBlockClasses = classicTheme
       ? classnames([styles.middleBlockClassic, styles.middleAboutBlockClassic])

--- a/app/components/wallet/hwConnect/trezor/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/trezor/ConnectDialog.js
@@ -70,7 +70,7 @@ export default class ConnectDialog extends Component<Props> {
       classicTheme
     } = this.props;
     const headerBlockClasses = classicTheme
-      ? headerMixin.headerBlockClassic
+      ? classnames([headerMixin.headerBlockClassic, styles.headerBlockClassic])
       : headerMixin.headerBlock;
     const middleBlockClasses = classicTheme ? styles.middleBlockClassic : styles.middleBlock;
     const middleConnectErrorBlockClasses = classicTheme

--- a/app/components/widgets/ErrorBlock.js
+++ b/app/components/widgets/ErrorBlock.js
@@ -35,7 +35,7 @@ export default class ErrorBlock extends Component<Props> {
     }
 
     return (
-      <div className={classicTheme ? styles.errorBlock : styles.errorBlock}>
+      <div className={classicTheme ? styles.errorBlockClassic : styles.errorBlock}>
         <span>{errorText}</span>
       </div>);
   }


### PR DESCRIPTION
REF: https://app.clubhouse.io/emurgo/story/962/fix-yoroiclassic-theme-regression-bugs

- [X] Restore 4 HW connect dialogs header block styling

![image](https://user-images.githubusercontent.com/19986226/57608972-f365c780-75a8-11e9-863b-f57318644c07.png)

![image](https://user-images.githubusercontent.com/19986226/57608986-f660b800-75a8-11e9-9f23-3c2779b52e4b.png)

![image](https://user-images.githubusercontent.com/19986226/57608992-f9f43f00-75a8-11e9-8e4c-088c3a1135d5.png)

![image](https://user-images.githubusercontent.com/19986226/57609005-fd87c600-75a8-11e9-8eb1-b9760a088034.png)

- [X] Restore classic theam ErrorBlock styling

![image](https://user-images.githubusercontent.com/19986226/57609887-b995c080-75aa-11e9-8d6f-2c0ebc456a13.png)

