### PR TITLE
Update of new SCSS architecture(base at #434)

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -19,6 +19,7 @@ import { themeOverrides } from './themes/overrides';
 import translations from './i18n/translations';
 import type { StoresMap } from './stores';
 import type { ActionsMap } from './actions';
+import { THEMES } from './themes';
 import ThemeManager from './ThemeManager';
 import environment from './environment';
 import { hot } from 'react-hot-loader';
@@ -58,8 +59,17 @@ class App extends Component<{
     const currentTheme = stores.profile.currentTheme;
     const mobxDevTools = this.mobxDevToolsInstanceIfDevEnv();
 
+    // Refer: https://github.com/Emurgo/yoroi-frontend/pull/497
+    if (document && document.body instanceof HTMLBodyElement) {
+      // Flow give error when directly assesing document.body.classList.[remove()]|[add()]
+      const bodyClassList = document.body.classList;
+      const allThemes: Array<string> = Object.keys(THEMES).map(key => THEMES[key]);
+      bodyClassList.remove(...allThemes);
+      bodyClassList.add(currentTheme);
+    }
+
     return (
-      <div className={currentTheme} style={{ height: '100%' }}>
+      <div style={{ height: '100%' }}>
         <ThemeManager variables={themeVars} />
 
         {/* Automatically pass a theme prop to all componenets in this subtree. */}

--- a/app/App.js
+++ b/app/App.js
@@ -63,6 +63,8 @@ class App extends Component<{
     if (document && document.body instanceof HTMLBodyElement) {
       // Flow give error when directly assesing document.body.classList.[remove()]|[add()]
       const bodyClassList = document.body.classList;
+      // we can't simply set the className because there can be other classes present
+      // therefore we only remove & add those related to the theme
       const allThemes: Array<string> = Object.keys(THEMES).map(key => THEMES[key]);
       bodyClassList.remove(...allThemes);
       bodyClassList.add(currentTheme);

--- a/chrome/views/main_window.html
+++ b/chrome/views/main_window.html
@@ -7,4 +7,4 @@
   <body>
     <div id="root"></div>
   </body>
-  </html>
+</html>


### PR DESCRIPTION
Base architecture in: https://github.com/Emurgo/yoroi-frontend/pull/434
As there was a problem in case of dialog, which is explained in: https://github.com/Emurgo/yoroi-frontend/pull/490

## Solution:
- [X]  Moved theme identifier tag to `<body>` tag

![image](https://user-images.githubusercontent.com/19986226/58164862-98775300-7cc1-11e9-9b49-f200243ad989.png)
