### PR TITLE
Add warning for slow internet connections on Daedalus transfer

### DIFF
--- a/app/components/transfer/AnnotatedLoader.js
+++ b/app/components/transfer/AnnotatedLoader.js
@@ -6,14 +6,18 @@ import styles from './AnnotatedLoader.scss';
 
 type Props = {
   title: string,
-  details: string
+  details: string,
+  warning?: string,
 };
 
 @observer
 export default class AnnotatedLoader extends Component<Props> {
+  static defaultProps = {
+    warning: undefined,
+  };
 
   render() {
-    const { title, details } = this.props;
+    const { title, details, warning } = this.props;
 
     return (
       <div className={styles.component}>
@@ -28,7 +32,12 @@ export default class AnnotatedLoader extends Component<Props> {
             <LoadingSpinner />
 
             <div className={styles.progressInfo}>
-              {details}
+              {details}<br /><br />
+              {warning &&
+                <div className={styles.error}>
+                  {warning}
+                </div>
+              }
             </div>
           </div>
         </div>

--- a/app/components/transfer/AnnotatedLoader.scss
+++ b/app/components/transfer/AnnotatedLoader.scss
@@ -27,5 +27,9 @@
     margin-bottom: 12px;
     word-break: break-word;
     text-align: center;
+
+    .error {
+      color: var(--rp-theme-color-error);
+    }
   }
 }

--- a/app/containers/transfer/DaedalusTransferWaitingPage.js
+++ b/app/containers/transfer/DaedalusTransferWaitingPage.js
@@ -20,6 +20,10 @@ const messages = defineMessages({
   generatingTx: {
     id: 'daedalusTransfer.waiting.checkingAddresses.generatingTx',
     defaultMessage: '!!!Generating transfer transaction',
+  },
+  internetConnectionWarning: {
+    id: 'daedalusTransfer.waiting.warning',
+    defaultMessage: '!!!⚠️ This may take a long time or fail on poor internet connections',
   }
 });
 
@@ -42,6 +46,7 @@ export default class DaedalusTransferWaitingPage extends Component<Props> {
       <AnnotatedLoader
         title={intl.formatMessage(messages.title)}
         details={intl.formatMessage(messages[status])}
+        warning={intl.formatMessage(messages.internetConnectionWarning)}
       />
     );
   }

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -66,6 +66,7 @@
   "daedalusTransfer.waiting.progressInfo.checkingAddresses": "Checking addresses funds",
   "daedalusTransfer.waiting.progressInfo.restoringAddresses": "Fetching addresses",
   "daedalusTransfer.waiting.title.label": "Daedalus wallet is being restored",
+  "daedalusTransfer.waiting.warning": "⚠️ This may take a long time or fail on poor internet connections",
   "environment.apiName.cardano": "Cardano",
   "environment.apiVersion.cardano": "1.0.4",
   "environment.currency.ada": "ADA",


### PR DESCRIPTION
As the blockchain gets bigger, Daedalus transfer takes much longer. Some users complain it doesn't work when in reality it is just their internet connection that isn't stable throughout the transfer process.

![image](https://user-images.githubusercontent.com/2608559/59351011-6903b580-8d58-11e9-856e-2d0b41655938.png)
