### PR TITLE
fix: "npm run build" exits with failure value if build fails

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,4 +11,4 @@ tasks.copyAssets('build', argv.env);
 console.log('[Webpack Build]');
 console.log('-'.repeat(80));
 
-exec(`./node_modules/.bin/webpack --config webpack/prodConfig.js --progress --profile --colors --env=${argv.env}`);
+process.exit(exec(`./node_modules/.bin/webpack --config webpack/prodConfig.js --progress --profile --colors --env=${argv.env}`).code);


### PR DESCRIPTION
Currently `npm run build` always exits 0. When I run `npm test-prepare`, which expands to `npm run clean && npm run build -- --env 'test' && npm run compress-e2e-tests"` and the build fails, the command is not aborted, instead it produces an bad .crx.
