### PR TITLE
Branch & Github links in About Yoroi

### DIFF
--- a/app/components/settings/categories/general-setting/AboutYoroiSettingsBlock.js
+++ b/app/components/settings/categories/general-setting/AboutYoroiSettingsBlock.js
@@ -14,6 +14,9 @@ import mediumSvg from '../../../../assets/images/social/medium.inline.svg';
 
 import environment from '../../../../environment';
 import LinkButton from '../../../widgets/LinkButton';
+import RawHash from '../../../widgets/hashWrappers/RawHash';
+import ExplorableHash from '../../../widgets/hashWrappers/ExplorableHash';
+import { handleExternalLinkClick } from '../../../../utils/routing';
 
 const messages = defineMessages({
   aboutYoroiLabel: {
@@ -60,6 +63,10 @@ const messages = defineMessages({
     id: 'settings.general.aboutYoroi.commitLabel',
     defaultMessage: '!!!Commit:',
   },
+  branchLabel: {
+    id: 'settings.general.aboutYoroi.git.branch',
+    defaultMessage: '!!!Branch:',
+  },
 });
 
 const socialMediaLinks = [{
@@ -93,6 +100,8 @@ const socialMediaLinks = [{
   message: messages.aboutYoroiGithub
 }];
 
+const baseGithubUrl = 'https://github.com/Emurgo/yoroi-frontend/';
+
 @observer
 export default class AboutYoroiSettingsBlock extends Component {
   static contextTypes = {
@@ -106,18 +115,53 @@ export default class AboutYoroiSettingsBlock extends Component {
       <div className={styles.component}>
         <h2>{intl.formatMessage(messages.aboutYoroiLabel)}</h2>
 
-        <p>
-          {intl.formatMessage(messages.versionLabel)}&nbsp;
-          {environment.version}
-        </p>
-        <p>
+        <p className={styles.aboutLine}>
           {intl.formatMessage(messages.networkLabel)}&nbsp;
           {environment.NETWORK}
         </p>
-        <p>
+        <div className={styles.aboutLine}>
+          {intl.formatMessage(messages.versionLabel)}&nbsp;
+          <ExplorableHash
+            websiteName="Github"
+            url={baseGithubUrl + 'releases/'}
+            light={false}
+            arrowRelativeToTip={false /* branch name may be too small otherwise */}
+            onExternalLinkClick={handleExternalLinkClick}
+          >
+            <RawHash light={false}>
+              {environment.version}
+            </RawHash>
+          </ExplorableHash>
+        </div>
+        <div className={styles.aboutLine}>
           {intl.formatMessage(messages.commitLabel)}&nbsp;
-          {environment.commit}
-        </p>
+          <ExplorableHash
+            websiteName="Github"
+            url={baseGithubUrl + 'commit/' + environment.commit}
+            light={false}
+            onExternalLinkClick={handleExternalLinkClick}
+          >
+            <RawHash light={false}>
+              {environment.commit}
+            </RawHash>
+          </ExplorableHash>
+        </div>
+        {!environment.isMainnet() &&
+          <div className={styles.aboutLine}>
+            {intl.formatMessage(messages.branchLabel)}&nbsp;
+            <ExplorableHash
+              websiteName="Github"
+              url={baseGithubUrl + 'tree/' + environment.branch}
+              light={false}
+              arrowRelativeToTip={false /* branch name may be too small otherwise */}
+              onExternalLinkClick={handleExternalLinkClick}
+            >
+              <RawHash light={false}>
+                {environment.branch}
+              </RawHash>
+            </ExplorableHash>
+          </div>
+        }
         <div className={styles.aboutScoial}>
           <GridFlexContainer rowSize={socialMediaLinks.length}>
             {socialMediaLinks.map(link => (

--- a/app/components/settings/categories/general-setting/AboutYoroiSettingsBlock.scss
+++ b/app/components/settings/categories/general-setting/AboutYoroiSettingsBlock.scss
@@ -9,8 +9,7 @@
     line-height: 22px;
     margin-bottom: 12px;
   }
-
-  p {
+  .aboutLine {
     font-size: 14px;
     line-height: 22px;
   }

--- a/app/components/widgets/hashWrappers/ExplorableHash.js
+++ b/app/components/widgets/hashWrappers/ExplorableHash.js
@@ -24,12 +24,14 @@ type Props = {|
   light: boolean,
   tooltipOpensUpward?: boolean,
   onExternalLinkClick: Function,
+  arrowRelativeToTip?: boolean,
 |};
 
 @observer
 export default class ExplorableHash extends Component<Props> {
   static defaultProps = {
     tooltipOpensUpward: false,
+    arrowRelativeToTip: true,
   };
 
   render() {
@@ -43,7 +45,7 @@ export default class ExplorableHash extends Component<Props> {
         className={styles.component}
         skin={TooltipSkin}
         isOpeningUpward={this.props.tooltipOpensUpward}
-        arrowRelativeToTip
+        arrowRelativeToTip={this.props.arrowRelativeToTip}
         tip={<FormattedMessage {...messages.websiteTip} values={{ websiteName }} />}
       >
         <a

--- a/app/components/widgets/hashWrappers/ExplorableHash.scss
+++ b/app/components/widgets/hashWrappers/ExplorableHash.scss
@@ -16,15 +16,11 @@
     line-height: 22px;
   }
 
-  :global(.SimpleBubble_root.SimpleBubble_transparent:not(.SimpleBubble_openUpward))  {
-    :global(.SimpleBubble_bubble) {
+  :global(.SimpleBubble_root:not(.SimpleBubble_openUpward))  {
       margin-top: -8px !important;
-    }
   }
   :global(.SimpleBubble_root.SimpleBubble_transparent.SimpleBubble_openUpward)  {
-    :global(.SimpleBubble_bubble) {
       margin-bottom: -8px !important;
-    }
   }
 }
 

--- a/app/environment.js
+++ b/app/environment.js
@@ -19,6 +19,7 @@ export const environment = (Object.assign({
   API: ('ada': Currency), // Note: can't change at runtime
   MOBX_DEV_TOOLS: process.env.MOBX_DEV_TOOLS,
   commit: process.env.COMMIT || '',
+  branch: process.env.BRANCH || '',
   isDev: () => environment.current === NetworkType.DEVELOPMENT,
   isTest: () => environment.current === NetworkType.TEST,
   isMainnet: () => environment.NETWORK === NetworkType.MAINNET,
@@ -32,6 +33,7 @@ export const environment = (Object.assign({
   API: Currency,
   MOBX_DEV_TOOLS: ?string,
   commit: string,
+  branch: string,
   isDev: void => boolean,
   isTest: void => boolean,
   isMainnet: void => boolean,

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -121,6 +121,7 @@
   "settings.display.themeWarning": "CHANGING THEME WILL REMOVE CUSTOMIZATION",
   "settings.general.aboutYoroi.commitLabel": "Commit:",
   "settings.general.aboutYoroi.facebook": "Yoroi Facebook",
+  "settings.general.aboutYoroi.git.branch": "Branch:",
   "settings.general.aboutYoroi.github": "Yoroi GitHub",
   "settings.general.aboutYoroi.label": "About Yoroi",
   "settings.general.aboutYoroi.medium": "EMURGO Medium",

--- a/webpack/commonConfig.js
+++ b/webpack/commonConfig.js
@@ -124,7 +124,8 @@ const resolve = {
 const definePlugin = (networkName) => ({
   'process.env': {
     NODE_ENV: JSON.stringify(networkName),
-    COMMIT: JSON.stringify(shell.exec('git rev-parse HEAD', { silent: true }).trim())
+    COMMIT: JSON.stringify(shell.exec('git rev-parse HEAD', { silent: true }).trim()),
+    BRANCH: JSON.stringify(shell.exec('git rev-parse --abbrev-ref HEAD', { silent: true }).trim())
   }
 });
 


### PR DESCRIPTION
## Before this PR

![image](https://user-images.githubusercontent.com/2608559/59590215-81901900-9126-11e9-887a-c06b6b75d6df.png)

## After this PR

Here is what the UI looks like:
![image](https://user-images.githubusercontent.com/2608559/59590065-337b1580-9126-11e9-8367-3ea7ad16d591.png)
![image](https://user-images.githubusercontent.com/2608559/59590079-3aa22380-9126-11e9-964d-481a815c89de.png)
![image](https://user-images.githubusercontent.com/2608559/59590089-40980480-9126-11e9-926e-e1fd5e1b89b3.png)
![image](https://user-images.githubusercontent.com/2608559/59590098-442b8b80-9126-11e9-963b-bee72c1ad173.png)

**Note:** There is no link for staging. Maybe in the future it can point to an explorer for the network you're on, but currently Seiza doesn't have a non-mainnet explorer so I left this out for now. I made "Network" be at the top since it's the only one not clickable so it felt strange to put it in the middle.

**Note:** Branch name is hidden on mainnet builds because I assume this would only confuse regular users given that all production builds may not be on `master`