### PR TITLE
Add missing scrollbar on two pages

### DIFF
--- a/app/components/settings/SettingsLayout.scss
+++ b/app/components/settings/SettingsLayout.scss
@@ -3,6 +3,7 @@
 .component {
   background-color: var(--theme-settings-body-background-color);
   display: flex;
+  overflow: overlay;
   height: 100%;
 
   .settingsPaneWrapper {

--- a/app/components/wallet/WalletAdd.scss
+++ b/app/components/wallet/WalletAdd.scss
@@ -1,4 +1,5 @@
 .component {
+  overflow: overlay;
   height: 100%;
   display: flex;
 


### PR DESCRIPTION
Both the wallet add screen and the settings page didn't work on small screens. This PR adds a scrollbar to both.