### PR TITLE
shin/ch1059/fix-app-components-widgets-copyableaddress

### DIFF
--- a/app/components/widgets/Dialog.js
+++ b/app/components/widgets/Dialog.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import type { Node } from 'react';
+import { THEMES } from '../../themes';
 import { Modal } from 'react-polymorph/lib/components/Modal';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
@@ -61,6 +62,16 @@ export default class Dialog extends Component<Props> {
     } = this.props;
     const secondaryButton = classicTheme ? 'flat' : 'outlined';
 
+    /* Dialog is spacial case as it's not a child of React #root.
+     * For Theme change management, setting current theme is nessesary like below
+     * classicTheme ? THEMES.YOROI_CLASSIC : THEMES.YOROI_MODERN
+     * This should be updated on addition/deletion of theme */
+    const componentStyle = classnames([
+      classicTheme ? THEMES.YOROI_CLASSIC : THEMES.YOROI_MODERN,
+      styles.component,
+      className,
+    ]);
+
     return (
       <Modal
         isOpen
@@ -69,7 +80,7 @@ export default class Dialog extends Component<Props> {
         skin={this.setSkin}
       >
 
-        <div className={classnames([styles.component, className])}>
+        <div className={componentStyle}>
           {title && (
             <div className={styles.title}>
               <h1>{title}</h1>


### PR DESCRIPTION
**Note:**
- [X] https://github.com/Emurgo/yoroi-frontend/pull/490/commits/bbc637808d25871798b28897ed6a7dd8443bdd47 As Dialog is not a child of `#root` or `.Yoroi[Classic]/[Modern]` we need to change our policy for Dialogs.

![image](https://user-images.githubusercontent.com/19986226/57926203-a4d86600-78e5-11e9-89bc-a9af9f28b4e8.png)
```
/* Dialog is spacial case as it's not a child of React #root.
* For Theme change management, setting current theme is nessesary like below
* classicTheme ? THEMES.YOROI_CLASSIC : THEMES.YOROI_MODERN
* This should be updated on addition/deletion of theme */
```

- [X] Checked following dialogs in both of the Themes:
![image](https://user-images.githubusercontent.com/19986226/58075276-43184480-7be2-11e9-9bf0-7571b62df486.png)
