### PR TITLE
Fix back button on hardware wallet send

### DIFF
--- a/app/components/wallet/send/HWSendConfirmationDialog.js
+++ b/app/components/wallet/send/HWSendConfirmationDialog.js
@@ -32,6 +32,7 @@ type Props = {
   error: ?LocalizableError,
   onSubmit: Function,
   onCancel: Function,
+  classicTheme: boolean,
 };
 
 @observer
@@ -53,6 +54,7 @@ export default class HWSendConfirmationDialog extends Component<Props> {
       messages,
       error,
       onCancel,
+      classicTheme,
     } = this.props;
 
     const infoBlock = (
@@ -130,6 +132,7 @@ export default class HWSendConfirmationDialog extends Component<Props> {
         onClose={!isSubmitting ? onCancel : null}
         className={styles.dialog}
         closeButton={<DialogCloseButton />}
+        classicTheme={classicTheme}
       >
         {infoBlock}
         {addressBlock}

--- a/app/containers/wallet/WalletSendPage.js
+++ b/app/containers/wallet/WalletSendPage.js
@@ -134,6 +134,7 @@ export default class WalletSendPage extends Component<Props> {
           error={ledgerSendStore.error}
           onSubmit={ledgerSendAction.sendUsingLedger.trigger}
           onCancel={ledgerSendAction.cancel.trigger}
+          classicTheme={this.props.stores.profile.isClassicTheme}
         />);
     } else if (active.isTrezorTWallet) {
       const trezorSendAction = this.props.actions[environment.API].trezorSend;
@@ -151,6 +152,7 @@ export default class WalletSendPage extends Component<Props> {
           error={trezorSendStore.error}
           onSubmit={trezorSendAction.sendUsingTrezor.trigger}
           onCancel={trezorSendAction.cancel.trigger}
+          classicTheme={this.props.stores.profile.isClassicTheme}
         />);
     } else {
       throw new Error('Unsupported hardware wallet found at hardwareWalletDoConfirmation.');


### PR DESCRIPTION
This is a temporary fill until `Dialog` moves to the new scss architecture (after which we can remove these)

<img width="701" alt="image" src="https://user-images.githubusercontent.com/2608559/57629367-a7317c00-75d6-11e9-922f-f4c9bde9c16b.png">
