### PR TITLE
Shin/ch1019/importing changes from closed pr 416

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -37,7 +37,9 @@ class App extends Component<{
     if (!environment.isDev()) return undefined;
     try {
       const mobxDevToolsPackage = require('mobx-react-devtools').default;
-      return React.createElement(mobxDevToolsPackage);
+      return React.createElement(mobxDevToolsPackage, {
+        position: 'topRight'
+      });
     } catch (err) {
       return undefined;
     }

--- a/app/components/layout/TopBarLayout.js
+++ b/app/components/layout/TopBarLayout.js
@@ -10,7 +10,7 @@ type Props = {
   children?: ?Node,
   notification?: ?Node,
   banner?: Node,
-  noTopbarNoBanner?: boolean,
+  hideTopbar?: boolean,
   languageSelectionBackground?: boolean,
   classicTheme?: boolean,
   footer?: Node,
@@ -23,7 +23,7 @@ export default class TopBarLayout extends Component<Props> {
     children: undefined,
     notification: undefined,
     banner: undefined,
-    noTopbarNoBanner: undefined,
+    hideTopbar: undefined,
     languageSelectionBackground: false,
     withFooter: false,
     classicTheme: false,
@@ -36,7 +36,7 @@ export default class TopBarLayout extends Component<Props> {
       children,
       topbar,
       notification,
-      noTopbarNoBanner,
+      hideTopbar,
       languageSelectionBackground,
       footer,
       classicTheme
@@ -53,13 +53,14 @@ export default class TopBarLayout extends Component<Props> {
     return (
       <div className={componentClasses}>
         <div className={styles.main}>
-          {noTopbarNoBanner ? null : (
+
+          {banner}
+
+          {hideTopbar ? null : (
             <div className={styles.topbar}>
               {topbar}
             </div>
           )}
-
-          {noTopbarNoBanner ? null : banner}
 
           {notification}
 

--- a/app/components/layout/TopBarLayout.scss
+++ b/app/components/layout/TopBarLayout.scss
@@ -10,12 +10,6 @@ $footerHeight: 56px;
   height: 100%;
   overflow: hidden;
   width: 100%;
-
-  .languageSelectionBackground {
-    background-image: url(../../assets/images/select-language.svg);
-    background-size: cover;
-    background-position-y: bottom;
-  }
   
   .topbar {
     height: $topBarClassicHeight;    
@@ -59,6 +53,12 @@ $footerHeight: 56px;
     flex-direction: column;
     position: relative;
   }
+}
+
+.languageSelectionBackground {
+  background-image: url(../../assets/images/select-language.svg);
+  background-size: cover;
+  background-position-y: bottom;
 }
 
 :global(.YoroiModern) .component {

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component } from 'react';
-import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import SvgInline from 'react-svg-inline';
@@ -59,7 +58,6 @@ type Props = {
   isSubmitting: boolean,
   error?: ?LocalizableError,
   classicTheme: boolean,
-  notification: Node
 };
 
 type State = {
@@ -96,7 +94,6 @@ export default class WalletReceive extends Component<Props, State> {
       onCopyAddress, onAddressDetail,
       isSubmitting, error, isWalletAddressUsed,
       classicTheme,
-      notification
     } = this.props;
     const { intl } = this.context;
     const { showUsed } = this.state;
@@ -144,7 +141,6 @@ export default class WalletReceive extends Component<Props, State> {
               onCopyAddress={onCopyAddress}
               isUsed={isWalletAddressUsed}
             />
-            {!classicTheme && notification}
             <div className={styles.instructionsText}>
               {intl.formatMessage(messages.walletReceiveInstructions)}
             </div>

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -201,7 +201,8 @@ export default class WalletRestoreDialog extends Component<Props> {
         },
         ({ field }) => ([
           // TODO: Should we allow 0-length paper wallet passwords?
-          // Disable for now to avoid user accidentally forgetting to enter his password and pressing restore
+          // Disable for now to avoid user accidentally forgetting
+          // to enter his password and pressing restore
           field.value.length > 0,
           this.context.intl.formatMessage(globalMessages.invalidPaperPassword)
         ]),

--- a/app/containers/MainLayout.js
+++ b/app/containers/MainLayout.js
@@ -10,7 +10,7 @@ import type { InjectedContainerProps } from '../types/injectedPropsType';
 export type MainLayoutProps = InjectedContainerProps & {
   topbar: ?Node,
   classicTheme: boolean,
-  noTopbarNoBanner?: boolean,
+  hideTopbar?: boolean,
   footer: ?Node,
 };
 
@@ -18,7 +18,7 @@ export type MainLayoutProps = InjectedContainerProps & {
 export default class MainLayout extends Component<MainLayoutProps> {
   static defaultProps = {
     topbar: null,
-    noTopbarNoBanner: undefined,
+    hideTopbar: undefined,
     footer: null,
   };
 
@@ -28,7 +28,7 @@ export default class MainLayout extends Component<MainLayoutProps> {
       stores,
       topbar,
       classicTheme,
-      noTopbarNoBanner,
+      hideTopbar,
       footer
     } = this.props;
     const topbarComponent = topbar || (<TopBarContainer actions={actions} stores={stores} />);
@@ -38,7 +38,7 @@ export default class MainLayout extends Component<MainLayoutProps> {
         topbar={topbarComponent}
         notification={<div />}
         classicTheme={classicTheme}
-        noTopbarNoBanner={noTopbarNoBanner}
+        hideTopbar={hideTopbar}
         footer={footer}
       >
         {this.props.children}

--- a/app/containers/profile/LanguageSelectionPage.js
+++ b/app/containers/profile/LanguageSelectionPage.js
@@ -7,6 +7,7 @@ import TopBar from '../../components/topbar/TopBar';
 import TopBarLayout from '../../components/layout/TopBarLayout';
 import LanguageSelectionForm from '../../components/profile/language-selection/LanguageSelectionForm';
 import type { InjectedProps } from '../../types/injectedPropsType';
+import TestnetWarningBanner from '../../components/topbar/banners/TestnetWarningBanner';
 
 const messages = defineMessages({
   title: {
@@ -42,8 +43,9 @@ export default class LanguageSelectionPage extends Component<InjectedProps> {
       <TopBarLayout
         topbar={topBar}
         classicTheme={profile.isClassicTheme}
-        noTopbarNoBanner={profile.isModernTheme}
+        hideTopbar={profile.isModernTheme}
         languageSelectionBackground
+        banner={<TestnetWarningBanner classicTheme={profile.isClassicTheme} />}
       >
         <LanguageSelectionForm
           onSubmit={this.onSubmit}

--- a/app/containers/profile/LanguageSelectionPage.js
+++ b/app/containers/profile/LanguageSelectionPage.js
@@ -45,7 +45,7 @@ export default class LanguageSelectionPage extends Component<InjectedProps> {
         classicTheme={profile.isClassicTheme}
         hideTopbar={profile.isModernTheme}
         languageSelectionBackground
-        banner={<TestnetWarningBanner classicTheme={profile.isClassicTheme} />}
+        banner={<TestnetWarningBanner />}
       >
         <LanguageSelectionForm
           onSubmit={this.onSubmit}

--- a/app/containers/profile/TermsOfUsePage.js
+++ b/app/containers/profile/TermsOfUsePage.js
@@ -30,7 +30,7 @@ export default class TermsOfUsePage extends Component<InjectedProps> {
   render() {
     const { setTermsOfUseAcceptanceRequest, termsOfUse } = this.props.stores.profile;
     const isSubmitting = setTermsOfUseAcceptanceRequest.isExecuting;
-    const { topbar, profile } = this.props.stores;
+    const { topbar } = this.props.stores;
     const topbarTitle = (
       <StaticTopbarTitle title={this.context.intl.formatMessage(messages.title)} />
     );
@@ -42,7 +42,6 @@ export default class TermsOfUsePage extends Component<InjectedProps> {
     return (
       <TopBarLayout
         topbar={topbarElement}
-        isBannerVisible={profile.isModernTheme}
         banner={<TestnetWarningBanner />}
       >
         <TermsOfUseForm

--- a/app/containers/profile/TermsOfUsePage.js
+++ b/app/containers/profile/TermsOfUsePage.js
@@ -30,7 +30,7 @@ export default class TermsOfUsePage extends Component<InjectedProps> {
   render() {
     const { setTermsOfUseAcceptanceRequest, termsOfUse } = this.props.stores.profile;
     const isSubmitting = setTermsOfUseAcceptanceRequest.isExecuting;
-    const { topbar } = this.props.stores;
+    const { topbar, profile } = this.props.stores;
     const topbarTitle = (
       <StaticTopbarTitle title={this.context.intl.formatMessage(messages.title)} />
     );
@@ -42,6 +42,7 @@ export default class TermsOfUsePage extends Component<InjectedProps> {
     return (
       <TopBarLayout
         topbar={topbarElement}
+        classicTheme={profile.isClassicTheme}
         banner={<TestnetWarningBanner />}
       >
         <TermsOfUseForm

--- a/app/containers/wallet/WalletAddPage.js
+++ b/app/containers/wallet/WalletAddPage.js
@@ -147,7 +147,7 @@ export default class WalletAddPage extends Component<Props> {
       <MainLayout
         topbar={topBar}
         footer={<AddWalletFooter />}
-        noTopbarNoBanner={profile.isModernTheme && isWalletAdd}
+        hideTopbar={profile.isModernTheme && isWalletAdd}
         classicTheme={profile.isClassicTheme}
       >
         {content}

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -113,10 +113,9 @@ export default class WalletReceivePage extends Component<Props, State> {
           isSubmitting={addresses.createAddressRequest.isExecuting}
           error={addresses.error}
           classicTheme={profile.isClassicTheme}
-          notification={notificationComponent}
         />
 
-        {profile.isClassicTheme && notificationComponent}
+        {notificationComponent}
 
         {uiDialogs.isOpen(AddressDetailsDialog) && hwVerifyAddress.selectedAddress ? (
           <AddressDetailsDialog


### PR DESCRIPTION
## 1. Move Mobx DevTools to top right
Some times Mobx DevTools overlaps on Yoroi components so moved it to top right, as Testnet warning banner is also moved it wont overlap Yoroi components.
![image](https://user-images.githubusercontent.com/19986226/57678268-ca563d00-7663-11e9-9152-a0e0b4900194.png)

## 2. Move TestnetWarningBanner to top most
- Separating it from main UI

![image](https://user-images.githubusercontent.com/19986226/57678638-9b8c9680-7664-11e9-9a1a-442c93bd2c67.png)

## 3. In case of non mainnet show TestnetWarningBanner on every page including Language Selection and Terms of Use as well.
- Show TestnetWarningBanner on Add Wallet page as well (which was hidden in Modern theme)

![image](https://user-images.githubusercontent.com/19986226/57758293-4fa82300-7732-11e9-9656-f199d96c9fbf.png)

![image](https://user-images.githubusercontent.com/19986226/57758300-53d44080-7732-11e9-8240-1e09a1392b6f.png)

![image](https://user-images.githubusercontent.com/19986226/57758318-5c2c7b80-7732-11e9-8c21-646bbf6c0b39.png)


## 4. New Design fix Receive page [ch523]
https://app.clubhouse.io/emurgo/story/523/new-design-fix-receive-page
Tried to fix copy icon as in: https://projects.invisionapp.com/d/main#/console/17159202/355689458/preview
but it was getting big for this PR, will fix that in subsequent PR.

![image](https://user-images.githubusercontent.com/19986226/57695550-8118e400-7689-11e9-8ac3-0d1ec189925c.png)

## 5. fix lost background on LanguageSelectionPage in new theme(bug in https://github.com/Emurgo/yoroi-frontend/pull/475)
- https://github.com/Emurgo/yoroi-frontend/pull/472/commits/dc00b509f7e38e1ed4e670589f49d96fc835ce8b