### PR TITLE
shin/ch1467/fix-about-yoroi-icon-font-same-as-text-block

### DIFF
--- a/app/components/widgets/LinkButton.scss
+++ b/app/components/widgets/LinkButton.scss
@@ -9,7 +9,8 @@ $blockHeight: 27px;
     display: flex;
     align-items: center;
     text-decoration: none;
-    color: #ADAEB6;
+    font-family: var(--font-regular);
+    color: var(--theme-link-button-text-color);
   }
 }
 
@@ -35,6 +36,6 @@ $blockHeight: 27px;
 };
 
 .block:hover {
-  background-color: var(--theme-footer-block-background-color-hover);
+  background-color: var(--theme-link-button-background-color-hover);
   cursor: pointer;
 };

--- a/app/themes/prebuilt/YoroiClassic.js
+++ b/app/themes/prebuilt/YoroiClassic.js
@@ -398,8 +398,8 @@ export default {
   '--theme-widgets-hash-dark-color': '#000000',
   '--theme-widgets-hash-light-color': '#929293',
 
-  '--theme-footer-block-background-color': 'rgba(218, 164, 154, 0.06)',
-  '--theme-footer-block-background-color-hover': '#D9DDE0',
+  '--theme-link-button-background-color-hover': '#D9DDE0',
+  '--theme-link-button-text-color': '#000',
 
   '--theme-export-transactions-to-file': '#f9f9fa',
 

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -410,8 +410,8 @@ export default {
   '--theme-widgets-hash-dark-color': '#464749',
   '--theme-widgets-hash-light-color': '#adaeB6',
 
-  '--theme-footer-block-background-color': '#fff',
-  '--theme-footer-block-background-color-hover': '#D9DDE0',
+  '--theme-link-button-background-color-hover': '#D9DDE0',
+  '--theme-link-button-text-color': '#000',
 
   '--theme-export-transactions-to-file': '#f9f9fa',
 


### PR DESCRIPTION
## Before:
![image](https://user-images.githubusercontent.com/19986226/59604342-e491a800-9146-11e9-921c-6c113dbac033.png)

## After:
![image](https://user-images.githubusercontent.com/19986226/59604356-ee1b1000-9146-11e9-866e-386312ff8e03.png)

Refer:
https://app.clubhouse.io/emurgo/story/1467/fix-about-yoroi-icon-font-same-as-text-block