### PR TITLE
Fixing input background in Modern Theme when transfering from Daedalus

### DIFF
--- a/app/components/transfer/TransferMnemonicPage.js
+++ b/app/components/transfer/TransferMnemonicPage.js
@@ -121,6 +121,8 @@ export default class TransferMnemonicPage extends Component<Props> {
 
     const recoveryPhraseField = form.$('recoveryPhrase');
 
+    console.log('theme: ' + classicTheme);
+
     return (
       <div className={styles.component}>
         <BorderedBox>
@@ -144,6 +146,7 @@ export default class TransferMnemonicPage extends Component<Props> {
             </div>
 
             <Autocomplete
+              className={styles.inputWrapper}
               options={validWords}
               maxSelections={mnemonicLength}
               {...recoveryPhraseField.bind()}

--- a/app/components/transfer/TransferMnemonicPage.js
+++ b/app/components/transfer/TransferMnemonicPage.js
@@ -121,8 +121,6 @@ export default class TransferMnemonicPage extends Component<Props> {
 
     const recoveryPhraseField = form.$('recoveryPhrase');
 
-    console.log('theme: ' + classicTheme);
-
     return (
       <div className={styles.component}>
         <BorderedBox>

--- a/app/components/transfer/TransferMnemonicPage.scss
+++ b/app/components/transfer/TransferMnemonicPage.scss
@@ -58,8 +58,8 @@
 }
 
 :global(.YoroiModern) .component {
-  .inputWrapper fieldset {
-    background-color: #ffffff !important;
+  .inputWrapper span[class*='selectedWordBox'] {
+    background-color: #D9DDE0 !important;
   }
 
   .body {

--- a/app/components/transfer/TransferMnemonicPage.scss
+++ b/app/components/transfer/TransferMnemonicPage.scss
@@ -59,7 +59,7 @@
 
 :global(.YoroiModern) .component {
   .inputWrapper span[class*='selectedWordBox'] {
-    background-color: #D9DDE0 !important;
+    background-color: var(--rp-autocomplete-selected-word-box-bg-color-secondary);
   }
 
   .body {

--- a/app/components/transfer/TransferMnemonicPage.scss
+++ b/app/components/transfer/TransferMnemonicPage.scss
@@ -59,7 +59,7 @@
 
 :global(.YoroiModern) .component {
   .inputWrapper fieldset {
-    background-color: #ffffff!important;
+    background-color: #ffffff !important;
   }
 
   .body {

--- a/app/components/transfer/TransferMnemonicPage.scss
+++ b/app/components/transfer/TransferMnemonicPage.scss
@@ -58,6 +58,10 @@
 }
 
 :global(.YoroiModern) .component {
+  .inputWrapper fieldset {
+    background-color: #ffffff!important;
+  }
+
   .body {
     .title {
       font-size: 18px;

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -17,6 +17,7 @@ const rpAutocomplete = {
   '--rp-autocomplete-input-text-color': '#353535',
   '--rp-autocomplete-placeholder-color': 'rgba(94, 96, 102, 0.5)', // #5E6066
   '--rp-autocomplete-selected-word-box-bg-color': '#f0f3f5',
+  '--rp-autocomplete-selected-word-box-bg-color-secondary': '#D9DDE0',
   '--rp-autocomplete-selected-word-text-color': '#353535',
 };
 


### PR DESCRIPTION
Fixing input background from gray to white.

![Screen Shot 2019-05-14 at 10 05 40 PM](https://user-images.githubusercontent.com/1937074/57748005-f5fa1700-76a5-11e9-9132-e26f7318154e.png)

UPDATE:
![Screen Shot 2019-05-15 at 4 44 11 PM](https://user-images.githubusercontent.com/1937074/57808136-bcbab900-7730-11e9-930c-e225d665496c.png)
