### PR TITLE
Fix sequential execution of fee requests

### DIFF
--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -140,9 +140,9 @@ export default class WalletSendForm extends Component<Props> {
           return;
         }
         // once sendAll is triggered, set the amount field to the total input
-        this.form.$('amount').value = formattedWalletAmount(
+        this.form.$('amount').set('value', formattedWalletAmount(
           this.props.totalInput.minus(this.props.fee)
-        );
+        ));
       },
     );
   }

--- a/app/stores/ada/AdaTransactionBuilderStore.js
+++ b/app/stores/ada/AdaTransactionBuilderStore.js
@@ -163,6 +163,7 @@ export default class AdaTransactionBuilderStore extends Store {
 
     const stateFetcher = this.stores.substores.ada.stateFetchStore.fetcher;
     if (this.createUnsignedTx.promise) {
+      // eslint-disable-next-line no-unused-vars
       await this.createUnsignedTx.promise.catch(err => { /* do nothing */ });
     }
     this.createUnsignedTx.execute({

--- a/app/stores/ada/AdaTransactionBuilderStore.js
+++ b/app/stores/ada/AdaTransactionBuilderStore.js
@@ -121,7 +121,8 @@ export default class AdaTransactionBuilderStore extends Store {
       // need to recalculate when there are no more pending transactions
       this.stores.substores.ada.transactions.hasAnyPending,
     ],
-    () => this._updateTxBuilder(),
+    // $FlowFixMe error in mobx types
+    async () => await this._updateTxBuilder(),
   )
 
   _canCompute(): boolean {
@@ -141,7 +142,7 @@ export default class AdaTransactionBuilderStore extends Store {
    * Note: need to check state outside of runInAction
    * Otherwise reaction won't trigger
    */
-  _updateTxBuilder = () => {
+  _updateTxBuilder = async (): Promise<void> => {
     runInAction(() => {
       this.createUnsignedTx.reset();
       this.plannedTx = null;
@@ -161,6 +162,9 @@ export default class AdaTransactionBuilderStore extends Store {
     const shouldSendAll = this.shouldSendAll;
 
     const stateFetcher = this.stores.substores.ada.stateFetchStore.fetcher;
+    if (this.createUnsignedTx.promise) {
+      await this.createUnsignedTx.promise.catch(err => { /* do nothing */ });
+    }
     this.createUnsignedTx.execute({
       accountId: account.account,
       receiver,
@@ -168,6 +172,7 @@ export default class AdaTransactionBuilderStore extends Store {
       getUTXOsForAddresses: stateFetcher.getUTXOsForAddresses,
       shouldSendAll,
     });
+
   }
 
   // ===========

--- a/app/stores/lib/Request.js
+++ b/app/stores/lib/Request.js
@@ -65,6 +65,8 @@ export default class Request<Func: (...args: any) => Promise<any>, Err> {
             if (this._currentApiCall) this._currentApiCall.result = result;
             this.isExecuting = false;
             this.wasExecuted = true;
+            this.error = null;
+            this.isError = false;
             this._isWaitingForResponse = false;
             resolve(result);
           }), 1);
@@ -73,6 +75,7 @@ export default class Request<Func: (...args: any) => Promise<any>, Err> {
         .catch(action('Request::execute/catch', (error) => {
           setTimeout(action(() => {
             this.error = error;
+            this.result = null;
             this.isExecuting = false;
             this.isError = true;
             this.wasExecuted = true;


### PR DESCRIPTION
As Pavel showed, triggering two fee requests quickly in the send page can cause the wrong execution order. It auto-corrects when the wallet balance is refreshed but it's not ideal.
EX:
A start
B start
B end
A end (becomes shown result even though user expects B)

To fix this, I make that a tx creation request has to finish before the next one starts. However, handling this correctly also required changing `Request.js` which is used by all API requests so it needs extensive testing.

Also, another way we could fix this is by changing `Request.js` to be sequential on multiple calls to `execute` but it's not clear if this is desirable or not (would cause other parts of the application to take longer)