### PR TITLE
Explorer integration (1/3)

### DIFF
--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -175,6 +175,7 @@ export default class WalletReceive extends Component<Props, State> {
                 {/* Address Id */}
                 <ExplorableHashContainer
                   hash={address.id}
+                  isUsed={address.isUsed}
                 >
                   <UsableHash isUsed={address.isUsed}>
                     <RawHash>

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -16,6 +16,9 @@ import LocalizableError from '../../i18n/LocalizableError';
 import LoadingSpinner from '../widgets/LoadingSpinner';
 import styles from './WalletReceive.scss';
 import CopyableAddress from '../widgets/CopyableAddress';
+import RawHash from '../widgets/hashWrappers/RawHash';
+import UsableHash from '../widgets/hashWrappers/UsableHash';
+import ExplorableHashContainer from '../../containers/widgets/ExplorableHashContainer';
 
 const messages = defineMessages({
   walletAddressLabel: {
@@ -170,7 +173,14 @@ export default class WalletReceive extends Component<Props, State> {
             return (
               <div key={`gen-${address.id}`} className={addressClasses}>
                 {/* Address Id */}
-                <div className={styles.addressId}>{address.id}</div>
+                <ExplorableHashContainer>
+                  <UsableHash isUsed={address.isUsed}>
+                    <RawHash>
+                      <span className={styles.addressId}>{address.id}</span>
+                    </RawHash>
+                  </UsableHash>
+                </ExplorableHashContainer>
+                <div className={styles.addressMargin} />
                 {/* Address Action block start */}
                 <div className={styles.addressActions}>
                   {/* Verify Address action */}

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -173,7 +173,9 @@ export default class WalletReceive extends Component<Props, State> {
             return (
               <div key={`gen-${address.id}`} className={addressClasses}>
                 {/* Address Id */}
-                <ExplorableHashContainer>
+                <ExplorableHashContainer
+                  hash={address.id}
+                >
                   <UsableHash isUsed={address.isUsed}>
                     <RawHash>
                       <span className={styles.addressId}>{address.id}</span>

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -118,6 +118,10 @@
       display: flex;
       padding: 8.5px 0;
       word-break: break-all;
+
+      .addressId {
+        color: var(--theme-transactions-received-address-color);
+      }
   
       & + .walletAddress {
         border-top: 1px solid var(--theme-separation-border-color);
@@ -274,10 +278,6 @@
 
       .addressMargin {
         margin-right: 32.5px;
-      }
-
-      .addressId {
-        color: var(--theme-transactions-received-address-color);
       }
     }
   }  

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -44,18 +44,6 @@
       line-height: 19px;
       letter-spacing: 0;
   
-      .hash {
-        font-size: 14px;
-        font-family: var(--font-mono-medium);
-        line-height: 23px;
-        margin-bottom: 6px;
-        word-break: break-all;
-      }
-  
-      .usedHash {
-        opacity: 0.4;
-      }
-  
       .hashLabel {
         font-size: 11px;
         margin-bottom: 6px;

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -123,11 +123,9 @@
         border-top: 1px solid var(--theme-separation-border-color);
       }
   
-      .addressId {
-        font-family: var(--font-mono-regular);
-        flex-grow: 1;
+      .addressMargin {
         margin-right: 32.5px;
-        letter-spacing: 0;
+        flex-grow: 1;
       }
   
       .addressActions {
@@ -187,12 +185,6 @@
             cursor: pointer;
           }
         }
-      }
-    }
-  
-    .usedWalletAddress {
-      .addressId {
-        opacity: 0.4;
       }
     }
   }
@@ -279,9 +271,12 @@
       & + .walletAddress {
         border-top: 1px solid var(--theme-separation-border-color);
       }
-  
-      .addressId {
+
+      .addressMargin {
         margin-right: 32.5px;
+      }
+
+      .addressId {
         color: var(--theme-transactions-received-address-color);
       }
     }

--- a/app/components/widgets/hashWrappers/ExplorableHash.js
+++ b/app/components/widgets/hashWrappers/ExplorableHash.js
@@ -3,6 +3,7 @@
 import { observer } from 'mobx-react';
 import React, { Component } from 'react';
 import type { Node } from 'react';
+import classnames from 'classnames';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styles from './ExplorableHash.scss';
 
@@ -20,6 +21,7 @@ type Props = {
   children: ?Node,
   explorerName: string,
   url: string,
+  isUsed: boolean,
   onExternalLinkClick: Function,
 };
 
@@ -29,6 +31,9 @@ export default class ExplorableHash extends Component<Props> {
   render() {
     const { explorerName, onExternalLinkClick } = this.props;
 
+    const addressClass = classnames([
+      this.props.isUsed ? styles.usedHash : styles.unusedHash
+    ]);
     return (
       <Tooltip
         className={styles.component}
@@ -42,7 +47,7 @@ export default class ExplorableHash extends Component<Props> {
           href={this.props.url}
           onClick={event => onExternalLinkClick(event)}
         >
-          <span className={styles.hash}>{this.props.children}</span>
+          <span className={addressClass}>{this.props.children}</span>
         </a>
       </Tooltip>
     );

--- a/app/components/widgets/hashWrappers/ExplorableHash.js
+++ b/app/components/widgets/hashWrappers/ExplorableHash.js
@@ -1,0 +1,50 @@
+// @flow
+
+import { observer } from 'mobx-react';
+import React, { Component } from 'react';
+import type { Node } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import styles from './ExplorableHash.scss';
+
+import { Tooltip } from 'react-polymorph/lib/components/Tooltip';
+import { TooltipSkin } from 'react-polymorph/lib/skins/simple/TooltipSkin';
+
+const messages = defineMessages({
+  explorerTip: {
+    id: 'widgets.explorer.tooltip',
+    defaultMessage: '!!!Go to {explorerName} Blockchain Explorer',
+  },
+});
+
+type Props = {
+  children: ?Node,
+  explorerName: string,
+  url: string,
+  onExternalLinkClick: Function,
+};
+
+@observer
+export default class ExplorableHash extends Component<Props> {
+
+  render() {
+    const { explorerName, onExternalLinkClick } = this.props;
+
+    return (
+      <Tooltip
+        className={styles.component}
+        skin={TooltipSkin}
+        isOpeningUpward={false}
+        arrowRelativeToTip
+        tip={<FormattedMessage {...messages.explorerTip} values={{ explorerName }} />}
+      >
+        <a
+          className={styles.url}
+          href={this.props.url}
+          onClick={event => onExternalLinkClick(event)}
+        >
+          <span className={styles.hash}>{this.props.children}</span>
+        </a>
+      </Tooltip>
+    );
+  }
+}

--- a/app/components/widgets/hashWrappers/ExplorableHash.scss
+++ b/app/components/widgets/hashWrappers/ExplorableHash.scss
@@ -1,0 +1,21 @@
+
+.component {
+  :global(.SimpleBubble_bubble) {
+    margin-top: -8px !important;
+    font-size: 12px;
+    height: 30px;
+    font-family: var(--font-regular);
+    min-width: auto;
+    background-color: rgba(56, 57, 61, 0.7);
+    padding: 4px 12px 4px 12px;
+  }
+}
+
+.url {
+  text-decoration: none;
+}
+
+.hash :hover {
+  box-sizing: border-box;
+  border-bottom: 0.1px solid var(--theme-widgets-explorable-hash-underline-color);
+}

--- a/app/components/widgets/hashWrappers/ExplorableHash.scss
+++ b/app/components/widgets/hashWrappers/ExplorableHash.scss
@@ -13,9 +13,18 @@
 
 .url {
   text-decoration: none;
+
 }
 
-.hash :hover {
-  box-sizing: border-box;
-  border-bottom: 0.1px solid var(--theme-widgets-explorable-hash-underline-color);
+.usedHash {
+  &:hover {
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--theme-widgets-explorable-hash-underline-used-color);
+  }
+}
+.unusedHash {
+  &:hover {
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--theme-widgets-explorable-hash-underline-unused-color);
+  }
 }

--- a/app/components/widgets/hashWrappers/RawHash.js
+++ b/app/components/widgets/hashWrappers/RawHash.js
@@ -1,0 +1,20 @@
+// @flow
+
+import { observer } from 'mobx-react';
+import React, { Component } from 'react';
+import type { Node } from 'react';
+import styles from './RawHash.scss';
+
+type Props = {
+  children: ?Node,
+};
+
+@observer
+export default class UsableHash extends Component<Props> {
+
+  render() {
+    return (
+      <span className={styles.hash}>{this.props.children}</span>
+    );
+  }
+}

--- a/app/components/widgets/hashWrappers/RawHash.scss
+++ b/app/components/widgets/hashWrappers/RawHash.scss
@@ -2,4 +2,5 @@
   word-break: break-all;
   font-family: var(--font-mono-regular);
   letter-spacing: 0;
+  color: var(--theme-transactions-received-address-color);
 }

--- a/app/components/widgets/hashWrappers/RawHash.scss
+++ b/app/components/widgets/hashWrappers/RawHash.scss
@@ -1,0 +1,5 @@
+.hash {
+  word-break: break-all;
+  font-family: var(--font-mono-regular);
+  letter-spacing: 0;
+}

--- a/app/components/widgets/hashWrappers/UsableHash.js
+++ b/app/components/widgets/hashWrappers/UsableHash.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { observer } from 'mobx-react';
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import type { Node } from 'react';
+import styles from './UsableHash.scss';
+
+type Props = {
+  isUsed: boolean,
+  children: ?Node,
+};
+
+@observer
+export default class UsableHash extends Component<Props> {
+
+  render() {
+    const addressClasses = classnames([
+      this.props.isUsed ? styles.usedHash : undefined,
+    ]);
+
+    return (
+      <span className={addressClasses}>{this.props.children}</span>
+    );
+  }
+}

--- a/app/components/widgets/hashWrappers/UsableHash.scss
+++ b/app/components/widgets/hashWrappers/UsableHash.scss
@@ -1,0 +1,3 @@
+.usedHash {
+  opacity: 0.4;
+}

--- a/app/containers/widgets/ExplorableHashContainer.js
+++ b/app/containers/widgets/ExplorableHashContainer.js
@@ -1,0 +1,28 @@
+// @flow
+import React, { Component } from 'react';
+import type { Node } from 'react';
+import { observer } from 'mobx-react';
+import { handleExternalLinkClick } from '../../utils/routing';
+
+import ExplorableHash from '../../components/widgets/hashWrappers/ExplorableHash';
+
+type Props = {
+  children: ?Node,
+};
+
+@observer
+export default class ExplorableHashContainer extends Component<Props> {
+
+  render() {
+    return (
+      <ExplorableHash
+        explorerName={"Seiza"}
+        url={"https://seiza.com"}
+        onExternalLinkClick={handleExternalLinkClick}
+      >
+        {this.props.children}
+      </ExplorableHash>
+    );
+  }
+
+}

--- a/app/containers/widgets/ExplorableHashContainer.js
+++ b/app/containers/widgets/ExplorableHashContainer.js
@@ -8,16 +8,18 @@ import ExplorableHash from '../../components/widgets/hashWrappers/ExplorableHash
 
 type Props = {
   children: ?Node,
+  hash: string,
 };
 
 @observer
 export default class ExplorableHashContainer extends Component<Props> {
 
   render() {
+    const seizaAddress = 'https://seiza.com/blockchain/address/';
     return (
       <ExplorableHash
-        explorerName={"Seiza"}
-        url={"https://seiza.com"}
+        explorerName={'Seiza'}
+        url={seizaAddress + this.props.hash}
         onExternalLinkClick={handleExternalLinkClick}
       >
         {this.props.children}

--- a/app/containers/widgets/ExplorableHashContainer.js
+++ b/app/containers/widgets/ExplorableHashContainer.js
@@ -18,7 +18,7 @@ export default class ExplorableHashContainer extends Component<Props> {
     const seizaAddress = 'https://seiza.com/blockchain/address/';
     return (
       <ExplorableHash
-        explorerName={'Seiza'}
+        explorerName="Seiza"
         url={seizaAddress + this.props.hash}
         onExternalLinkClick={handleExternalLinkClick}
       >

--- a/app/containers/widgets/ExplorableHashContainer.js
+++ b/app/containers/widgets/ExplorableHashContainer.js
@@ -9,6 +9,7 @@ import ExplorableHash from '../../components/widgets/hashWrappers/ExplorableHash
 type Props = {
   children: ?Node,
   hash: string,
+  isUsed: boolean,
 };
 
 @observer
@@ -20,6 +21,7 @@ export default class ExplorableHashContainer extends Component<Props> {
       <ExplorableHash
         explorerName="Seiza"
         url={seizaAddress + this.props.hash}
+        isUsed={this.props.isUsed}
         onExternalLinkClick={handleExternalLinkClick}
       >
         {this.props.children}

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -455,5 +455,6 @@
   "wallet.transaction.type": "{currency} transaction",
   "wallet.transaction.type.exchange": "Exchange",
   "wallet.transaction.type.intrawallet": "{currency} intrawallet transaction",
-  "wallet.transaction.type.multiparty": "{currency} multiparty transaction"
+  "wallet.transaction.type.multiparty": "{currency} multiparty transaction",
+  "widgets.explorer.tooltip": "Go to {explorerName} Blockchain Explorer"
 }

--- a/app/themes/PolymorphThemes.js
+++ b/app/themes/PolymorphThemes.js
@@ -11,6 +11,7 @@ import SimpleOptions from 'react-polymorph/lib/themes/simple/SimpleOptions.scss'
 import SimpleSelect from 'react-polymorph/lib/themes/simple/SimpleSelect.scss';
 import SimpleSwitch from 'react-polymorph/lib/themes/simple/SimpleSwitch.scss';
 import SimpleTextArea from 'react-polymorph/lib/themes/simple/SimpleTextArea.scss';
+import SimpleTooltip from 'react-polymorph/lib/themes/simple/SimpleTooltip.scss';
 
 import { IDENTIFIERS } from 'react-polymorph/lib/themes/API';
 
@@ -26,6 +27,7 @@ const {
   SELECT,
   SWITCH,
   TEXT_AREA,
+  TOOLTIP,
 } = IDENTIFIERS;
 
 // package all our overrides into one theme
@@ -40,5 +42,6 @@ export const yoroiPolymorphTheme = {
   [OPTIONS]: SimpleOptions,
   [SELECT]: SimpleSelect,
   [SWITCH]: SimpleSwitch,
-  [TEXT_AREA]: SimpleTextArea
+  [TEXT_AREA]: SimpleTextArea,
+  [TOOLTIP]: SimpleTooltip,
 };

--- a/app/themes/overrides/index.js
+++ b/app/themes/overrides/index.js
@@ -1,3 +1,4 @@
+// @flow
 import { IDENTIFIERS } from 'react-polymorph/lib/themes/API';
 import AutocompleteOverrides from './AutocompleteOverrides.scss';
 import BubbleOverrides from './BubbleOverrides.scss';

--- a/app/themes/prebuilt/YoroiClassic.js
+++ b/app/themes/prebuilt/YoroiClassic.js
@@ -1,3 +1,4 @@
+// @flow
 //  ==== Theme: Yoroi Classic === //
 
 import common from './Common';
@@ -27,6 +28,9 @@ const rpBubble = {
   '--rp-bubble-bg-color': '#f3f3f5',
   '--rp-bubble-border-color': '#c6cdd6',
   '--rp-bubble-border-radius': '2px',
+  // arrows are actually used by tooltips
+  '--rp-bubble-arrow-width': '14px',
+  '--rp-bubble-arrow-height': '4px',
 };
 
 // BUTTON
@@ -389,6 +393,7 @@ export default {
   '--theme-hw-connect-dialog-middle-block-common-error-background-color': '#fdf1f0',
 
   '--theme-widgets-progress-step-common-color': '#daa49a',
+  '--theme-widgets-explorable-hash-underline-color': '#adaeB6',
 
   '--theme-footer-block-background-color': 'rgba(218, 164, 154, 0.06)',
   '--theme-footer-block-background-color-hover': '#D9DDE0',

--- a/app/themes/prebuilt/YoroiClassic.js
+++ b/app/themes/prebuilt/YoroiClassic.js
@@ -394,7 +394,8 @@ export default {
   '--theme-hw-connect-dialog-middle-block-common-error-background-color': '#fdf1f0',
 
   '--theme-widgets-progress-step-common-color': '#daa49a',
-  '--theme-widgets-explorable-hash-underline-color': '#adaeB6',
+  '--theme-widgets-explorable-hash-underline-used-color': '#adaeB6',
+  '--theme-widgets-explorable-hash-underline-unused-color': '#464749',
 
   '--theme-footer-block-background-color': 'rgba(218, 164, 154, 0.06)',
   '--theme-footer-block-background-color-hover': '#D9DDE0',

--- a/app/themes/prebuilt/YoroiClassic.js
+++ b/app/themes/prebuilt/YoroiClassic.js
@@ -324,6 +324,7 @@ export default {
   '--theme-transactions-icon-type-exchange-background-color': '#10aca4',
   '--theme-transactions-icon-type-failed-background-color': '#eb6d7a',
   '--theme-transactions-sent-color': '#4a4a4a',
+  '--theme-transactions-received-address-color': '#000000',
   '--theme-transactions-received-color': '#54ca87',
 
   '--theme-ada-redemption-headline-color': '#121327',

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -1,3 +1,4 @@
+// @flow
 //  ==== Theme: Yoroi Modern === //
 
 import common from './Common';
@@ -28,6 +29,9 @@ const rpBubble = {
   '--rp-bubble-bg-color': '#fff',
   '--rp-bubble-border-color': '#fff',
   '--rp-bubble-border-radius': '8px',
+  // arrows are actually used by tooltips
+  '--rp-bubble-arrow-width': '14px',
+  '--rp-bubble-arrow-height': '4px',
 };
 
 // BUTTON
@@ -403,6 +407,7 @@ export default {
   '--theme-trezor-connect-dialog-middle-block-common-error-background-color': '#ffffff',
 
   '--theme-widgets-progress-step-common-color': '#15d1aa',
+  '--theme-widgets-explorable-hash-underline-color': '#adaeB6',
 
   '--theme-footer-block-background-color': '#fff',
   '--theme-footer-block-background-color-hover': '#D9DDE0',

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -407,7 +407,8 @@ export default {
   '--theme-trezor-connect-dialog-middle-block-common-error-background-color': '#ffffff',
 
   '--theme-widgets-progress-step-common-color': '#15d1aa',
-  '--theme-widgets-explorable-hash-underline-color': '#adaeB6',
+  '--theme-widgets-explorable-hash-underline-used-color': '#adaeB6',
+  '--theme-widgets-explorable-hash-underline-unused-color': '#464749',
 
   '--theme-footer-block-background-color': '#fff',
   '--theme-footer-block-background-color-hover': '#D9DDE0',

--- a/app/utils/routing.js
+++ b/app/utils/routing.js
@@ -107,9 +107,13 @@ export const getUrlParameterByName = (name, url) => {
   return decodeURIComponent(results[2].replace(/\+/g, ' '));
 };
 
+/** pre-req: either the target is an anchor or is the child of an anchor */
 export const handleExternalLinkClick = (event: MouseEvent) => {
   event.preventDefault();
-  const target = event.target;
+  let target = event.target;
+  while (!(target instanceof HTMLAnchorElement)) {
+    target = target.parentNode;
+  }
   if (target instanceof HTMLAnchorElement) {
     window.open(target.href, '_blank');
   }


### PR DESCRIPTION
Splitting the explorer integration into Yoroi into 3 parts:

- [x] 0) upgrade React-Polymorph to support tooltip for design (see #558)
- [x] 1) add Seiza links on the receive page
- [ ] 2) add Seiza links on all pages that use hashes
- [ ] 3) Add ability to replace Seiza with other explorers

This PR is part 1/3

<img width="545" alt="image" src="https://user-images.githubusercontent.com/2608559/59173850-c4cc1400-8b89-11e9-9e23-d4c83b56aba1.png">
<img width="537" alt="image" src="https://user-images.githubusercontent.com/2608559/59173856-cbf32200-8b89-11e9-9435-8311ccd53a44.png">
<img width="589" alt="image" src="https://user-images.githubusercontent.com/2608559/59174096-e5e13480-8b8a-11e9-9df6-71ddf239c36a.png">
