### PR TITLE
Back button after restoring/creating wallet 

### DIFF
--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -111,6 +111,8 @@ export default class AdaWalletsStore extends WalletStore {
     await this._restore(params);
 
     this.showWalletRestoredNotification();
+    // TODO: patch for triggering topbar update, there should be a better way of doing it
+    this.stores.topbar.updateCategories();
   };
 
   // =================== WALLET IMPORTING ==================== //

--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -85,6 +85,8 @@ export default class AdaWalletsStore extends WalletStore {
     if (matchRoute(ROUTES.WALLETS.SEND, buildRoute(options.route, options.params))) {
       this.sendMoneyRequest.reset();
     }
+    // TODO: patch for triggering topbar update, there should be a better way of doing it
+    this.stores.topbar.updateCategories();
   };
 
   // =================== VALIDITY CHECK ==================== //
@@ -111,8 +113,6 @@ export default class AdaWalletsStore extends WalletStore {
     await this._restore(params);
 
     this.showWalletRestoredNotification();
-    // TODO: patch for triggering topbar update, there should be a better way of doing it
-    this.stores.topbar.updateCategories();
   };
 
   // =================== WALLET IMPORTING ==================== //


### PR DESCRIPTION
Back arrow was shown after a user created/restored a wallet if he previously went to the settings page. The specific case was the following:

-> Starting from a fresh install -> going to settings -> going back without clicking on the back arrow (e.g. trackpad) ->  restoring or creating a wallet.

Then, the topbar looked like this:
![topbar](https://user-images.githubusercontent.com/1937074/59656354-48c66300-916b-11e9-9316-9c19615e0ae6.png)

