### PR TITLE
Generic build compress script

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,9 +7,9 @@ To create a release candidate you must compress a local build.
 Zip files can be shared
 
 ```bash
-# compress build folder to {manifest.name}.zip and crx
-$ npm run build -- --env "${network}"
-$ npm run compress -- --env "${network}" --zip-only --app-id "APP_ID" --codebase "https://www.sample.com/dw/yoroi-extension.crx"
+# compress build folder to {manifest.name}.zip
+# if CARDANO_NETWORK is not provided, it defaults to "testnet"
+$ CARDANO_NETWORK=staging npm run build-compress
 ```
 
 ## (Chrome) Signed build

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build-compress-crx:production": "npm run build -- --env 'mainnet' && npm run compress -- --env 'mainnet' --app-id 'yoroi' --codebase 'https://yoroiwallet.com/dw/yoroi-extension.crx' --key ./production-key.pem",
     "build-compress:staging": "npm run build -- --env 'staging' && npm run compress -- --env 'staging' --app-id 'yoroi-stag' --zip-only --codebase 'https://yoroiwallet.com/dw/yoroi-staging-extension.crx' --key ./staging-key.pem",
     "build-compress-crx:staging": "npm run build -- --env 'staging' && npm run compress -- --env 'staging' --app-id 'yoroi-stag' --codebase 'https://yoroiwallet.com/dw/yoroi-staging-extension.crx' --key ./staging-key.pem",
+    "build-compress": "npm run build -- --env ${CARDANO_NETWORK:-testnet} && npm run compress -- --env ${CARDANO_NETWORK:-testnet} --app-id yoroi-${CARDANO_NETWORK:-testnet} --zip-only --codebase https://yoroiwallet.com/dw/yoroi-${CARDANO_NETWORK:-testnet}-extension.crx",
+    "build-compress-crx": "npm run build -- --env ${CARDANO_NETWORK:-testnet} && npm run compress -- --env ${CARDANO_NETWORK:-testnet} --app-id yoroi-${CARDANO_NETWORK:-testnet} --codebase https://yoroiwallet.com/dw/yoroi-${CARDANO_NETWORK:-testnet}-extension.crx --key ./${CARDANO_NETWORK:-testnet}-key.pem",
     "compress-keygen": "crx keygen",
     "clean": "rimraf build/ dev/ *.zip *.crx",
     "flow": "flow --show-all-errors .",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "compress-e2e-tests": "npm run compress -- --env 'test' --app-id 'yoroi' --codebase 'https://yoroiwallet.com/dw/yoroi-test-extension.crx' --key ./e2etest-key.pem",
     "build-compress:production": "npm run build -- --env 'mainnet' && npm run compress -- --env 'mainnet' --app-id 'yoroi' --zip-only --codebase 'https://yoroiwallet.com/dw/yoroi-extension.crx' --key ./production-key.pem",
     "build-compress-crx:production": "npm run build -- --env 'mainnet' && npm run compress -- --env 'mainnet' --app-id 'yoroi' --codebase 'https://yoroiwallet.com/dw/yoroi-extension.crx' --key ./production-key.pem",
-    "build-compress:staging": "npm run build -- --env 'staging' && npm run compress -- --env 'staging' --app-id 'yoroi-stag' --zip-only --codebase 'https://yoroiwallet.com/dw/yoroi-staging-extension.crx' --key ./staging-key.pem",
-    "build-compress-crx:staging": "npm run build -- --env 'staging' && npm run compress -- --env 'staging' --app-id 'yoroi-stag' --codebase 'https://yoroiwallet.com/dw/yoroi-staging-extension.crx' --key ./staging-key.pem",
     "build-compress": "npm run build -- --env ${CARDANO_NETWORK:-testnet} && npm run compress -- --env ${CARDANO_NETWORK:-testnet} --app-id yoroi-${CARDANO_NETWORK:-testnet} --zip-only --codebase https://yoroiwallet.com/dw/yoroi-${CARDANO_NETWORK:-testnet}-extension.crx",
     "build-compress-crx": "npm run build -- --env ${CARDANO_NETWORK:-testnet} && npm run compress -- --env ${CARDANO_NETWORK:-testnet} --app-id yoroi-${CARDANO_NETWORK:-testnet} --codebase https://yoroiwallet.com/dw/yoroi-${CARDANO_NETWORK:-testnet}-extension.crx --key ./${CARDANO_NETWORK:-testnet}-key.pem",
     "compress-keygen": "crx keygen",


### PR DESCRIPTION
build-compress[-crx]' yarn script that uses environment var '\$CARDANO_NETWORK' as template (if empty, defaults to 'testnet')