### PR TITLE
Make prop types in the wallet component exact types

### DIFF
--- a/app/components/wallet/WalletAdd.js
+++ b/app/components/wallet/WalletAdd.js
@@ -51,7 +51,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onCreate: Function,
   onRestore: Function,
   onHardwareConnect: Function,
@@ -59,7 +59,7 @@ type Props = {
   onDaedalusTransfer: Function,
   isRestoreActive: boolean,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class WalletAdd extends Component<Props> {

--- a/app/components/wallet/WalletBackupDialog.js
+++ b/app/components/wallet/WalletBackupDialog.js
@@ -5,7 +5,7 @@ import WalletBackupPrivacyWarningDialog from './backup-recovery/WalletBackupPriv
 import WalletRecoveryPhraseDisplayDialog from './backup-recovery/WalletRecoveryPhraseDisplayDialog';
 import WalletRecoveryPhraseEntryDialog from './backup-recovery/WalletRecoveryPhraseEntryDialog';
 
-type Props = {
+type Props = {|
   currentStep: ?string,
   canPhraseBeShown: boolean,
   isPrivacyNoticeAccepted: boolean,
@@ -30,7 +30,7 @@ type Props = {
   removeWord: Function,
   hasWord: Function,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class WalletBackupDialog extends Component<Props> {

--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -50,11 +50,11 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onSubmit: Function,
   onCancel: Function,
   classicTheme: boolean
-};
+|};
 
 type State = {
   isSubmitting: boolean,

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -55,7 +55,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   walletAddress: string,
   selectedExplorer: ExplorerType,
   isWalletAddressUsed: boolean,
@@ -65,7 +65,7 @@ type Props = {
   onVerifyAddress: Function,
   isSubmitting: boolean,
   error?: ?LocalizableError,
-};
+|};
 
 type State = {
   showUsed: boolean,

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -109,7 +109,7 @@ export type WalletRestoreDialogValues = {
   paperPassword: string,
 }
 
-type Props = {
+type Props = {|
   onSubmit: Function,
   onCancel: Function,
   onBack?: Function,
@@ -125,7 +125,7 @@ type Props = {
   classicTheme: boolean,
   initValues?: WalletRestoreDialogValues,
   introMessage?: string,
-};
+|};
 
 @observer
 export default class WalletRestoreDialog extends Component<Props> {

--- a/app/components/wallet/WalletRestoreVerifyDialog.js
+++ b/app/components/wallet/WalletRestoreVerifyDialog.js
@@ -47,7 +47,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   addresses: Array<string>,
   accountPlate: WalletAccountNumberPlate,
   selectedExplorer: ExplorerType,
@@ -57,12 +57,11 @@ type Props = {
   isSubmitting: boolean,
   classicTheme: boolean,
   error?: ?LocalizableError,
-};
+|};
 
 @observer
 export default class WalletRestoreVerifyDialog extends Component<Props> {
   static defaultProps = {
-    onBack: undefined,
     onCopyAddress: undefined,
     error: undefined,
   };

--- a/app/components/wallet/WalletSettings.js
+++ b/app/components/wallet/WalletSettings.js
@@ -26,7 +26,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   walletName: string,
   walletPasswordUpdateDate: ?Date,
   error?: ?LocalizableError,
@@ -44,7 +44,7 @@ type Props = {
   lastUpdatedField: ?string,
   showPasswordBlock: boolean,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class WalletSettings extends Component<Props> {

--- a/app/components/wallet/ada-redemption/AdaRedemptionChoices.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionChoices.js
@@ -29,11 +29,11 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   activeChoice: RedemptionTypeChoices,
   onSelectChoice: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class AdaRedemptionChoices extends Component<Props> {

--- a/app/components/wallet/ada-redemption/AdaRedemptionDisclaimer.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionDisclaimer.js
@@ -29,10 +29,10 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onSubmit: Function,
   classicTheme: boolean,
-};
+|};
 
 type State = {
   isAccepted: boolean,

--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -157,7 +157,7 @@ where Ada should be redeemed and enter {adaRedemptionPassphraseLength} word mnem
   },
 });
 
-type Props = {
+type Props = {|
   wallets: Array<{ value: string, label: string }>,
   onAcceptRedemptionDisclaimer: Function,
   onChooseRedemptionType: Function,
@@ -187,7 +187,7 @@ type Props = {
   error: ?LocalizableError,
   suggestedMnemonics: Array<string>,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class AdaRedemptionForm extends Component<Props> {

--- a/app/components/wallet/ada-redemption/AdaRedemptionNoWallets.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionNoWallets.js
@@ -23,10 +23,10 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onGoToCreateWalletClick: Function,
   classicTheme: boolean,
-};
+|};
 
 export default class AdaRedemptionNoWallets extends Component<Props> {
 

--- a/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.js
@@ -21,11 +21,11 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   amount: number,
   onClose: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class AdaRedemptionSuccessOverlay extends Component<Props> {

--- a/app/components/wallet/add/option-dialog/OptionBlock.js
+++ b/app/components/wallet/add/option-dialog/OptionBlock.js
@@ -9,14 +9,14 @@ import globalMessages from '../../../../i18n/global-messages';
 import arrowDownSVG from '../../../../assets/images/expand-arrow-grey.inline.svg';
 import styles from './OptionBlock.scss';
 
-type Props = {
+type Props = {|
   parentName: string,
   type: string,
   title: string,
   onSubmit: Function,
   // If learnMoreText is not provided, learn more block will disabled
   learnMoreText?: string,
-};
+|};
 
 type State = {
   showLearnMore: boolean,

--- a/app/components/wallet/add/option-dialog/WalletConnectHWOptionDialog.js
+++ b/app/components/wallet/add/option-dialog/WalletConnectHWOptionDialog.js
@@ -32,12 +32,12 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onCancel: Function,
   onTrezor: Function,
   onLedger: Function,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class WalletConnectHWOptionDialog extends Component<Props> {

--- a/app/components/wallet/add/option-dialog/WalletRestoreOptionDialog.js
+++ b/app/components/wallet/add/option-dialog/WalletRestoreOptionDialog.js
@@ -32,12 +32,12 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onCancel: Function,
   onRestore: Function,
   onPaperRestore: Function,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class WalletRestoreOptionDialog extends Component<Props> {

--- a/app/components/wallet/backup-recovery/MnemonicWord.js
+++ b/app/components/wallet/backup-recovery/MnemonicWord.js
@@ -6,13 +6,13 @@ import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import styles from './MnemonicWord.scss';
 
-type Props = {
+type Props = {|
   word: string,
   index: number,
   isActive: boolean,
   onClick: Function,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class MnemonicWord extends Component<Props> {

--- a/app/components/wallet/backup-recovery/WalletBackupPrivacyWarningDialog.js
+++ b/app/components/wallet/backup-recovery/WalletBackupPrivacyWarningDialog.js
@@ -30,7 +30,7 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   countdownRemaining: number,
   canPhraseBeShown: boolean,
   isPrivacyNoticeAccepted: boolean,
@@ -38,7 +38,7 @@ type Props = {
   onContinue: Function,
   onCancelBackup: Function,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class WalletBackupPrivacyWarningDialog extends Component<Props> {

--- a/app/components/wallet/backup-recovery/WalletRecoveryInstructions.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryInstructions.js
@@ -4,10 +4,10 @@ import type { Element } from 'react';
 import { observer } from 'mobx-react';
 import styles from './WalletRecoveryInstructions.scss';
 
-type Props = {
+type Props = {|
   instructionsText: string | Element<any>,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class WalletRecoveryInstructions extends Component<Props> {

--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseDisplayDialog.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseDisplayDialog.js
@@ -23,12 +23,12 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   recoveryPhrase: string,
   onStartWalletBackup: Function,
   onCancelBackup: Function,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class WalletRecoveryPhraseDisplayDialog extends Component<Props> {

--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
@@ -42,7 +42,7 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   recoveryPhraseSorted: Array<{ word: string, isActive: boolean }>,
   enteredPhrase: Array<{ word: string }>,
   isValid: boolean,
@@ -59,7 +59,7 @@ type Props = {
   removeWord: Function,
   hasWord: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class WalletRecoveryPhraseEntryDialog extends Component<Props> {

--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseMnemonic.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseMnemonic.js
@@ -5,11 +5,11 @@ import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import styles from './WalletRecoveryPhraseMnemonic.scss';
 
-type Props = {
+type Props = {|
   phrase: string | Element<any>,
   classicTheme: boolean,
   filled?: boolean
-};
+|};
 
 @observer
 export default class WalletRecoveryPhraseMnemonic extends Component<Props> {

--- a/app/components/wallet/export/ExportTransactionDialog.js
+++ b/app/components/wallet/export/ExportTransactionDialog.js
@@ -27,12 +27,12 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   isActionProcessing: ?boolean,
   error: ?LocalizableError,
   submit: Function,
   cancel: Function,
-};
+|};
 
 @observer
 export default class ExportTransactionDialog extends Component<Props> {

--- a/app/components/wallet/hwConnect/common/HWErrorBlock.js
+++ b/app/components/wallet/hwConnect/common/HWErrorBlock.js
@@ -7,11 +7,11 @@ import LocalizableError from '../../../../i18n/LocalizableError';
 import { ProgressInfo } from '../../../../types/HWConnectStoreTypes';
 
 // this component will only re-render when there is change in progressInfo
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
   error: ?LocalizableError,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default @observer

--- a/app/components/wallet/hwConnect/common/ProgressStepBlock.js
+++ b/app/components/wallet/hwConnect/common/ProgressStepBlock.js
@@ -21,10 +21,10 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class ProgressStepBlock extends Component<Props> {

--- a/app/components/wallet/hwConnect/ledger/CheckDialog.js
+++ b/app/components/wallet/hwConnect/ledger/CheckDialog.js
@@ -55,14 +55,14 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
   isActionProcessing: boolean,
   error: ?LocalizableError,
   submit: Function,
   cancel: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class CheckDialog extends Component<Props> {

--- a/app/components/wallet/hwConnect/ledger/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/ledger/ConnectDialog.js
@@ -42,7 +42,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
   isActionProcessing: boolean,
   error: ?LocalizableError,
@@ -50,7 +50,7 @@ type Props = {
   submit: Function,
   cancel: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class ConnectDialog extends Component<Props> {

--- a/app/components/wallet/hwConnect/ledger/HelpLinkBlock.js
+++ b/app/components/wallet/hwConnect/ledger/HelpLinkBlock.js
@@ -19,9 +19,9 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
-};
+|};
 
 @observer
 export default class HelpLinkBlock extends Component<Props> {

--- a/app/components/wallet/hwConnect/ledger/SaveDialog.js
+++ b/app/components/wallet/hwConnect/ledger/SaveDialog.js
@@ -46,7 +46,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
   error: ?LocalizableError,
   isActionProcessing: boolean,
@@ -54,7 +54,7 @@ type Props = {
   submit: Function,
   cancel: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class SaveDialog extends Component<Props> {

--- a/app/components/wallet/hwConnect/trezor/CheckDialog.js
+++ b/app/components/wallet/hwConnect/trezor/CheckDialog.js
@@ -55,14 +55,14 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
   isActionProcessing: boolean,
   error: ?LocalizableError,
   submit: Function,
   cancel: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class CheckDialog extends Component<Props> {
@@ -141,7 +141,7 @@ export default class CheckDialog extends Component<Props> {
         <ProgressStepBlock progressInfo={progressInfo} classicTheme={classicTheme} />
         {middleBlock}
         <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
-        <HelpLinkBlock progressInfo={progressInfo} />
+        <HelpLinkBlock />
       </Dialog>);
   }
 }

--- a/app/components/wallet/hwConnect/trezor/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/trezor/ConnectDialog.js
@@ -42,7 +42,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
   isActionProcessing: boolean,
   error: ?LocalizableError,
@@ -50,7 +50,7 @@ type Props = {
   submit: Function,
   cancel: Function,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class ConnectDialog extends Component<Props> {
@@ -149,7 +149,7 @@ export default class ConnectDialog extends Component<Props> {
         {introBlock}
         {middleBlock}
         <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
-        <HelpLinkBlock progressInfo={progressInfo} classicTheme={classicTheme} />
+        <HelpLinkBlock />
       </Dialog>);
   }
 }

--- a/app/components/wallet/hwConnect/trezor/HelpLinkBlock.js
+++ b/app/components/wallet/hwConnect/trezor/HelpLinkBlock.js
@@ -19,9 +19,8 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
-  progressInfo: ProgressInfo,
-};
+type Props = {|
+|};
 
 @observer
 export default class HelpLinkBlock extends Component<Props> {

--- a/app/components/wallet/hwConnect/trezor/SaveDialog.js
+++ b/app/components/wallet/hwConnect/trezor/SaveDialog.js
@@ -46,7 +46,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   progressInfo: ProgressInfo,
   error: ?LocalizableError,
   isActionProcessing: boolean,
@@ -54,7 +54,7 @@ type Props = {
   submit: Function,
   cancel: Function,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class SaveDialog extends Component<Props> {
@@ -173,7 +173,7 @@ export default class SaveDialog extends Component<Props> {
         {walletNameBlock}
         {middleBlock}
         <HWErrorBlock progressInfo={progressInfo} error={error} classicTheme={classicTheme} />
-        <HelpLinkBlock progressInfo={progressInfo} classicTheme={classicTheme} />
+        <HelpLinkBlock />
       </Dialog>);
   }
 

--- a/app/components/wallet/layouts/WalletWithNavigation.js
+++ b/app/components/wallet/layouts/WalletWithNavigation.js
@@ -5,11 +5,11 @@ import { observer } from 'mobx-react';
 import WalletNavigation from '../navigation/WalletNavigation';
 import styles from './WalletWithNavigation.scss';
 
-type Props = {
+type Props = {|
   children?: Node,
   isActiveScreen: Function,
   onWalletNavItemClick: Function,
-};
+|};
 
 @observer
 export default class WalletWithNavigation extends Component<Props> {

--- a/app/components/wallet/navigation/WalletNavButton.js
+++ b/app/components/wallet/navigation/WalletNavButton.js
@@ -4,13 +4,13 @@ import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import styles from './WalletNavButton.scss';
 
-type Props = {
+type Props = {|
   label: string,
   icon: string,
   isActive: boolean,
   onClick: Function,
   className?: string,
-};
+|};
 
 @observer
 export default class WalletNavButton extends Component<Props> {

--- a/app/components/wallet/navigation/WalletNavigation.js
+++ b/app/components/wallet/navigation/WalletNavigation.js
@@ -23,10 +23,10 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   isActiveNavItem: Function,
   onNavItemClick: Function,
-};
+|};
 
 @observer
 export default class WalletNavigation extends Component<Props> {

--- a/app/components/wallet/receive/VerifyAddressDialog.js
+++ b/app/components/wallet/receive/VerifyAddressDialog.js
@@ -43,7 +43,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   isActionProcessing: boolean,
   error: ?LocalizableError,
   verify: Function,
@@ -53,7 +53,7 @@ type Props = {
   walletAddress: string,
   walletPath: BIP32Path,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class VerifyAddressDialog extends Component<Props> {

--- a/app/components/wallet/send/HWSendConfirmationDialog.js
+++ b/app/components/wallet/send/HWSendConfirmationDialog.js
@@ -25,7 +25,7 @@ type ExpectedMessages = {
   sendUsingHWButtonLabel: MessageDescriptor,
 };
 
-type Props = {
+type Props = {|
   staleTx: boolean,
   selectedExplorer: ExplorerType,
   amount: string,
@@ -40,7 +40,7 @@ type Props = {
   onSubmit: void => void,
   onCancel: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class HWSendConfirmationDialog extends Component<Props> {

--- a/app/components/wallet/send/WalletSendConfirmationDialog.js
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.js
@@ -38,7 +38,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   staleTx: boolean,
   selectedExplorer: ExplorerType,
   amount: string,
@@ -53,7 +53,7 @@ type Props = {
   error: ?LocalizableError,
   currencyUnit: string,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class WalletSendConfirmationDialog extends Component<Props> {

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -94,7 +94,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   currencyUnit: string,
   currencyMaxIntegerDigits: number,
   currencyMaxFractionalDigits: number,
@@ -112,7 +112,7 @@ type Props = {
   isCalculatingFee: boolean,
   reset: void => void,
   error: ?LocalizableError,
-};
+|};
 
 @observer
 export default class WalletSendForm extends Component<Props> {

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.js
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.js
@@ -47,7 +47,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   currentPasswordValue: string,
   newPasswordValue: string,
   repeatedPasswordValue: string,
@@ -58,7 +58,7 @@ type Props = {
   isSubmitting: boolean,
   error: ?LocalizableError,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class ChangeWalletPasswordDialog extends Component<Props> {

--- a/app/components/wallet/settings/paper-wallets/CreatePaperDialog.js
+++ b/app/components/wallet/settings/paper-wallets/CreatePaperDialog.js
@@ -65,7 +65,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   renderStatus: ?PdfGenStepType,
   paperFile: ?Blob,
   onNext: Function,
@@ -73,7 +73,7 @@ type Props = {
   onDownload: Function,
   onDataChange: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class CreatePaperDialog extends Component<Props> {

--- a/app/components/wallet/settings/paper-wallets/FinalizeDialog.js
+++ b/app/components/wallet/settings/paper-wallets/FinalizeDialog.js
@@ -42,7 +42,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onCopyAddress?: Function,
   selectedExplorer: ExplorerType,
   paper: AdaPaper,
@@ -50,7 +50,7 @@ type Props = {
   onCancel: Function,
   onBack?: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class FinalizeDialog extends Component<Props> {

--- a/app/components/wallet/settings/paper-wallets/UserPasswordDialog.js
+++ b/app/components/wallet/settings/paper-wallets/UserPasswordDialog.js
@@ -51,14 +51,14 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   passwordValue: string,
   repeatedPasswordValue: string,
   onNext: Function,
   onCancel: Function,
   onDataChange: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class UserPasswordDialog extends Component<Props> {

--- a/app/components/wallet/skins/AmountInputSkin.js
+++ b/app/components/wallet/skins/AmountInputSkin.js
@@ -13,13 +13,13 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   currency: string,
   fees: BigNumber,
   total: BigNumber,
   error: boolean,
   classicTheme: boolean
-};
+|};
 
 export default class AmountInputSkin extends Component<Props> {
 

--- a/app/components/wallet/summary/WalletSummary.js
+++ b/app/components/wallet/summary/WalletSummary.js
@@ -29,12 +29,12 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   numberOfTransactions: number,
   pendingAmount: UnconfirmedAmount,
   isLoadingTransactions: boolean,
   openExportTxToFileDialog: Function,
-};
+|};
 
 @observer
 export default class WalletSummary extends Component<Props> {

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -110,14 +110,14 @@ const stateTranslations = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   data: WalletTransaction,
   state: TransactionState,
   selectedExplorer: ExplorerType,
   assuranceLevel: string,
   isLastInList: boolean,
   formattedWalletAmount: Function,
-};
+|};
 
 type State = {
   isExpanded: boolean,

--- a/app/components/wallet/transactions/TransactionTypeIcon.js
+++ b/app/components/wallet/transactions/TransactionTypeIcon.js
@@ -8,9 +8,9 @@ import exchangeIcon from '../../../assets/images/exchange-ic.inline.svg';
 import failedIcon from '../../../assets/images/transaction/deny-ic.inline.svg';
 import styles from './TransactionTypeIcon.scss';
 
-type Props = {
+type Props = {|
   iconType: string,
-};
+|};
 
 export default class TransactionTypeIcon extends Component<Props> {
 

--- a/app/components/wallet/transactions/WalletNoTransactions.js
+++ b/app/components/wallet/transactions/WalletNoTransactions.js
@@ -6,10 +6,10 @@ import styles from './WalletNoTransactions.scss';
 import noTransactionClassicSvg from '../../../assets/images/transaction/no-transactions-yet.classic.inline.svg';
 import noTransactionModernSvg from '../../../assets/images/transaction/no-transactions-yet.modern.inline.svg';
 
-type Props = {
+type Props = {|
   label: string,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class WalletNoTransactions extends Component<Props> {

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -31,7 +31,7 @@ const messages = defineMessages({
 
 const dateFormat = 'YYYY-MM-DD';
 
-type Props = {
+type Props = {|
   transactions: Array<WalletTransaction>,
   isLoadingTransactions: boolean,
   hasMoreToLoad: boolean,
@@ -40,7 +40,7 @@ type Props = {
   walletId: string,
   formattedWalletAmount: Function,
   onLoadMore: Function,
-};
+|};
 
 @observer
 export default class WalletTransactionsList extends Component<Props> {

--- a/app/containers/wallet/WalletAddPage.js
+++ b/app/containers/wallet/WalletAddPage.js
@@ -52,8 +52,6 @@ export default class WalletAddPage extends Component<Props> {
     const { uiDialogs } = stores;
     const { restoreRequest } = wallets;
 
-    const isCreateTrezorWalletActive = this._getTrezorConnectStore().isCreateHWActive;
-    const isCreateLedgerWalletActive = this._getLedgerConnectStore().isCreateHWActive;
     const openTrezorConnectDialog = () => {
       actions.dialogs.open.trigger({ dialog: WalletTrezorConnectDialogContainer });
       this.props.actions[environment.API].trezorConnect.init.trigger();
@@ -139,11 +137,8 @@ export default class WalletAddPage extends Component<Props> {
         onHardwareConnect={
           () => actions.dialogs.open.trigger({ dialog: WalletConnectHWOptionDialog })
         }
-        isCreateTrezorWalletActive={isCreateTrezorWalletActive}
-        isCreateLedgerWalletActive={isCreateLedgerWalletActive}
         onCreate={() => actions.dialogs.open.trigger({ dialog: WalletCreateDialog })}
         onRestore={() => actions.dialogs.open.trigger({ dialog: WalletRestoreOptionDialog })}
-        onPaperRestore={() => actions.dialogs.open.trigger({ dialog: WalletRestoreDialog, params: { restoreType: 'paper' } })}
         isRestoreActive={restoreRequest.isExecuting}
         onSettings={this._goToSettingsRoot}
         onDaedalusTransfer={this._goToDaedalusTransferRoot}

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -114,7 +114,6 @@ export default class WalletRestoreDialogContainer
           onNext={this.onVerifiedSubmit}
           onCancel={this.cancelVerification}
           isSubmitting={restoreRequest.isExecuting}
-          onSubmit={this.onSubmit}
           classicTheme={this.props.classicTheme}
           error={restoreRequest.error}
         />


### PR DESCRIPTION
Summary of changes:
1. Replace all `type Props = {...}` with `type Props = {|...|}` in app/components/wallet

2. Due to change 1, this dead property passing is removed: https://github.com/Emurgo/yoroi-frontend/commit/1cc45b75b96a8db1139b88dececd5f1d0e9c3ab2#diff-bb0d1f47214ea0362e62c58c81e19773

3. In https://github.com/Emurgo/yoroi-frontend/commit/1cc45b75b96a8db1139b88dececd5f1d0e9c3ab2#diff-8fcf44547d46e3b464bdf065de77505b, since the properties are not referenced, I removed them. And  changed the users of `HelpLinkBlock` accordingly: https://github.com/Emurgo/yoroi-frontend/commit/1cc45b75b96a8db1139b88dececd5f1d0e9c3ab2#diff-bf3e8c20cfec882b67ed925e0b2e1e29 https://github.com/Emurgo/yoroi-frontend/commit/1cc45b75b96a8db1139b88dececd5f1d0e9c3ab2#diff-1d03de52c629aa74177f6fab887e97c9 https://github.com/Emurgo/yoroi-frontend/commit/1cc45b75b96a8db1139b88dececd5f1d0e9c3ab2#diff-b262f54cf62b3aaaa32580f257d3632c

4. Due to change 1, dead properties in https://github.com/Emurgo/yoroi-frontend/commit/1cc45b75b96a8db1139b88dececd5f1d0e9c3ab2#diff-eb964c5702091af0927b33c347e96961 are removed.