### PR TITLE
Adding translation for Total Balance string in the topbar

### DIFF
--- a/app/components/topbar/WalletTopbarTitle.js
+++ b/app/components/topbar/WalletTopbarTitle.js
@@ -9,6 +9,14 @@ import Wallet from '../../domain/Wallet';
 import WalletAccountIcon from './WalletAccountIcon';
 import { WalletTypeOption } from '../../types/WalletType';
 import type { WalletAccount } from '../../domain/Wallet';
+import { defineMessages, intlShape } from 'react-intl';
+
+const messages = defineMessages({
+  totalBalance: {
+    id: 'wallet.topbar.totalbalance',
+    defaultMessage: '!!!Total balance',
+  },
+});
 
 type Props = {
   wallet: ?Wallet,
@@ -42,11 +50,16 @@ export default class WalletTopbarTitle extends Component<Props> {
     },
   };
 
+  static contextTypes = {
+    intl: intlShape.isRequired,
+  };
+
   render() {
     const {
       wallet, account, currentRoute, formattedWalletAmount, themeProperties
     } = this.props;
     const { identiconSaturationFactor } = themeProperties || {};
+    const { intl } = this.context;
 
     // If we are looking at a wallet, show its name and balance
     const walletRoutesMatch = matchRoute(`${ROUTES.WALLETS.ROOT}/:id(*page)`, currentRoute);
@@ -69,7 +82,9 @@ export default class WalletTopbarTitle extends Component<Props> {
           <div className={styles.walletAmount}>
             { wallet && formattedWalletAmount(wallet.amount) + ' ADA' }
           </div>
-          <div className={styles.walletAmountLabel}>Total balance</div>
+          <div className={styles.walletAmountLabel}>
+            {intl.formatMessage(messages.totalBalance)}
+          </div>
         </div>
       </div>
     ) : null;

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -431,6 +431,7 @@
   "wallet.summary.page.walletCreatedNotificationMessage": "You have successfully created a new Wallet",
   "wallet.summary.page.walletRestoredNotificationMessage": "You have successfully restored your Wallet",
   "wallet.summary.page.yesterdayLabel": "Yesterday",
+  "wallet.topbar.totalbalance": "Total balance",
   "wallet.transaction.address.from": "From address",
   "wallet.transaction.address.to": "To address",
   "wallet.transaction.addresses.from": "From addresses",


### PR DESCRIPTION
I noticed the string "Total balance" was not being translated. Adding it.

![Screen Shot 2019-05-24 at 12 40 29 AM](https://user-images.githubusercontent.com/1937074/58303210-22581680-7dbd-11e9-9ce2-517d9e372bc6.png)
