### PR TITLE
Fix encoding for background page for non-EN users

### DIFF
--- a/chrome/views/background.html
+++ b/chrome/views/background.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
+      <meta charset="UTF-8">
   </head>
 </html>


### PR DESCRIPTION
Not having this makes Yoroi fail to open at all on Firefox for non-EN users (ex: Japanese)