### PR TITLE
Update react-polymorph and remove hack

### DIFF
--- a/app/themes/overrides/OptionsOverrides.scss
+++ b/app/themes/overrides/OptionsOverrides.scss
@@ -14,17 +14,6 @@
 
 .ul {
   font-size: 16px;
-  overflow-x: hidden;
-  overflow-y: overlay;
-  max-height: 300px;
-  &::-webkit-scrollbar-button {
-    height: 7px;
-    display: block;
-  }
-  li {
-    // need this to give room to the scrollbar
-    margin-right: 10px;
-  }
 }
 
 .option {

--- a/app/themes/overrides/OptionsOverridesClassic.scss
+++ b/app/themes/overrides/OptionsOverridesClassic.scss
@@ -1,15 +1,2 @@
 // Css module overrides go here …
 
-.ul {
-  overflow-x: hidden;
-  overflow-y: overlay;
-  max-height: 300px;
-  &::-webkit-scrollbar-button {
-    height: 7px;
-    display: block;
-  }
-  li {
-    // need this to give room to the scrollbar
-    margin-right: 10px;
-  }
-}

--- a/app/themes/skins/AutocompleteOwnSkin.js
+++ b/app/themes/skins/AutocompleteOwnSkin.js
@@ -42,6 +42,7 @@ type Props = {
   suggestionsRef: ElementRef<any>,
   theme: Object,
   themeId: string,
+  toggleMouseLocation: Function,
   toggleOpen: Function,
   done: Boolean
 };
@@ -148,6 +149,7 @@ export const AutocompleteOwnSkin = (props: Props) => {
         selectedOptions={props.selectedOptions}
         skin={OptionsSkin}
         targetRef={props.suggestionsRef}
+        toggleMouseLocation={props.toggleMouseLocation}
         toggleOpen={props.toggleOpen}
       />
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11529,9 +11529,9 @@
       }
     },
     "react-polymorph": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/react-polymorph/-/react-polymorph-0.8.0.tgz",
-      "integrity": "sha512-AZuDHowp6XnE/qNETMDu8P7ZrAjI5dlpig5H7wqi3ZTp3gZ1VfbWHOoLCAeQtoPHAoYdAJHFlDRQRMmwyVHDTg==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/react-polymorph/-/react-polymorph-0.8.6.tgz",
+      "integrity": "sha512-HMPw+x7mpo4jtbfsPyCDj8pGoZwwfng3VLrAbbF8Cpm2hUPuX/dbF9kE6piJuhdhdwzwPmD6C/ZdhSaEoC7yBw==",
       "requires": {
         "create-react-context": "0.2.2",
         "create-react-ref": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11529,9 +11529,8 @@
       }
     },
     "react-polymorph": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/react-polymorph/-/react-polymorph-0.8.6.tgz",
-      "integrity": "sha512-HMPw+x7mpo4jtbfsPyCDj8pGoZwwfng3VLrAbbF8Cpm2hUPuX/dbF9kE6piJuhdhdwzwPmD6C/ZdhSaEoC7yBw==",
+      "version": "git+https://github.com/SebastienGllmt/react-polymorph-fix.git#876239486f48b48528b5cd6b055b62398de205dc",
+      "from": "git+https://github.com/SebastienGllmt/react-polymorph-fix.git",
       "requires": {
         "create-react-context": "0.2.2",
         "create-react-ref": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "react-hot-loader": "4.3.12",
     "react-intl": "2.7.2",
     "react-markdown": "2.5.0",
-    "react-polymorph": "0.8.0",
+    "react-polymorph": "0.8.6",
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
     "react-svg-inline": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "react-hot-loader": "4.3.12",
     "react-intl": "2.7.2",
     "react-markdown": "2.5.0",
-    "react-polymorph": "0.8.6",
+    "react-polymorph": "git+https://github.com/SebastienGllmt/react-polymorph-fix.git",
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
     "react-svg-inline": "2.1.1",


### PR DESCRIPTION
We needed a hack to properly render the scrollbar on small screens (see #358 ) but this was fixed by https://github.com/input-output-hk/react-polymorph/pull/102 so now we can get rid of the hack.

Note: I also have to change `AutocompleteOwnSkin` to port over the fix from https://github.com/input-output-hk/react-polymorph/pull/108

- [ ] ~~fix for [this bug](https://github.com/input-output-hk/react-polymorph/issues/112)~~
- [x] upgrade to include [this change](https://github.com/input-output-hk/react-polymorph/pull/113)

**Note** I had to use a custom build to React-Polymorph to fix a bug in the latest tip of the NPM package. Will move back to NPM package after it's fixed.