### PR TITLE
Fix scrollbar on settings

### DIFF
--- a/app/components/settings/SettingsLayout.scss
+++ b/app/components/settings/SettingsLayout.scss
@@ -3,18 +3,12 @@
 .component {
   background-color: var(--theme-settings-body-background-color);
   display: flex;
-  overflow: overlay;
   height: 100%;
 
   .settingsPaneWrapper {
     flex: 1;
     overflow-x: hidden;
     overflow-y: overlay;
-    
-    &::-webkit-scrollbar-button {
-      height: 7px;
-      display: block;
-    }
   }
 
   .settingsPane {

--- a/app/components/settings/menu/SettingsMenu.scss
+++ b/app/components/settings/menu/SettingsMenu.scss
@@ -3,6 +3,8 @@
 .component {
   background-color: var(--theme-settings-menu-box-background-color);
   border: var(--theme-settings-menu-box-border);
+  height: 100%;
+  overflow: overlay;
 }
 
 :global(.YoroiClassic) .component {
@@ -13,7 +15,6 @@
 
 :global(.YoroiModern) .component {
   width: 250px;
-  height: 100%;
   padding: 20px 0;
   border: none;
   border-radius: 8px;


### PR DESCRIPTION
In #467 I  added a scrolbar to the Settings page (as a whole). This had an unintended side-effect where scrolling to see all categories created whitespace

![image](https://user-images.githubusercontent.com/2608559/57667097-55700c80-763d-11e9-99d1-f1caa7175213.png)

To fix this, I remove the scrollpage from the page as a whole an instead add the scrollbar to the category select which gives the right behavior.

![image](https://user-images.githubusercontent.com/2608559/57667151-7c2e4300-763d-11e9-9561-a5770fd4f732.png)
