### PR TITLE
Wingdings as default on dev

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -56,7 +56,14 @@ class App extends Component<{
     // (missed in object keys) just stay in english
     const mergedMessages = Object.assign({}, translations['en-US'], translations[locale]);
 
-    const themeVars = stores.profile.currentThemeVars;
+    const themeVars = Object.assign(
+      stores.profile.currentThemeVars,
+      {
+        // show wingdings on dev builds when no font is set to easily find missing font bugs
+        // however, on production, we use Times New Roman which looks ugly but at least it's readable.
+        '--default-font': environment.isDev() ? 'wingdings' : 'Times New Roman',
+      }
+    );
     const currentTheme = stores.profile.currentTheme;
     const mobxDevTools = this.mobxDevToolsInstanceIfDevEnv();
 

--- a/app/themes/index.global.scss
+++ b/app/themes/index.global.scss
@@ -196,7 +196,7 @@ html, body, #root, #root > [data-reactroot] {
   letter-spacing: 1px; // TODO: remove from modern theme
   // Make the default font ugly so we immediately see when something
   // is not yet defined correctly in our UI
-  font-family: "Times New Roman", serif;
+  font-family: var(--default-font), serif;
   -webkit-font-smoothing: antialiased;
 }
 


### PR DESCRIPTION
Currently when no font is set (which is always a bug) it defaults to Times New Roman. Although this looks out of place, it's still possible we miss it. To avoid this, I now set wingdings as the default font on dev builds.

Here is what it looks like
![image](https://user-images.githubusercontent.com/2608559/59313426-e218f380-8ceb-11e9-9014-dcca670b23c9.png)
