### PR TITLE
Fix 4 bugs in wallet creation & restoration

### DIFF
--- a/app/components/wallet/WalletRestoreVerifyDialog.js
+++ b/app/components/wallet/WalletRestoreVerifyDialog.js
@@ -10,6 +10,7 @@ import CopyableAddress from '../widgets/CopyableAddress';
 import WalletAccountIcon from '../topbar/WalletAccountIcon';
 import Dialog from '../widgets/Dialog';
 import type { WalletAccountNumberPlate } from '../../domain/Wallet';
+import LocalizableError from '../../i18n/LocalizableError';
 
 const messages = defineMessages({
   dialogTitleVerifyWalletRestoration: {
@@ -49,7 +50,9 @@ type Props = {
   onCopyAddress?: Function,
   onNext: Function,
   onCancel: Function,
+  isSubmitting: boolean,
   classicTheme: boolean,
+  error?: ?LocalizableError,
 };
 
 @observer
@@ -57,6 +60,7 @@ export default class WalletRestoreVerifyDialog extends Component<Props> {
   static defaultProps = {
     onBack: undefined,
     onCopyAddress: undefined,
+    error: undefined,
   };
 
   static contextTypes = {
@@ -68,6 +72,8 @@ export default class WalletRestoreVerifyDialog extends Component<Props> {
     const {
       addresses,
       accountPlate,
+      error,
+      isSubmitting,
       onCancel,
       onNext,
       classicTheme,
@@ -86,7 +92,7 @@ export default class WalletRestoreVerifyDialog extends Component<Props> {
         label: intl.formatMessage(globalMessages.confirm),
         onClick: onNext,
         primary: true,
-        className: confirmButtonClasses,
+        className: classnames(['confirmButton', isSubmitting ? styles.isSubmitting : null]),
       },
     ];
 
@@ -140,6 +146,8 @@ export default class WalletRestoreVerifyDialog extends Component<Props> {
             />
           ))}
         </div>
+
+        {error && <p className={styles.error}>{intl.formatMessage(error)}</p>}
 
       </Dialog>
     );

--- a/app/components/wallet/WalletRestoreVerifyDialog.scss
+++ b/app/components/wallet/WalletRestoreVerifyDialog.scss
@@ -1,3 +1,6 @@
+@import '../../themes/mixins/loading-spinner';
+@import '../../themes/mixins/error-message';
+
 .dialog {
   font-family: var(--font-light);
 
@@ -37,4 +40,14 @@
   font-size: 35px;
   font-weight: 600;
   opacity: 0.7;
+}
+
+.error {
+  @include error-message;
+  margin-top: 30px;
+  text-align: center;
+}
+
+.isSubmitting {
+  @include loading-spinner("../../assets/images/spinner-light.svg");
 }

--- a/app/containers/wallet/WalletAddPage.js
+++ b/app/containers/wallet/WalletAddPage.js
@@ -69,7 +69,7 @@ export default class WalletAddPage extends Component<Props> {
     const wallets = this._getWalletsStore();
     const { actions, stores } = this.props;
     const { uiDialogs } = stores;
-    const { isRestoreActive } = wallets;
+    const { restoreRequest } = wallets;
     const isCreateTrezorWalletActive = this._getTrezorConnectStore().isCreateHWActive;
     const isCreateLedgerWalletActive = this._getLedgerConnectStore().isCreateHWActive;
     const openTrezorConnectDialog = () => {
@@ -142,7 +142,7 @@ export default class WalletAddPage extends Component<Props> {
             onCreate={() => actions.dialogs.open.trigger({ dialog: WalletCreateDialog })}
             onRestore={() => actions.dialogs.open.trigger({ dialog: WalletRestoreDialog })}
             onPaperRestore={() => actions.dialogs.open.trigger({ dialog: WalletRestoreDialog, params: { restoreType: 'paper' } })}
-            isRestoreActive={isRestoreActive}
+            isRestoreActive={restoreRequest.isExecuting}
             classicTheme={profile.isClassicTheme}
             title={this.context.intl.formatMessage(messages.title)}
           />
@@ -157,7 +157,7 @@ export default class WalletAddPage extends Component<Props> {
             onCreate={() => actions.dialogs.open.trigger({ dialog: WalletCreateDialog })}
             onRestore={() => actions.dialogs.open.trigger({ dialog: WalletRestoreDialog })}
             onPaperRestore={() => actions.dialogs.open.trigger({ dialog: WalletRestoreDialog, params: { restoreType: 'paper' } })}
-            isRestoreActive={isRestoreActive}
+            isRestoreActive={restoreRequest.isExecuting}
             classicTheme={profile.isClassicTheme}
             title={this.context.intl.formatMessage(messages.title)}
             subTitle={this.context.intl.formatMessage(messages.subTitle)}

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -108,7 +108,10 @@ export default class WalletRestoreDialogContainer
           accountPlate={accountPlate}
           onNext={this.onVerifiedSubmit}
           onCancel={this.cancelVerification}
+          isSubmitting={restoreRequest.isExecuting}
+          onSubmit={this.onSubmit}
           classicTheme={this.props.classicTheme}
+          error={restoreRequest.error}
         />
       );
     }

--- a/app/stores/base/WalletStore.js
+++ b/app/stores/base/WalletStore.js
@@ -27,8 +27,6 @@ export default class WalletsStore extends Store {
 
   WALLET_REFRESH_INTERVAL = environment.walletRefreshInterval;
   ON_VISIBLE_DEBOUNCE_WAIT = 1000;
-  WAIT_FOR_SERVER_ERROR_TIME = 2000;
-  MIN_NOTIFICATION_TIME = 500;
 
   @observable active: ?Wallet = null;
   @observable activeAccount: ?WalletAccount = null;
@@ -38,10 +36,6 @@ export default class WalletsStore extends Store {
   @observable generateWalletRecoveryPhraseRequest: Request<GenerateWalletRecoveryPhraseFunc>;
   @observable restoreRequest: Request<RestoreWalletFunc>;
   @observable isImportActive: boolean = false;
-
-  /** While restoration is taking place, we need to block users from starting a restoration
-   *  on a seperate wallet and explain to them why the action is blocked */
-  @observable isRestoreActive: boolean = false;
 
   _newWalletDetails: { name: string, mnemonic: string, password: string } = {
     name: '',
@@ -125,6 +119,8 @@ export default class WalletsStore extends Store {
     walletName: string,
     walletPassword: string,
   }) => {
+    this.restoreRequest.reset();
+
     const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
     const restoredWallet = await this.restoreRequest.execute({
       ...params,


### PR DESCRIPTION
Four different problems were found as I was writing the new tests:

1) We have two functions for restoring a wallet. `_restoreWallet` in `AdaWalletsStore.js` and `_restore` in `WalletStore.js`. Turns out `_restore` was duplicate dead code so I unified the two
2) Wallet restoration used weird timeout logic (that I assume came from Daedalus and isn't required for Yoroi) that just caused problems. I removed this code since the `Request` class means we don't need these
3) User could not open a dialog shortly after restoring a wallet because dialog `close` function was called in one of the timeouts mentioned in (2)
4) If wallet creation/restoration fails no error message would be shown to the user. This is because the wallet creation/verification code now gets called from the `verify account` screen and when we added the `verify account` screen, we forgot to add code to display any error to the user.