### PR TITLE
 shin/ch1230/make-new-theme-top-bar-height-same-as-old

### DIFF
--- a/app/assets/images/top-bar/with-trezor-t-logo-white.inline.svg
+++ b/app/assets/images/top-bar/with-trezor-t-logo-white.inline.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="64px" height="45px"
+<svg width="64px" height="64px"
   viewBox="0 0 64 45"
   version="1.1"
   xmlns="http://www.w3.org/2000/svg"

--- a/app/components/layout/TopBarLayout.scss
+++ b/app/components/layout/TopBarLayout.scss
@@ -1,5 +1,3 @@
-$topBarClassicHeight: 64px;
-$topBarHeight: 58px;
 $footerHeight: 56px;
 
 .component {
@@ -12,7 +10,7 @@ $footerHeight: 56px;
   width: 100%;
   
   .topbar {
-    height: $topBarClassicHeight;    
+    height: var(--cmn-topbar-height);
     flex-shrink: 0;
     // Show elements that overflow the topbar above the content area
     z-index: 1;
@@ -59,10 +57,4 @@ $footerHeight: 56px;
   background-image: url(../../assets/images/select-language.svg);
   background-size: cover;
   background-position-y: bottom;
-}
-
-:global(.YoroiModern) .component {
-  .topbar {
-    height: $topBarHeight;
-  }  
 }

--- a/app/components/topbar/TopBar.scss
+++ b/app/components/topbar/TopBar.scss
@@ -1,11 +1,8 @@
-$topBarClassicHeight: 64px;
-$topBarHeight: 58px;
-
 .topBar {
   align-items: center;
   background: var(--theme-topbar-background-color);
   display: flex;
-  height: $topBarClassicHeight;
+  height: var(--cmn-topbar-height);
   padding: 0;
   position: relative;
   z-index: 100;
@@ -13,8 +10,4 @@ $topBarHeight: 58px;
   .topBarTitle {
     flex-grow: 1;
   }  
-}
-
-:global(.YoroiModern) .topBar {
-  height: $topBarHeight;
 }

--- a/app/components/topbar/TopBarCategory.scss
+++ b/app/components/topbar/TopBarCategory.scss
@@ -1,14 +1,11 @@
 @import '../../themes/mixins/buttons';
 
-$topBarClassicHeight: 64px;
-$topBarHeight: 58px;
-
 .component {
   @include button;
   align-items: center;
   color: var(--theme-topbar-category-text-color);
   display: flex;
-  height: $topBarClassicHeight;
+  height: var(--cmn-topbar-height);
   justify-content: center;
   width: 87px;
 
@@ -98,7 +95,7 @@ $topBarHeight: 58px;
 .withLedgerNanoSIcon {
   flex-shrink: 0;
   & > svg {
-    width: 64px;
+    width: var(--cmn-topbar-icon-default-width);
     height: 42.5px;
     // plus-logo
     & > g > g:nth-child(1) {
@@ -116,7 +113,7 @@ $topBarHeight: 58px;
 .withTrezorTIcon {
   flex-shrink: 0;
   & > svg {
-    width: 64px;
+    width: var(--cmn-topbar-icon-default-width);
     height: 42.5px;
     // plus-logo
     & > g > g:nth-child(1) {
@@ -145,11 +142,11 @@ $topBarHeight: 58px;
     }
 
     &.with-trezor-t {
-      left: 64px;
+      left: var(--cmn-topbar-icon-default-width);
     }
 
     &.with-ledger-nano-s {
-      left: 64px;
+      left: var(--cmn-topbar-icon-default-width);
     }    
 
     &.daedalus-transfer {
@@ -165,8 +162,4 @@ $topBarHeight: 58px;
 .label {
   font-family: var(--font-regular);
   font-size: 18px;
-}
-
-:global(.YoroiModern) .component {
-  height: $topBarHeight;
 }

--- a/app/themes/prebuilt/Common.js
+++ b/app/themes/prebuilt/Common.js
@@ -1,0 +1,6 @@
+//  ==== Common: Theme independent === //
+
+export default {
+  '--cmn-topbar-height': `64px`,
+  '--cmn-topbar-icon-default-width': `64px`,
+};

--- a/app/themes/prebuilt/Global.js
+++ b/app/themes/prebuilt/Global.js
@@ -1,0 +1,5 @@
+//  ==== Global: Theme independent === //
+
+export default {
+  '--global-topbar-height': `64px`,
+};

--- a/app/themes/prebuilt/Global.js
+++ b/app/themes/prebuilt/Global.js
@@ -1,5 +1,0 @@
-//  ==== Global: Theme independent === //
-
-export default {
-  '--global-topbar-height': `64px`,
-};

--- a/app/themes/prebuilt/YoroiClassic.js
+++ b/app/themes/prebuilt/YoroiClassic.js
@@ -1,6 +1,6 @@
 //  ==== Theme: Yoroi Classic === //
 
-import global from './Global';
+import common from './Common';
 
 // FONTS
 const rpFonts = {
@@ -184,8 +184,8 @@ const topbarGradient = {
 };
 
 export default {
-  // GLOBAL-THEME-INDEPENDENT
-  ...global,
+  // COMMON-THEME-INDEPENDENT
+  ...common,
 
   // REACT-POLYMORPH
   ...rpYoroiTheme,

--- a/app/themes/prebuilt/YoroiClassic.js
+++ b/app/themes/prebuilt/YoroiClassic.js
@@ -1,5 +1,7 @@
 //  ==== Theme: Yoroi Classic === //
 
+import global from './Global';
+
 // FONTS
 const rpFonts = {
   '--rp-theme-font-thin': 'SFUIDisplay-Thin',
@@ -182,6 +184,9 @@ const topbarGradient = {
 };
 
 export default {
+  // GLOBAL-THEME-INDEPENDENT
+  ...global,
+
   // REACT-POLYMORPH
   ...rpYoroiTheme,
 

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -1,5 +1,7 @@
 //  ==== Theme: Yoroi Modern === //
 
+import global from './Global';
+
 // FONTS
 const rpFonts = {
   '--rp-theme-font-thin': 'Rubik-Light',
@@ -188,6 +190,9 @@ const modalMargin = {
 };
 
 export default {
+  // GLOBAL-THEME-INDEPENDENT
+  ...global,
+
   // REACT-POLYMORPH
   ...rpYoroiTheme,
 

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -1,6 +1,6 @@
 //  ==== Theme: Yoroi Modern === //
 
-import global from './Global';
+import common from './Common';
 
 // FONTS
 const rpFonts = {
@@ -190,8 +190,8 @@ const modalMargin = {
 };
 
 export default {
-  // GLOBAL-THEME-INDEPENDENT
-  ...global,
+  // COMMON-THEME-INDEPENDENT
+  ...common,
 
   // REACT-POLYMORPH
   ...rpYoroiTheme,


### PR DESCRIPTION
**Before**
![Clipboard 2019-31-05 at 5 39 55 PM](https://user-images.githubusercontent.com/19986226/58714554-f01f6800-83ff-11e9-8197-3c2ba6a7671c.png)

**After**
![image](https://user-images.githubusercontent.com/19986226/58714596-00cfde00-8400-11e9-8237-d7ddfef6c0b6.png)

This PR also fixes: https://app.clubhouse.io/emurgo/story/1026/fix-repeating-topbarclassicheight-and-topbarheight-in-scss

Have added new constant file, where we can put Theme independent constants:
![image](https://user-images.githubusercontent.com/19986226/58714794-7a67cc00-8400-11e9-85df-d3db85d6a049.png)


