### PR TITLE
shin/ch1472/fix-create-paper-wallet-password-margin

### DIFF
--- a/app/components/wallet/settings/paper-wallets/UserPasswordDialog.scss
+++ b/app/components/wallet/settings/paper-wallets/UserPasswordDialog.scss
@@ -21,7 +21,3 @@
 .paperPassword {
   margin-top: 20px;
 }
-
-.repeatedPassword {
-  margin-top: 20px;
-}


### PR DESCRIPTION
## Before:
![image](https://user-images.githubusercontent.com/19986226/59605685-4869a000-914a-11e9-9e6e-9e58c0d89ba6.png)


## After:
![image](https://user-images.githubusercontent.com/19986226/59605709-50294480-914a-11e9-928e-8e09578bdefe.png)


Refer:
https://app.clubhouse.io/emurgo/story/1472/fix-create-paper-wallet-password-margin