### PR TITLE
Update bignumber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2427,9 +2427,9 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bignumber.js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.0.tgz",
-      "integrity": "sha1-JrI6MkCCD7a4dfB96CIATH00toI="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
     },
     "binary": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@download/blockies": "1.0.3",
     "aes-js": "3.1.0",
     "axios": "0.18.0",
-    "bignumber.js": "4.0.0",
+    "bignumber.js": "5.0.0",
     "bip39": "3.0.0",
     "blakejs": "1.1.0",
     "bs58": "4.0.1",


### PR DESCRIPTION
The new version adds typescript definitions (and that's basically all that changed). Flow doesn't recognize them unfortunately but Visual Studio Code does so at least the type completions and documentation now links properly. The latest version of this library is `9.0.0` but there are too many breaking changes to really bother.