### PR TITLE
Maintain button for showing password when the field is on error

### DIFF
--- a/app/themes/skins/FormFieldOwnSkin.js
+++ b/app/themes/skins/FormFieldOwnSkin.js
@@ -85,7 +85,7 @@ export const FormFieldOwnSkin = class extends React.Component<Props, State> {
 
           <div className={styles.iconsWrapper}>
             {this.props.done && <SvgInline svg={SuccessSvg} />}
-            {this.props.error && <SvgInline svg={ErrorSvg}/>}
+            {this.props.error && <SvgInline svg={ErrorSvg} />}
             {this.props.type === 'password' ? (
               <button tabIndex="-1" type="button" onClick={this.showPassword}>
                 {isPasswordShown

--- a/app/themes/skins/FormFieldOwnSkin.js
+++ b/app/themes/skins/FormFieldOwnSkin.js
@@ -85,14 +85,14 @@ export const FormFieldOwnSkin = class extends React.Component<Props, State> {
 
           <div className={styles.iconsWrapper}>
             {this.props.done && <SvgInline svg={SuccessSvg} />}
-            {this.props.type === 'password' && !this.props.error ? (
+            {this.props.error && <SvgInline svg={ErrorSvg}/>}
+            {this.props.type === 'password' ? (
               <button tabIndex="-1" type="button" onClick={this.showPassword}>
                 {isPasswordShown
                   ? <SvgInline svg={PasswordSvg} />
                   : <SvgInline svg={PasswordHiddenSvg} />}
               </button>
             ) : null}
-            {this.props.error && <SvgInline svg={ErrorSvg} />}
           </div>
           {this.props.render(omit(renderProps, ['themeId']))}
         </fieldset>


### PR DESCRIPTION
Eye button for showing passwords disappears if the input is incorrect so it doesn't let you see what's wrong. Fixing that.

![Screen Shot 2019-05-14 at 8 14 18 PM](https://user-images.githubusercontent.com/1937074/57748067-57ba8100-76a6-11e9-9805-ed014d4a2aea.png)
