### PR TITLE
Bump timeout for real

### DIFF
--- a/features/step_definitions/common-steps.js
+++ b/features/step_definitions/common-steps.js
@@ -25,7 +25,7 @@ const testProgress = {
 BeforeAll(() => {
   rimraf.sync(screenshotsDir);
   fs.mkdirSync(screenshotsDir);
-  setDefaultTimeout(30 * 1000);
+  setDefaultTimeout(60 * 1000);
 
   getMockServer({});
 });

--- a/features/support/webdriver.js
+++ b/features/support/webdriver.js
@@ -258,4 +258,4 @@ function CustomWorld(cmdInput: WorldInput) {
 }
 
 setWorldConstructor(CustomWorld);
-setDefaultTimeout(30 * 1000);
+setDefaultTimeout(60 * 1000);


### PR DESCRIPTION
I thought we wouldn't have to bump the timeout since the Firefox CI issue was caused by something else but it still feels like tests timeout all the time. Let's try bumping it back up then