### PR TITLE
Remove default letter-spcing on modern theme

### DIFF
--- a/app/components/wallet/WalletAdd.scss
+++ b/app/components/wallet/WalletAdd.scss
@@ -38,6 +38,7 @@
   .heroTitle {
     font-family: var(--font-bold);
     font-size: 54px;
+    letter-spacing: 0.5px;
     line-height: 62px;
     margin-bottom: 15px;
     margin-right: 42px;

--- a/app/themes/index.global.scss
+++ b/app/themes/index.global.scss
@@ -193,11 +193,13 @@ button {
 html, body, #root, #root > [data-reactroot] {
   width: 100%;
   height: 100%;
-  letter-spacing: 1px; // TODO: remove from modern theme
   // Make the default font ugly so we immediately see when something
   // is not yet defined correctly in our UI
   font-family: var(--default-font), serif;
   -webkit-font-smoothing: antialiased;
+  :global(.YoroiClassic) {
+    letter-spacing: 1px; 
+  }
 }
 
 * {


### PR DESCRIPTION
Marta has requested this multiple times. This changes how many screens on the modern theme look so we need to be kind of careful about merging it.

## Before

![image](https://user-images.githubusercontent.com/2608559/59595338-9376b980-9130-11e9-8b74-56a138e771c0.png)

## After 

![image](https://user-images.githubusercontent.com/2608559/59595309-7f32bc80-9130-11e9-806d-1888685cdfbf.png)

I also noticed many screens manually set a different default letter-spacing. For example, the paper wallet screen manually sets `letter-spacing: 0.5px` so this PR doesn't affect them.