### PR TITLE
Shin/ch1096/fix dialog width in moderntheme

### DIFF
--- a/app/components/wallet/hwConnect/trezor/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/trezor/ConnectDialog.js
@@ -136,16 +136,8 @@ export default class ConnectDialog extends Component<Props> {
         <ProgressStepBlock progressInfo={progressInfo} classicTheme={classicTheme} />
         {introBlock}
         {middleBlock}
-
-        {!classicTheme && (
-          <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
-        )}
-
         <HelpLinkBlock progressInfo={progressInfo} classicTheme={classicTheme} />
-
-        {classicTheme && (
-          <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
-        )}
+        <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
       </Dialog>);
   }
 }

--- a/app/components/wallet/hwConnect/trezor/SaveDialog.js
+++ b/app/components/wallet/hwConnect/trezor/SaveDialog.js
@@ -162,16 +162,8 @@ export default class SaveDialog extends Component<Props> {
         <ProgressStepBlock progressInfo={progressInfo} classicTheme={classicTheme} />
         {walletNameBlock}
         {middleBlock}
-
-        {!classicTheme && (
-          <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
-        )}
-
         <HelpLinkBlock progressInfo={progressInfo} classicTheme={classicTheme} />
-
-        {classicTheme && (
-          <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
-        )}
+        <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
       </Dialog>);
   }
 

--- a/app/themes/overrides/AutocompleteOverrides.scss
+++ b/app/themes/overrides/AutocompleteOverrides.scss
@@ -12,7 +12,6 @@
     }
 
     &:focus, &:active, &.opened {
-      padding: 9px 14px;
       border-width: 2px;
     }
 

--- a/app/themes/overrides/AutocompleteOverrides.scss
+++ b/app/themes/overrides/AutocompleteOverrides.scss
@@ -3,8 +3,8 @@
 .autocompleteWrapper  {
   .autocompleteContent {
     border: none;
-    min-height: 160px;
-    padding: 10px 15px;
+    min-height: 140px;
+    padding: 0px 15px 15px 15px;
     border-radius: 8px;
 
     &:hover {

--- a/app/themes/overrides/ModalOverrides.scss
+++ b/app/themes/overrides/ModalOverrides.scss
@@ -6,7 +6,7 @@
 
 .modal {
   border-radius: 8px;
-  padding: 25px 30px 30px;
+  padding: 25px 40px 40px 40px;
   display: flex;
   flex-direction: column;
 

--- a/app/themes/overrides/ModalOverrides.scss
+++ b/app/themes/overrides/ModalOverrides.scss
@@ -9,8 +9,6 @@
   padding: 25px 30px 30px;
   display: flex;
   flex-direction: column;
-  min-width: 465px;
-  max-width: 465px;
 
   :global {
     .WalletExportDialogChoices_component {

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -85,6 +85,8 @@ const rpModal = {
   '--rp-modal-bg-color': '#fff',
   '--rp-modal-max-height': '97%',
   '--rp-modal-overlay-bg-color': 'rgba(0, 0, 0, 0.4)', // #000000
+  '--rp-modal-max-width': `600px`,
+  '--rp-modal-min-width': `600px`,
 };
 
 // OPTIONS

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -85,8 +85,8 @@ const rpModal = {
   '--rp-modal-bg-color': '#fff',
   '--rp-modal-max-height': '97%',
   '--rp-modal-overlay-bg-color': 'rgba(0, 0, 0, 0.4)', // #000000
-  '--rp-modal-max-width': `600px`,
-  '--rp-modal-min-width': `600px`,
+  '--rp-modal-max-width': `560px`,
+  '--rp-modal-min-width': `560px`,
 };
 
 // OPTIONS

--- a/app/themes/skins/FormFieldOwnSkin.scss
+++ b/app/themes/skins/FormFieldOwnSkin.scss
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   height: 100%;
-  right: 13px;
+  right: 12px;
   top: 0;
   padding-top: 7px;
 


### PR DESCRIPTION
### 1. Common width for New theme dialog ( later need to customize for some dialog)
![image](https://user-images.githubusercontent.com/19986226/58111592-b646a880-7c2c-11e9-838b-be00e19d743d.png)

### 2. Location of error block was varying on Theme and Trezor or Ledger, made it fixed position in both of the Themes and Trezor/Ledger dialog
![image](https://user-images.githubusercontent.com/19986226/58111835-3240f080-7c2d-11e9-9ccb-fae503062819.png)

### 3 Fixed glitch on all `Autocomplete` components on edit start

### 4 Fixed glitch on all `Autocomplete` component's right icon on edit start