### PR TITLE
Fix About Yoroi SVG on Firefox

### DIFF
--- a/app/components/widgets/LinkButton.js
+++ b/app/components/widgets/LinkButton.js
@@ -32,7 +32,7 @@ export default class LinkButton extends Component<Props> {
             title={intl.formatMessage(message)}
           >
             <div className={styles.icon}>
-              <SvgInline svg={svg} className={svgClassName} width="20" height="52" />
+              <SvgInline svg={svg} className={svgClassName} />
             </div>
             <div className={styles.text}>
               <span className={textClassName}>

--- a/app/components/widgets/LinkButton.scss
+++ b/app/components/widgets/LinkButton.scss
@@ -20,6 +20,10 @@ $blockHeight: 56px;
     margin-right: 8px;
     display: inline-block;
     vertical-align: middle;
+    svg {
+      width: 20px;
+      height: 52px;
+    }
   }
   .text {
     display: inline-block;


### PR DESCRIPTION
The hack for width/height worked on Chrome but not on Firefox so I added the proper fix.