### PR TITLE
Informative message about verification step in the creation of a paper wallet

### DIFF
--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -10,6 +10,7 @@ import { AutocompleteSkin } from 'react-polymorph/lib/skins/simple/AutocompleteS
 import { defineMessages, intlShape } from 'react-intl';
 import ReactToolboxMobxForm from '../../utils/ReactToolboxMobxForm';
 import DialogCloseButton from '../widgets/DialogCloseButton';
+import InformativeMessage from '../widgets/InformativeMessage';
 import Dialog from '../widgets/Dialog';
 import {
   isValidWalletName,
@@ -123,6 +124,7 @@ type Props = {
   showPaperPassword?: boolean,
   classicTheme: boolean,
   initValues?: WalletRestoreDialogValues,
+  introMessage?: string,
 };
 
 @observer
@@ -135,6 +137,7 @@ export default class WalletRestoreDialog extends Component<Props> {
     isVerificationMode: undefined,
     showPaperPassword: undefined,
     initValues: undefined,
+    introMessage: '',
   };
 
   static contextTypes = {
@@ -283,6 +286,7 @@ export default class WalletRestoreDialog extends Component<Props> {
       classicTheme,
       mnemonicValidator,
       passwordValidator,
+      introMessage
     } = this.props;
     const {
       walletName,
@@ -381,7 +385,12 @@ export default class WalletRestoreDialog extends Component<Props> {
         classicTheme={classicTheme}
       >
 
-        {isVerificationMode ? '' : (
+        {isVerificationMode ? (
+          introMessage && <InformativeMessage
+            subclass="component-bordered"
+            message={introMessage}
+          />
+        ) : (
           <Input
             className={walletNameFieldClasses}
             ref={(input) => { this.walletNameInput = input; }}

--- a/app/components/widgets/InformativeMessage.js
+++ b/app/components/widgets/InformativeMessage.js
@@ -1,0 +1,36 @@
+// @flow
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import ReactMarkdown from 'react-markdown';
+import classNames from 'classnames';
+import styles from './InformativeMessage.scss';
+
+type Props = {
+  title?: string,
+  message?: string,
+  subclass?: string,
+};
+
+@observer
+export default class InformativeMessage extends Component<Props> {
+  static defaultProps = {
+    title: '',
+    message: '',
+    subclass: ''
+  };
+
+  render() {
+    const { title, message, subclass } = this.props;
+
+    const messageStyle = classNames([
+      subclass ? styles[subclass] : styles.component
+    ]);
+
+    return (
+      <div className={messageStyle}>
+        {title && <h1>{title}</h1>}
+        {message && <ReactMarkdown source={message} />}
+      </div>
+    );
+  }
+}

--- a/app/components/widgets/InformativeMessage.scss
+++ b/app/components/widgets/InformativeMessage.scss
@@ -1,0 +1,52 @@
+.component {
+  color: var(--theme-bordered-box-text-color);
+  text-align: justify;
+  margin-top: 10px;
+
+  h1 {
+    color: var(--theme-dialog-title-color);
+    font-family: var(--font-medium);
+    font-size: 14px;
+    margin-bottom: 11px;
+  }
+
+  p {
+    font-family: var(--font-regular);
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    line-height: 1.38;
+    margin-bottom: 11px;
+  }
+
+  p em {
+  	font-weight: bold;
+  }
+}
+
+.component-bordered {
+  color: var(--theme-bordered-box-text-color);
+  text-align: justify;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  background-color: var(--theme-bordered-box-background-color);
+  border-radius: 8px;
+  padding: 16px;
+
+  h1 {
+    color: var(--theme-dialog-title-color);
+    font-family: var(--font-medium);
+    font-size: 14px;
+    margin-bottom: 11px;
+  }
+
+  p {
+    font-family: var(--font-regular);
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    line-height: 1.38;
+  }
+
+  p em {
+  	font-weight: bold;
+  }
+}

--- a/app/containers/wallet/dialogs/CreatePaperWalletDialogContainer.js
+++ b/app/containers/wallet/dialogs/CreatePaperWalletDialogContainer.js
@@ -12,11 +12,24 @@ import WalletRestoreDialog from '../../../components/wallet/WalletRestoreDialog'
 import validWords from 'bip39/src/wordlists/english.json';
 import FinalizeDialog from '../../../components/wallet/settings/paper-wallets/FinalizeDialog';
 import type { AdaPaper } from '../../../api/ada';
+import { defineMessages, intlShape } from 'react-intl';
+
+const messages = defineMessages({
+  verifyPaperWallet: {
+    id: 'settings.paperWallet.dialog.verify.message',
+    defaultMessage: '!!!Verify your paper wallet',
+  },
+});
 
 @observer
 export default class CreatePaperWalletDialogContainer extends Component<InjectedProps> {
 
+  static contextTypes = {
+    intl: intlShape.isRequired
+  };
+
   render() {
+    const { intl } = this.context;
     const { actions } = this.props;
     const { uiDialogs, profile } = this.props.stores;
     const { updateDataForActiveDialog } = actions.dialogs;
@@ -88,6 +101,7 @@ export default class CreatePaperWalletDialogContainer extends Component<Injected
             showPaperPassword
             isVerificationMode
             classicTheme={profile.isClassicTheme}
+            introMessage={intl.formatMessage(messages.verifyPaperWallet)}
           />
         );
       case ProgressStep.FINALIZE:

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -14,7 +14,8 @@ import {
 import type { WalletAccountNumberPlate } from '../../../domain/Wallet';
 
 type Props = InjectedDialogContainerProps & {
-  mode: "regular" | "paper"
+  mode: "regular" | "paper",
+  introMessage?: string,
 };
 
 const NUMBER_OF_VERIFIED_ADDRESSES = 1;
@@ -130,6 +131,7 @@ export default class WalletRestoreDialogContainer
         showPaperPassword={isPaper}
         classicTheme={this.props.classicTheme}
         initValues={submitValues || undefined}
+        introMessage={this.props.introMessage || ''}
       />
     );
   }

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -160,6 +160,7 @@
   "settings.paperWallet.dialog.repeatPasswordLabel": "Repeat paper wallet password",
   "settings.paperWallet.dialog.repeatPasswordPlaceholder": "Type paper wallet password again",
   "settings.paperWallet.dialog.userPassword.title": "Set custom paper wallet password",
+  "settings.paperWallet.dialog.verify.message": "This is the final step. Please verify the mnemonic phrase (printed on the PDF certificate) and the password to make sure you have all the valid information to *access your funds later*. On the next screen you will also be able to verify the account checksum and copy your new addresses.",
   "settings.paperWallet.numAddressesSelect.label": "Number of addresses",
   "settings.paperWallet.printIdentificationCheckbox.label": "Print Paper Wallet account checksum",
   "settings.support.faq.blogLinkUrl": "https://emurgo.io/#/en/blog/yoroi-custom-themes",


### PR DESCRIPTION
Created a new component for displaying customizable informative messages. Included it in the restore wallet dialog when creating a paper wallet.

The new component has an optional title, text and style. I included two basic styles: 1) gray box with text. 2) just text

1)
![Screen Shot 2019-05-21 at 12 40 13 AM](https://user-images.githubusercontent.com/1937074/58070472-36a2d600-7b67-11e9-9c20-2c643ba934dd.png)


2) 
![Screen Shot 2019-05-21 at 12 40 45 AM](https://user-images.githubusercontent.com/1937074/58070454-23900600-7b67-11e9-949f-9e16a7f46e8d.png)
