### PR TITLE
New checkbox component with label and description

### DIFF
--- a/app/components/settings/categories/PaperWalletSettings.js
+++ b/app/components/settings/categories/PaperWalletSettings.js
@@ -14,6 +14,8 @@ import LocalizableError from '../../../i18n/LocalizableError';
 import styles from './PaperWalletSettings.scss';
 import ReactMarkdown from 'react-markdown';
 import type { Node } from 'react';
+import { CheckboxOwnSkin } from '../../../themes/skins/CheckboxOwnSkin';
+import InformativeMessage from '../../widgets/InformativeMessage';
 
 const messages = defineMessages({
   numAddressesSelectLabel: {
@@ -23,6 +25,10 @@ const messages = defineMessages({
   printIdentificationSelectLabel: {
     id: 'settings.paperWallet.printIdentificationCheckbox.label',
     defaultMessage: '!!!Print Paper Wallet account checksum',
+  },
+  printIdentificationMessage: {
+    id: 'settings.paperWallet.printIdentificationCheckbox.description',
+    defaultMessage: '!!!Enabling this will forfeit plausible deniability',
   },
   createPaperLabel: {
     id: 'settings.paperWallet.createPaper.label',
@@ -106,10 +112,12 @@ export default class PaperWalletSettings extends Component<Props> {
         />
 
         <Checkbox
-          skin={CheckboxSkin}
+          skin={CheckboxOwnSkin}
           {...printPaperWalletIdentification.bind()}
           checked={printPaperWalletIdentification.value}
           onChange={this.setPrintPaperIdentification}
+          label={this.context.intl.formatMessage(messages.printIdentificationSelectLabel)}
+          description={this.context.intl.formatMessage(messages.printIdentificationMessage)}
         />
 
         <Button

--- a/app/components/settings/categories/PaperWalletSettings.js
+++ b/app/components/settings/categories/PaperWalletSettings.js
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import { Checkbox } from 'react-polymorph/lib/components/Checkbox';
 import { Select } from 'react-polymorph/lib/components/Select';
 import { Button } from 'react-polymorph/lib/components/Button';
-import { CheckboxSkin } from 'react-polymorph/lib/skins/simple/CheckboxSkin';
 import { SelectSkin } from 'react-polymorph/lib/skins/simple/SelectSkin';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import { defineMessages, intlShape } from 'react-intl';
@@ -15,7 +14,6 @@ import styles from './PaperWalletSettings.scss';
 import ReactMarkdown from 'react-markdown';
 import type { Node } from 'react';
 import { CheckboxOwnSkin } from '../../../themes/skins/CheckboxOwnSkin';
-import InformativeMessage from '../../widgets/InformativeMessage';
 
 const messages = defineMessages({
   numAddressesSelectLabel: {

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -10,10 +10,6 @@
   margin-bottom: 0;
 }
 
-.paperPassword {
-  margin-top: 30px;
-}
-
 .walletPasswordClassic {
   .walletPasswordFields {
     display: flex;

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -33,6 +33,10 @@
 
     @include place-form-field-error-below-input;
   }
+
+  .paperPassword {
+    margin-top: 30px;
+  }
 }
 
 .walletPassword {

--- a/app/components/widgets/InformativeMessage.js
+++ b/app/components/widgets/InformativeMessage.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component } from 'react';
+import type { Children } from 'react';
 import { observer } from 'mobx-react';
 import ReactMarkdown from 'react-markdown';
 import classNames from 'classnames';
@@ -9,6 +10,7 @@ type Props = {
   title?: string,
   message?: string,
   subclass?: string,
+  children?: Children
 };
 
 @observer
@@ -16,21 +18,30 @@ export default class InformativeMessage extends Component<Props> {
   static defaultProps = {
     title: '',
     message: '',
-    subclass: ''
+    subclass: '',
+    children: null
   };
 
   render() {
-    const { title, message, subclass } = this.props;
+    const { title, message, subclass, children } = this.props;
 
     const messageStyle = classNames([
       subclass ? styles[subclass] : styles.component
     ]);
 
-    return (
-      <div className={messageStyle}>
-        {title && <h1>{title}</h1>}
-        {message && <ReactMarkdown source={message} />}
-      </div>
-    );
+    if (children !== null) {
+      return (
+        <div className={messageStyle}>
+          {children}
+        </div>
+      );
+    } else {
+      return (
+        <div className={messageStyle}>
+          {title && <h1>{title}</h1>}
+          {message && <ReactMarkdown source={message} />}
+        </div>
+      );
+    }
   }
 }

--- a/app/components/widgets/InformativeMessage.js
+++ b/app/components/widgets/InformativeMessage.js
@@ -1,4 +1,3 @@
-// @flow
 import React, { Component } from 'react';
 import type { Children } from 'react';
 import { observer } from 'mobx-react';
@@ -35,13 +34,12 @@ export default class InformativeMessage extends Component<Props> {
           {children}
         </div>
       );
-    } else {
-      return (
-        <div className={messageStyle}>
-          {title && <h1>{title}</h1>}
-          {message && <ReactMarkdown source={message} />}
-        </div>
-      );
     }
+    return (
+      <div className={messageStyle}>
+        {title && <h1>{title}</h1>}
+        {message && <ReactMarkdown source={message} />}
+      </div>
+    );
   }
 }

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -167,6 +167,7 @@
   "settings.paperWallet.dialog.verify.message": "This is the final step. Please verify the mnemonic phrase (printed on the PDF certificate) and the password to make sure you have all the valid information to *access your funds later*. On the next screen you will also be able to verify the account checksum and copy your new addresses.",
   "settings.paperWallet.numAddressesSelect.label": "Number of addresses",
   "settings.paperWallet.printIdentificationCheckbox.label": "Print Paper Wallet account checksum",
+  "settings.paperWallet.printIdentificationCheckbox.description": "Enabling this will forfeit plausible deniability for your wallet.",
   "settings.support.faq.blogLinkUrl": "https://emurgo.io/#/en/blog/yoroi-custom-themes",
   "settings.support.faq.blogLinkWrapper": "blog post",
   "settings.support.faq.content": "If you are experiencing issues, please see the {faqLink} for guidance on known issues.",

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -167,7 +167,7 @@
   "settings.paperWallet.dialog.verify.message": "This is the final step. Please verify the mnemonic phrase (printed on the PDF certificate) and the password to make sure you have all the valid information to *access your funds later*. On the next screen you will also be able to verify the account checksum and copy your new addresses.",
   "settings.paperWallet.numAddressesSelect.label": "Number of addresses",
   "settings.paperWallet.printIdentificationCheckbox.label": "Print Paper Wallet account checksum",
-  "settings.paperWallet.printIdentificationCheckbox.description": "Enabling this will forfeit plausible deniability for your wallet.",
+  "settings.paperWallet.printIdentificationCheckbox.description": "Enabling this will help you verify your wallet at the moment of restoration, but it will also **forfeit plausible deniability**.",
   "settings.support.faq.blogLinkUrl": "https://emurgo.io/#/en/blog/yoroi-custom-themes",
   "settings.support.faq.blogLinkWrapper": "blog post",
   "settings.support.faq.content": "If you are experiencing issues, please see the {faqLink} for guidance on known issues.",

--- a/app/themes/skins/CheckboxOwnSkin.js
+++ b/app/themes/skins/CheckboxOwnSkin.js
@@ -46,16 +46,15 @@ export const CheckboxOwnSkin = (props: Props) => (
         props.checked ? props.theme[props.themeId].checked : null
       ])}
     />
-    
     <div
       className={styles.checkboxWrapper}
     >
       {props.label && (
+        // eslint-disable-next-line
         <label className={props.theme[props.themeId].label}>
           {props.label}
         </label>
       )}
-      <br />
       {props.description && (
         <ReactMarkdown source={props.description} />
       )}

--- a/app/themes/skins/CheckboxOwnSkin.js
+++ b/app/themes/skins/CheckboxOwnSkin.js
@@ -1,0 +1,64 @@
+// @flow
+// Extended version of Checkbox component from react-polymorph (simple skin)
+import React from 'react';
+import type { Element } from 'react';
+// external libraries
+import classnames from 'classnames';
+import { pickDOMProps } from 'react-polymorph/lib/utils/props';
+import ReactMarkdown from 'react-markdown';
+import styles from './CheckboxOwnSkin.scss';
+
+type Props = {
+  checked: boolean,
+  className: string,
+  disabled: boolean,
+  onChange: Function,
+  label: string | Element<any>,
+  description: string | Element<any>,
+  theme: Object,
+  themeId: string
+};
+
+export const CheckboxOwnSkin = (props: Props) => (
+  <div
+    role="presentation"
+    aria-hidden
+    className={classnames([
+      props.className,
+      props.theme[props.themeId].root,
+      props.disabled ? props.theme[props.themeId].disabled : null,
+      props.checked ? props.theme[props.themeId].checked : null
+    ])}
+    onClick={event => {
+      if (!props.disabled && props.onChange) {
+        props.onChange(!props.checked, event);
+      }
+    }}
+  >
+    <input
+      {...pickDOMProps(props)}
+      className={props.theme[props.themeId].input}
+      type="checkbox"
+    />
+    <div
+      className={classnames([
+        props.theme[props.themeId].check,
+        props.checked ? props.theme[props.themeId].checked : null
+      ])}
+    />
+    
+    <div
+      className={styles.checkboxWrapper}
+    >
+      {props.label && (
+        <label className={props.theme[props.themeId].label}>
+          {props.label}
+        </label>
+      )}
+      <br />
+      {props.description && (
+        <ReactMarkdown source={props.description} />
+      )}
+    </div>
+  </div>
+);

--- a/app/themes/skins/CheckboxOwnSkin.scss
+++ b/app/themes/skins/CheckboxOwnSkin.scss
@@ -1,0 +1,20 @@
+.checkboxWrapper {
+  margin: var(--rp-checkbox-label-margin, 10px 0 0 20px);
+
+  label {
+    margin: 0;
+  }
+
+  p {
+    font-family: var(--font-regular);
+    color: var(--theme-terms-of-use-text-color);
+    font-size: 14px;
+    letter-spacing: 0.5px;
+    line-height: 1.38;
+    margin-bottom: 11px;
+
+    strong, em {
+      font-weight: 500;
+    }
+  }
+}

--- a/app/themes/skins/CheckboxOwnSkin.scss
+++ b/app/themes/skins/CheckboxOwnSkin.scss
@@ -8,9 +8,10 @@
   p {
     font-family: var(--font-regular);
     color: var(--theme-terms-of-use-text-color);
-    font-size: 14px;
+    font-size: 13px;
     letter-spacing: 0.5px;
     line-height: 1.38;
+    margin-top: 5px;
     margin-bottom: 11px;
 
     strong, em {


### PR DESCRIPTION
Adding a new checkbox component with label and description, useful for warning users of the consequences of marking a checkbox. The description element accepts markdown format.

I also added some small changes to Informative component to accept children elements and a small CSS fix for one of the paper wallet dialogs.

Regular checkbox:
![Screen Shot 2019-05-22 at 10 04 23 PM](https://user-images.githubusercontent.com/1937074/58221091-43e2d080-7cdf-11e9-98c2-60c808adf8ec.png)

New checkbox:
![Screen Shot 2019-05-22 at 10 12 58 PM](https://user-images.githubusercontent.com/1937074/58221097-4a714800-7cdf-11e9-9027-6dc599e89a96.png)


