### PR TITLE
Fix ref usage

### DIFF
--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -198,7 +198,7 @@ export default class WalletCreateDialog extends Component<Props, State> {
         <Input
           className="walletName"
           onKeyPress={this.checkForEnterKey.bind(this)}
-          ref={(input) => { this.walletNameInput = input; }}
+          inputRef={(input) => { this.walletNameInput = input; }}
           {...walletNameField.bind()}
           done={isValidWalletName(walletName)}
           error={walletNameField.error}

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -393,7 +393,7 @@ export default class WalletRestoreDialog extends Component<Props> {
         ) : (
           <Input
             className={walletNameFieldClasses}
-            ref={(input) => { this.walletNameInput = input; }}
+            inputRef={(input) => { this.walletNameInput = input; }}
             {...walletNameField.bind()}
             done={isValidWalletName(walletName)}
             error={walletNameField.error}

--- a/app/components/widgets/forms/InlineEditingInput.js
+++ b/app/components/widgets/forms/InlineEditingInput.js
@@ -170,7 +170,7 @@ export default class InlineEditingInput extends Component<Props, State> {
           onKeyDown={event => this.handleInputKeyDown(event)}
           error={isActive ? inputField.error : null}
           disabled={!isActive}
-          ref={(input) => { this.inputField = input; }}
+          inputRef={(input) => { this.inputField = input; }}
           skin={classicTheme ? InputSkin : InputOwnSkin}
         />
 


### PR DESCRIPTION
Although the way we use refs works, React-Polymorph asks you to use the `inputRef` property instead otherwise it will display this error in the console

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `InlineEditingInput`.
    in withTheme(Input) (created by InlineEditingInput)
    in div (created by InlineEditingInput)
    in InlineEditingInput (created by WalletSettings)
    in div (created by WalletSettings)
    in WalletSettings (created by WalletSettingsPage)
    in WalletSettingsPage (created by component)
    in component (created by t)
    in t (created by component)
    in t (created by component)
    in div (created by SettingsLayout)
    in div (created by SettingsLayout)
    in div (created by SettingsLayout)
    in SettingsLayout (created by Settings)
    in div (created by TopBarLayout)
    in div (created by TopBarLayout)
    in div (created by TopBarLayout)
    in div (created by TopBarLayout)
    in TopBarLayout (created by MainLayout)
    in MainLayout (created by Settings)
    in Settings (created by component)
    in component (created by t)
    in t (created by App)
    in t (created by App)
    in div (created by App)
    in t (created by App)
    in IntlProvider (created by App)
    in ThemeProvider (created by App)
    in div (created by App)
    in App
```