### PR TITLE
Fix error logging

### DIFF
--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -23,8 +23,9 @@ export const Logger = {
   },
 
   error: (data : string) => {
-    logger.error(data);
-    logs.enq(`[${moment().format()}] ${data}\n`);
+    const fixedString = data.replace(/\\n/g, '\n');
+    logger.error(fixedString);
+    logs.enq(`[${moment().format()}] ${fixedString}\n`);
   },
 
   warn: (data : string) => {


### PR DESCRIPTION
We've probably all experienced it at this point:

Your code throws an error and you try and click the line in the stack trace to open the file but it fails because the `\n` is considered part of the URL

No more!

### Old
<img width="819" alt="image" src="https://user-images.githubusercontent.com/2608559/57971495-ed694f80-79c9-11e9-8bc2-9c73d0db99a5.png">

### New
<img width="846" alt="image" src="https://user-images.githubusercontent.com/2608559/57971469-aa0ee100-79c9-11e9-86e5-11a45e638799.png">
