### PR TITLE
shin/fix-trezor-API-firefox-manifest-setup-#344

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -11,8 +11,11 @@ export default {
         VENDOR: 'trezor.io',
         MODEL: 'T',
         manifest: {
-          EMAIL: 'systems@emurgo.io',
-          APP_URL: 'https://chrome.google.com/webstore/detail/yoroi/ffnbelfdoeiohenkjibnmadjiehjhajb'
+          EMAIL: 'rnd@emurgo.io',
+          appURL: {
+            CHROME: 'https://chrome.google.com/webstore/detail/yoroi/ffnbelfdoeiohenkjibnmadjiehjhajb',
+            FIREFOX: 'https://addons.mozilla.org/en-US/firefox/addon/yoroi/'
+          }
         }
       },
       ledgerNanoS: {

--- a/app/environment.js
+++ b/app/environment.js
@@ -2,7 +2,8 @@
 
 import type { ConfigType, Network } from '../config/config-types';
 import { NetworkType } from '../config/config-types';
-import UserAgentInfo from './utils/userAgentInfo';
+import type { UserAgentInfo } from './utils/userAgentInfo';
+import userAgentInfo from './utils/userAgentInfo';
 
 declare var CONFIG: ConfigType;
 
@@ -23,7 +24,7 @@ export const environment = (Object.assign({
   isMainnet: () => environment.NETWORK === NetworkType.MAINNET,
   isAdaApi: () => environment.API === 'ada',
   walletRefreshInterval: CONFIG.app.walletRefreshInterval,
-  userAgentInfo: new UserAgentInfo(),
+  userAgentInfo,
 }, process.env): {
   NETWORK: Network,
   version: string,

--- a/app/environment.js
+++ b/app/environment.js
@@ -1,6 +1,8 @@
 // @flow
+
 import type { ConfigType, Network } from '../config/config-types';
 import { NetworkType } from '../config/config-types';
+import UserAgentInfo from './utils/userAgentInfo';
 
 declare var CONFIG: ConfigType;
 
@@ -21,6 +23,7 @@ export const environment = (Object.assign({
   isMainnet: () => environment.NETWORK === NetworkType.MAINNET,
   isAdaApi: () => environment.API === 'ada',
   walletRefreshInterval: CONFIG.app.walletRefreshInterval,
+  userAgentInfo: new UserAgentInfo(),
 }, process.env): {
   NETWORK: Network,
   version: string,
@@ -32,7 +35,8 @@ export const environment = (Object.assign({
   isTest: void => boolean,
   isMainnet: void => boolean,
   isAdaApi: void => boolean,
-  walletRefreshInterval: number
+  walletRefreshInterval: number,
+  userAgentInfo: UserAgentInfo
 });
 
 export default environment;

--- a/app/environment.js
+++ b/app/environment.js
@@ -1,5 +1,4 @@
 // @flow
-import os from 'os';
 import type { ConfigType, Network } from '../config/config-types';
 import { NetworkType } from '../config/config-types';
 
@@ -21,7 +20,6 @@ export const environment = (Object.assign({
   isTest: () => environment.current === NetworkType.TEST,
   isMainnet: () => environment.NETWORK === NetworkType.MAINNET,
   isAdaApi: () => environment.API === 'ada',
-  platform: os.platform(),
   walletRefreshInterval: CONFIG.app.walletRefreshInterval,
 }, process.env): {
   NETWORK: Network,
@@ -34,7 +32,6 @@ export const environment = (Object.assign({
   isTest: void => boolean,
   isMainnet: void => boolean,
   isAdaApi: void => boolean,
-  platform: string,
   walletRefreshInterval: number
 });
 

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -93,15 +93,19 @@ export default class TrezorConnectStore extends Store implements HWConnectStoreT
     try {
       /** Starting from v7 Trezor Connect Manifest has been made mandatory
         * https://github.com/trezor/connect/blob/develop/docs/index.md#trezor-connect-manifest */
-      const trezorTConfig = Config.wallets.hardwareWallet.trezorT;
-      TrezorConnect.manifest({
-        email: trezorTConfig.manifest.EMAIL,
-        appUrl: trezorTConfig.manifest.APP_URL
-      });
+      const { manifest } = Config.wallets.hardwareWallet.trezorT;
+
+      const trezorManifest = {};
+      trezorManifest.email = manifest.EMAIL;
+      // set appUrl depending upon browser
+      if (environment.userAgentInfo.isChromeBrowser()) {
+        trezorManifest.appUrl = manifest.appURL.CHROME;
+      } else if (environment.userAgentInfo.isFirefoxBrowser()) {
+        trezorManifest.appUrl = manifest.appURL.FIREFOX;
+      }
+      TrezorConnect.manifest(trezorManifest);
 
       /** Preinitialization of TrezorConnect API will result in faster first response */
-      // TODO [TREZOR]: sometimes when user does fast action initialization is still not complete
-      // try to use same approach as ledger [for now moving this from _init() to setup()]
       TrezorConnect.init({});
     } catch (error) {
       Logger.error(`TrezorConnectStore::setup:error: ${stringifyError(error)}`);

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -97,11 +97,13 @@ export default class TrezorConnectStore extends Store implements HWConnectStoreT
 
       const trezorManifest = {};
       trezorManifest.email = manifest.EMAIL;
-      // set appUrl depending upon browser
-      if (environment.userAgentInfo.isChromeBrowser()) {
-        trezorManifest.appUrl = manifest.appURL.CHROME;
-      } else if (environment.userAgentInfo.isFirefoxBrowser()) {
+      if (environment.userAgentInfo.isFirefoxExtension()) {
+        // Set appUrl for `moz-extension:` protocol using browser (like Firefox)
         trezorManifest.appUrl = manifest.appURL.FIREFOX;
+      } else {
+        // For all other browser supported that uses `chrome-extension:` protocol
+        // In future if other non chrome like browser is supported them we can consider updating
+        trezorManifest.appUrl = manifest.appURL.CHROME;
       }
       TrezorConnect.manifest(trezorManifest);
 

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -97,7 +97,7 @@ export default class TrezorConnectStore extends Store implements HWConnectStoreT
 
       const trezorManifest = {};
       trezorManifest.email = manifest.EMAIL;
-      if (environment.userAgentInfo.isFirefoxExtension()) {
+      if (environment.userAgentInfo.isFirefoxExtension) {
         // Set appUrl for `moz-extension:` protocol using browser (like Firefox)
         trezorManifest.appUrl = manifest.appURL.FIREFOX;
       } else {

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -50,7 +50,7 @@ export const generateLogHeader = () => (
   `[INFO] Yoroi v.${environment.version}\r\n`
   + `[INFO] Commit: ${environment.commit}\r\n`
   + `[INFO] Network: ${environment.NETWORK}\r\n`
-  + `[INFO] User Agent: ${JSON.stringify(environment.userAgentInfo, null, 2)}\r\n`
+  + `[INFO] User Agent: ${stringifyData(environment.userAgentInfo.ua)}\r\n`
   + `----\r\n` // this like should be always the last line of the header block
 );
 

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -47,7 +47,11 @@ export const downloadLogs = () => {
 // ========== STRINGIFY =========
 
 export const generateLogHeader = () => (
-  `[INFO] Yoroi v.${environment.version}\r\n[INFO] Commit: ${environment.commit}\r\n[INFO] Network: ${environment.NETWORK}\r\n`
+  `[INFO] Yoroi v.${environment.version}\r\n`
+  + `[INFO] Commit: ${environment.commit}\r\n`
+  + `[INFO] Network: ${environment.NETWORK}\r\n`
+  + `[INFO] User Agent: ${JSON.stringify(environment.userAgentInfo, null, 2)}\r\n`
+  + `----\r\n` // this like should be always the last line of the header block
 );
 
 export const stringifyData = (data : any) => JSON.stringify(data, null, 2);

--- a/app/utils/userAgentInfo.js
+++ b/app/utils/userAgentInfo.js
@@ -2,21 +2,20 @@
 
 import UAParser from 'ua-parser-js';
 
-export default class UserAgentInfo {
+export class UserAgentInfo {
   // Refer: Refer: https://www.npmjs.com/package/ua-parser-js
   ua: UAParser.getResult;
+  isChromeExtension: boolean;
+  isFirefoxExtension: boolean;
 
   constructor() {
     this.ua = (new UAParser()).getResult();
-  }
+    /** This method returns true for all browser that uses `chrome-extension:` protocol,
+      * hence it will return true for browsers like Google Chrome, Brave */
 
-  /** This method returns true for all browser that uses `chrome-extension:` protocol,
-    * hence it will return true for browsers like Google Chrome, Brave */
-  isChromeExtension() {
-    return location.protocol === 'chrome-extension:';
-  }
-
-  isFirefoxExtension() {
-    return location.protocol === 'moz-extension:';
+    this.isChromeExtension = (location.protocol === 'chrome-extension:');
+    this.isFirefoxExtension = (location.protocol === 'moz-extension:');
   }
 }
+
+export default new UserAgentInfo();

--- a/app/utils/userAgentInfo.js
+++ b/app/utils/userAgentInfo.js
@@ -10,9 +10,9 @@ export class UserAgentInfo {
 
   constructor() {
     this.ua = (new UAParser()).getResult();
+
     /** This method returns true for all browser that uses `chrome-extension:` protocol,
       * hence it will return true for browsers like Google Chrome, Brave */
-
     this.isChromeExtension = (location.protocol === 'chrome-extension:');
     this.isFirefoxExtension = (location.protocol === 'moz-extension:');
   }

--- a/app/utils/userAgentInfo.js
+++ b/app/utils/userAgentInfo.js
@@ -1,0 +1,19 @@
+// @flow
+
+import UAParser from 'ua-parser-js';
+
+export default class UserAgentInfo {
+  ua: UAParser.getResult;
+
+  constructor() {
+    this.ua = (new UAParser()).getResult();
+  }
+
+  isChromeBrowser() {
+    return this.ua.browser.name === 'Chrome';
+  }
+
+  isFirefoxBrowser() {
+    return this.ua.browser.name === 'Firefox';
+  }
+}

--- a/app/utils/userAgentInfo.js
+++ b/app/utils/userAgentInfo.js
@@ -3,6 +3,32 @@
 import UAParser from 'ua-parser-js';
 
 export default class UserAgentInfo {
+  /** Object structured like this:
+    * Refer: https://www.npmjs.com/package/ua-parser-js
+    * {
+    *    ua: "",
+    *    browser: {
+    *      name: "",
+    *      version: ""
+    *    },
+    *    engine: {
+    *      name: "",
+    *      version: ""
+    *    },
+    *    os: {
+    *      name: "",
+    *      version: ""
+    *    },
+    *    device: {
+    *      model: "",
+    *      type: "",
+    *      vendor: ""
+    *    },
+    *    cpu: {
+    *      architecture: ""
+    *    }
+    *  }
+    */
   ua: UAParser.getResult;
 
   constructor() {

--- a/app/utils/userAgentInfo.js
+++ b/app/utils/userAgentInfo.js
@@ -3,43 +3,20 @@
 import UAParser from 'ua-parser-js';
 
 export default class UserAgentInfo {
-  /** Object structured like this:
-    * Refer: https://www.npmjs.com/package/ua-parser-js
-    * {
-    *    ua: "",
-    *    browser: {
-    *      name: "",
-    *      version: ""
-    *    },
-    *    engine: {
-    *      name: "",
-    *      version: ""
-    *    },
-    *    os: {
-    *      name: "",
-    *      version: ""
-    *    },
-    *    device: {
-    *      model: "",
-    *      type: "",
-    *      vendor: ""
-    *    },
-    *    cpu: {
-    *      architecture: ""
-    *    }
-    *  }
-    */
+  // Refer: Refer: https://www.npmjs.com/package/ua-parser-js
   ua: UAParser.getResult;
 
   constructor() {
     this.ua = (new UAParser()).getResult();
   }
 
-  isChromeBrowser() {
-    return this.ua.browser.name === 'Chrome';
+  /** This method returns true for all browser that uses `chrome-extension:` protocol,
+    * hence it will return true for browsers like Google Chrome, Brave */
+  isChromeExtension() {
+    return location.protocol === 'chrome-extension:';
   }
 
-  isFirefoxBrowser() {
-    return this.ua.browser.name === 'Firefox';
+  isFirefoxExtension() {
+    return location.protocol === 'moz-extension:';
   }
 }

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "semver": "5.7.0",
     "tinycolor2": "1.4.1",
     "trezor-connect": "7.0.2",
+    "ua-parser-js": "0.7.19",
     "unorm": "1.4.1",
     "validator": "6.3.0",
     "yoroi-extension-ledger-bridge": "git+https://github.com/Emurgo/yoroi-extension-ledger-bridge.git"


### PR DESCRIPTION
Fix of: https://github.com/Emurgo/yoroi-frontend/issues/344

### 1. https://github.com/Emurgo/yoroi-frontend/pull/520/commits/5b0bd05834b6fb0896bce1745246e6e543c099b4 Remove os module and platform property from environment
It's NodeJS Core Module: https://github.com/DiegoRBaquero/node-os
`platform` property is not used in the project

### 2. https://github.com/Emurgo/yoroi-frontend/pull/520/commits/d9cabe00ad9cd7541eecad3a8433df328488331c added UserAgentInfo utility
Easy to use utility for determining current browser/OS/architecture (needed for https://github.com/Emurgo/yoroi-frontend/pull/520/commits/8b37c6ba8313ef8262b1131a5218b18572a2f3d5)

### 3. https://github.com/Emurgo/yoroi-frontend/pull/520/commits/8b37c6ba8313ef8262b1131a5218b18572a2f3d5 Actual Trezor API firefox manifest setup
Also made same email-Id for both Trezor and Ledger to `rnd@emurgo.io`.
(Before for Trezor it was `systems@emurgo.io` ) cc @nicarq 

### 4. https://github.com/Emurgo/yoroi-frontend/pull/520/commits/691f102c67c7a0237f7a5856e9e18ce4fe5d30f0 Add userAgentInfo log in the header of downloadLogs functionality
This will help supporting user problems.
cc @Leo-Emurgo 

**Before:**
```
﻿[INFO] Yoroi v.1.6.0
[INFO] Commit: d06987d242694f34234982983963fbe279c985e8
[INFO] Network: staging
[2019-05-26T21:48:18+09:00] No errors logged.
```
**After:**
```
﻿[INFO] Yoroi v.1.6.0
[INFO] Commit: 8b37c6ba8313ef8262b1131a5218b18572a2f3d5
[INFO] Network: staging
[INFO] User Agent: {
  "ua": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
  "browser": {
    "name": "Chrome",
    "version": "74.0.3729.169",
    "major": "74"
  },
  "engine": {
    "name": "WebKit",
    "version": "537.36"
  },
  "os": {
    "name": "Linux",
    "version": "x86_64"
  },
  "device": {},
  "cpu": {
    "architecture": "amd64"
  }
}
----
[2019-05-26T22:24:53+09:00] No errors logged.
```
 