### PR TITLE
Disable hot reload on production

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,7 +17,6 @@ module.exports = function(api) {
       "@babel/preset-react"
     ],
     "plugins": [
-      "react-hot-loader/babel",
       [
         "@babel/plugin-proposal-decorators",
         {
@@ -55,6 +54,7 @@ module.exports = function(api) {
     "env": {
       "development": {
         "plugins": [
+          "react-hot-loader/babel",
           "@babel/plugin-transform-runtime"
         ]
       }


### PR DESCRIPTION
I noticed we had hot-reload enabled on production builds also (even though it would do nothing). I assume this was just an oversight? @nicarq 

It only lowers our build size by 0.1 MB so it's not super impactful but any space saved is worth something I guess