### PR TITLE
shin/ch1412/change-button-s-text-opacity-on-receive-page

### DIFF
--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -218,9 +218,7 @@ export default class WalletReceive extends Component<Props, State> {
                           svg={verifyIcon}
                           className={styles.verifyIcon}
                         />
-                        <span className={styles.actionIconText}>
-                          {intl.formatMessage(messages.verifyAddressLabel)}
-                        </span>
+                        <span>{intl.formatMessage(messages.verifyAddressLabel)}</span>
                       </div>
                     </button>
                   </div>
@@ -231,9 +229,7 @@ export default class WalletReceive extends Component<Props, State> {
                   >
                     <div className={styles.addressActionItemBlock}>
                       <SvgInline svg={iconCopy} className={styles.copyIcon} />
-                      <span className={styles.actionIconText}>
-                        {intl.formatMessage(messages.copyAddressLabel)}
-                      </span>
+                      <span>{intl.formatMessage(messages.copyAddressLabel)}</span>
                     </div>
                   </CopyToClipboard>
                 </div>

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -147,10 +147,6 @@
             font-size: 14px;
             margin-left: 6px;
           }
-          
-          .actionIconText {
-             opacity: 0.5;
-          }
 
           .verifyIcon,
           .copyIcon {


### PR DESCRIPTION
## Before:
![image](https://user-images.githubusercontent.com/19986226/59606612-8e276800-914c-11e9-84f6-28addba661f7.png)


## After:
![image](https://user-images.githubusercontent.com/19986226/59606626-95e70c80-914c-11e9-9a74-afdca03de548.png)

Refer:
https://app.clubhouse.io/emurgo/story/1412/change-button-s-text-opacity-on-receive-page-s-generated-address-block