### PR TITLE
Fixing overlapping pre-filled values with floating labels

### DIFF
--- a/app/themes/skins/FormFieldOwnSkin.scss
+++ b/app/themes/skins/FormFieldOwnSkin.scss
@@ -38,7 +38,7 @@
   input:-webkit-autofill:hover,
   input:-webkit-autofill:focus,
   input:-webkit-autofill:active {
-      -webkit-transition-delay: 99999s;
+    -webkit-transition-delay: 99999s;
   }
 
   &:hover {

--- a/app/themes/skins/FormFieldOwnSkin.scss
+++ b/app/themes/skins/FormFieldOwnSkin.scss
@@ -31,7 +31,6 @@
     border-radius: 8px;
 
     margin-top: -17px;
-    background-color: transparent;
   }
 
   input:-webkit-autofill,

--- a/app/themes/skins/FormFieldOwnSkin.scss
+++ b/app/themes/skins/FormFieldOwnSkin.scss
@@ -31,6 +31,14 @@
     border-radius: 8px;
 
     margin-top: -17px;
+    background-color: transparent;
+  }
+
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+      -webkit-transition-delay: 99999s;
   }
 
   &:hover {

--- a/app/themes/skins/FormFieldOwnSkin.scss
+++ b/app/themes/skins/FormFieldOwnSkin.scss
@@ -33,6 +33,10 @@
     margin-top: -17px;
   }
 
+  /* By default, Chrome's styling for autofill inputs overlaps with floating labels.
+   * The following fix delays webkit-autofill transition to avoid Chrome setting its
+   * own style and thus floating fields are not overlapped.
+   */
   input:-webkit-autofill,
   input:-webkit-autofill:hover,
   input:-webkit-autofill:focus,


### PR DESCRIPTION
CSS hack for avoiding Chrome pre-filled inputs overlapping with floating input fields.

Before:
![image](https://user-images.githubusercontent.com/1937074/57667932-80be1180-75d3-11e9-9e4c-eaf30ebb465c.png)

After: 
![image](https://user-images.githubusercontent.com/1937074/57667940-887db600-75d3-11e9-9089-a6f285c797f2.png)
