### PR TITLE
[ClassicTheme] fix CREATE A NEW WALLET dialog

### DIFF
--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -222,7 +222,7 @@ export default class WalletCreateDialog extends Component<Props, State> {
               skin={classicTheme ? InputSkin : InputOwnSkin}
             />
 
-            <PasswordInstructions isClassicThemeActive={classicTheme} />
+            <PasswordInstructions />
           </div>
         </div>
 

--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -1,52 +1,61 @@
 @import '../../themes/mixins/loading-spinner';
 @import '../../themes/mixins/place-form-field-error-below-input';
 
-.walletPasswordClassic {
-  .walletPasswordFields {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    transition: all 400ms ease;
-
-    &.show {
-      max-height: 250px;
-      opacity: 1;
-      overflow: visible;
+.component {
+  .walletPassword {
+    .walletPasswordFields {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      max-height: 0;
+      opacity: 0;
+      overflow: hidden;
+      transition: all 400ms ease;
+  
+      &.show {
+        max-height: 250px;
+        opacity: 1;
+      }
+  
+      & > div {
+        width: 350px;
+      }
+  
+      @include place-form-field-error-below-input;
     }
+  }
 
-    & > div {
-      margin-top: 30px;
-      width: 350px;
-    }
-
-    @include place-form-field-error-below-input;
+  .isSubmitting {
+    @include loading-spinner("../../assets/images/spinner-light.svg");
   }
 }
 
-.walletPassword {
-  .walletPasswordFields {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    transition: all 400ms ease;
-
-    &.show {
-      max-height: 600px;
-      opacity: 1;
+:global(.YoroiClassic) .component {
+  .walletPassword {
+    .walletPasswordFields {
+      &.show {
+        overflow: visible;
+      }
+  
+      & > div {
+        margin-top: 30px;
+      }
+  
+      @include place-form-field-error-below-input;
     }
-
-    & > div {
-      width: 100%;
-    }
-  }
+  }  
 }
 
-.isSubmitting {
-  @include loading-spinner("../../assets/images/spinner-light.svg");
+:global(.YoroiModern) .component {
+  .walletPassword {
+    .walletPasswordFields {
+      &.show {
+        max-height: 600px;
+      }
+
+      & > div {
+        width: 100%;
+      }
+    }
+  }
 }

--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -20,8 +20,6 @@
       & > div {
         width: 350px;
       }
-  
-      @include place-form-field-error-below-input;
     }
   }
 

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -449,7 +449,7 @@ export default class WalletRestoreDialog extends Component<Props> {
                 error={repeatedPasswordField.error}
                 skin={classicTheme ? InputSkin : InputOwnSkin}
               />
-              <PasswordInstructions isClassicThemeActive={classicTheme} />
+              <PasswordInstructions />
             </div>
           </div>
         )}

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.js
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.js
@@ -235,7 +235,7 @@ export default class ChangeWalletPasswordDialog extends Component<Props> {
             skin={classicTheme ? InputSkin : InputOwnSkin}
           />
 
-          <PasswordInstructions isClassicThemeActive={classicTheme} />
+          <PasswordInstructions />
         </div>
 
         {error ? <p className={styles.error}>{intl.formatMessage(error)}</p> : null}

--- a/app/components/wallet/settings/paper-wallets/UserPasswordDialog.js
+++ b/app/components/wallet/settings/paper-wallets/UserPasswordDialog.js
@@ -190,7 +190,6 @@ export default class UserPasswordDialog extends Component<Props> {
           />
         </div>
         <PasswordInstructions
-          isClassicThemeActive={classicTheme}
           instructionDescriptor={globalMessages.passwordInstructionsPaperWallet}
         />
 

--- a/app/components/widgets/forms/PasswordInstructions.js
+++ b/app/components/widgets/forms/PasswordInstructions.js
@@ -4,7 +4,6 @@ import styles from './PasswordInstructions.scss';
 import { defineMessages, intlShape, MessageDescriptor } from 'react-intl';
 
 type Props = {
-  isClassicThemeActive: boolean,
   instructionDescriptor?: MessageDescriptor
 };
 
@@ -27,18 +26,14 @@ export default class PasswordInstructions extends Component<Props> {
 
   render() {
     const { intl } = this.context;
-    const { isClassicThemeActive, instructionDescriptor } = this.props;
-
-    const passwordInstructionsClasses = isClassicThemeActive
-      ? styles.passwordInstructionsClassic
-      : styles.passwordInstructions;
+    const { instructionDescriptor } = this.props;
 
     const displayInstructionDescriptor = instructionDescriptor
       ? instructionDescriptor
       : messages.passwordInstructions;
 
     return (
-      <p className={passwordInstructionsClasses}>
+      <p className={styles.component}>
         {intl.formatMessage(displayInstructionDescriptor)}
       </p>
     );

--- a/app/components/widgets/forms/PasswordInstructions.scss
+++ b/app/components/widgets/forms/PasswordInstructions.scss
@@ -1,42 +1,18 @@
-.passwordInstructionsClassic {
+.component {
   color: var(--theme-instructions-text-color);
   font-family: var(--font-light);
   line-height: 1.38;
   margin-top: 20px;
+}
+
+:global(.YoroiClassic) .component {
   opacity: 0.5;
 }
 
-.passwordInstructions {
-  color: var(--theme-instructions-text-color);
+:global(.YoroiModern) .component {
   font-family: var(--font-regular);
   line-height: 1.71;
   margin-top: 14px;
   font-size: 14px;
   letter-spacing: 0;
-
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  li {
-    list-style-type: disc;
-    margin-left: 18px;
-    width: calc(50% - 18px);
-  }
-
-  .successCondition {
-    position: relative;
-    color: var(--theme-password-condition-text-color);
-    list-style-type: none;
-
-    span:first-child {
-      position: absolute;
-      left: -18px;
-    }
-
-    svg {
-      width: 11px;
-    }
-  }
 }


### PR DESCRIPTION
REF: https://github.com/Emurgo/yoroi-frontend/pull/434

#### 1. https://github.com/Emurgo/yoroi-frontend/pull/501/commits/074675798f7d2503aa37e76f73f214cb1f9ece22 PasswordInstructions new scss architecture ( is used inside WalletCreateDialog )

#### 2. https://github.com/Emurgo/yoroi-frontend/pull/501/commits/a0ea1d581fd0e71b06ef3d112970b839980339eb WalletCreateDialog apply new scss architecture

This story started with fixing this:
![image](https://user-images.githubusercontent.com/19986226/58184208-9fb35680-7ceb-11e9-937e-10ea47b12b32.png)
But after looking into code, I found out that it was not intentional to change the old design(it was bug in SCSS), after fixing SCSS bugs, it automatically restored(without changing anything in `WalletCreateDialog.js`) like before:
![image](https://user-images.githubusercontent.com/19986226/58184507-2e27d800-7cec-11e9-82e7-52b8998e661d.png)

