### PR TITLE
Exactify prop types in /components

### DIFF
--- a/app/components/footer/FooterItem.js
+++ b/app/components/footer/FooterItem.js
@@ -3,11 +3,11 @@ import React, { Component } from 'react';
 import LinkButton from '../widgets/LinkButton';
 import styles from './FooterItem.scss';
 
-type Props = {
+type Props = {|
   url: string,
   svg: string,
   message: any
-};
+|};
 
 export default class FooterItem extends Component<Props> {
 

--- a/app/components/layout/CenteredLayout.js
+++ b/app/components/layout/CenteredLayout.js
@@ -4,9 +4,9 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import styles from './CenteredLayout.scss';
 
-type Props = {
+type Props = {|
   children?: Node,
-};
+|};
 
 @observer
 export default class CenteredLayout extends Component<Props> {

--- a/app/components/layout/GridFlexContainer.js
+++ b/app/components/layout/GridFlexContainer.js
@@ -6,10 +6,10 @@ import _ from 'lodash';
 
 import HorizontalFlexContainer from './HorizontalFlexContainer';
 
-type Props = {
+type Props = {|
   children: ?Node,
   rowSize: number
-};
+|};
 
 @observer
 export default class GridFlexContainer extends Component<Props> {

--- a/app/components/layout/HorizontalFlexContainer.js
+++ b/app/components/layout/HorizontalFlexContainer.js
@@ -4,9 +4,9 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import styles from './HorizontalFlexContainer.scss';
 
-type Props = {
+type Props = {|
   children: ?Node,
-};
+|};
 
 @observer
 export default class HorizontalFlexContainer extends Component<Props> {

--- a/app/components/layout/TopBarLayout.js
+++ b/app/components/layout/TopBarLayout.js
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import styles from './TopBarLayout.scss';
 
-type Props = {
+type Props = {|
   banner?: Node,
   topbar?: Node,
   children?: ?Node,
@@ -13,7 +13,7 @@ type Props = {
   languageSelectionBackground?: boolean,
   footer?: Node,
   classicTheme?: boolean,
-};
+|};
 
 /** Adds a top bar above the wrapped node */
 @observer
@@ -24,7 +24,6 @@ export default class TopBarLayout extends Component<Props> {
     children: undefined,
     notification: undefined,
     languageSelectionBackground: false,
-    withFooter: false,
     footer: undefined,
     classicTheme: false,
   };

--- a/app/components/layout/VerticalFlexContainer.js
+++ b/app/components/layout/VerticalFlexContainer.js
@@ -4,9 +4,9 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import styles from './VerticalFlexContainer.scss';
 
-type Props = {
+type Props = {|
   children: ?Node,
-};
+|};
 
 @observer
 export default class VerticalFlexContainer extends Component<Props> {

--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -12,7 +12,7 @@ import type { MessageDescriptor } from 'react-intl';
 import environment from '../../environment';
 import LocalizableError from '../../i18n/LocalizableError';
 
-type Props = {
+type Props = {|
   currencyIcon: string,
   apiIcon: string,
   isLoadingDataForNextScreen: boolean,
@@ -21,7 +21,7 @@ type Props = {
   hasLoadedCurrentTheme: boolean,
   error: ?LocalizableError,
   getErrorMessage: void => Node,
-};
+|};
 
 @observer
 export default class Loading extends Component<Props> {

--- a/app/components/profile/language-selection/LanguageSelectionForm.js
+++ b/app/components/profile/language-selection/LanguageSelectionForm.js
@@ -22,14 +22,14 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onSelectLanguage: Function,
   languages: Array<{ value: string, label: MessageDescriptor, svg: string }>,
   onSubmit: Function,
   isSubmitting: boolean,
   currentLocale: string,
   error?: ?LocalizableError,
-};
+|};
 
 @observer
 export default class LanguageSelectionForm extends Component<Props> {

--- a/app/components/profile/terms-of-use/TermsOfUseForm.js
+++ b/app/components/profile/terms-of-use/TermsOfUseForm.js
@@ -22,12 +22,12 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   localizedTermsOfUse: string,
   onSubmit: Function,
   isSubmitting: boolean,
   error?: ?LocalizableError,
-};
+|};
 
 type State = {
   areTermsOfUseAccepted: boolean,

--- a/app/components/profile/terms-of-use/TermsOfUseText.js
+++ b/app/components/profile/terms-of-use/TermsOfUseText.js
@@ -5,10 +5,10 @@ import ReactMarkdown from 'react-markdown';
 import styles from './TermsOfUseText.scss';
 import classNames from 'classnames';
 
-type Props = {
+type Props = {|
   localizedTermsOfUse: string,
   fixedHeight?: bool,
-};
+|};
 
 @observer
 export default class TermsOfUseText extends Component<Props> {

--- a/app/components/settings/SettingsLayout.js
+++ b/app/components/settings/SettingsLayout.js
@@ -4,10 +4,10 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import styles from './SettingsLayout.scss';
 
-type Props = {
+type Props = {|
   children: Node,
   menu: Node,
-};
+|};
 
 @observer
 export default class SettingsLayout extends Component<Props> {

--- a/app/components/settings/categories/PaperWalletSettings.js
+++ b/app/components/settings/categories/PaperWalletSettings.js
@@ -34,13 +34,13 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onCreatePaper: Function,
   dialog: Node,
   paperWalletsIntroText: string,
   isDialogOpen: boolean,
   error?: ?LocalizableError,
-};
+|};
 
 @observer
 export default class PaperWalletSettings extends Component<Props> {

--- a/app/components/settings/categories/SupportSettings.js
+++ b/app/components/settings/categories/SupportSettings.js
@@ -36,10 +36,10 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onExternalLinkClick: Function,
   onDownloadLogs: Function,
-};
+|};
 
 @observer
 export default class SupportSettings extends Component<Props> {

--- a/app/components/settings/categories/TermsOfUseSettings.js
+++ b/app/components/settings/categories/TermsOfUseSettings.js
@@ -4,9 +4,9 @@ import { observer } from 'mobx-react';
 import TermsOfUseText from '../../profile/terms-of-use/TermsOfUseText';
 import styles from './TermsOfUseSettings.scss';
 
-type Props = {
+type Props = {|
   localizedTermsOfUse: string,
-};
+|};
 
 @observer
 export default class TermsOfUseSettings extends Component<Props> {

--- a/app/components/settings/categories/display/ThemeThumbnail.js
+++ b/app/components/settings/categories/display/ThemeThumbnail.js
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react';
 
-type Props = {
+type Props = {|
   themeVars: Object,
   themeKey: string,
-};
+|};
 
 export default class ThemeThumbnail extends Component<Props> {
   render() {

--- a/app/components/settings/categories/general-setting/ExplorerSettings.js
+++ b/app/components/settings/categories/general-setting/ExplorerSettings.js
@@ -12,13 +12,13 @@ import globalMessages from '../../../../i18n/global-messages';
 import type { ExplorerType } from '../../../../domain/Explorer';
 
 
-type Props = {
+type Props = {|
   explorers: Array<{ value: ExplorerType, label: string }>,
   selectedExplorer: ExplorerType,
   onSelectExplorer: Function,
   isSubmitting: boolean,
   error?: ?LocalizableError,
-};
+|};
 
 @observer
 export default class ExplorerSettings extends Component<Props> {

--- a/app/components/settings/categories/general-setting/GeneralSettings.js
+++ b/app/components/settings/categories/general-setting/GeneralSettings.js
@@ -13,13 +13,13 @@ import FlagLabel from '../../../widgets/FlagLabel';
 import { tier1Languages } from '../../../../config/languagesConfig';
 import globalMessages, { listOfTranslators } from '../../../../i18n/global-messages';
 
-type Props = {
+type Props = {|
   languages: Array<{ value: string, label: MessageDescriptor, svg: string }>,
   currentLocale: string,
   onSelectLanguage: Function,
   isSubmitting: boolean,
   error?: ?LocalizableError,
-};
+|};
 
 @observer
 export default class GeneralSettings extends Component<Props> {

--- a/app/components/settings/categories/general-setting/ThemeSettingsBlock.js
+++ b/app/components/settings/categories/general-setting/ThemeSettingsBlock.js
@@ -50,14 +50,14 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   currentTheme: Theme,
   selectTheme: Function,
   exportTheme: Function,
   getThemeVars: Function,
   hasCustomTheme: Function,
   onExternalLinkClick: Function,
-};
+|};
 
 @observer
 export default class ThemeSettingsBlock extends Component<Props> {

--- a/app/components/settings/menu/SettingsMenu.js
+++ b/app/components/settings/menu/SettingsMenu.js
@@ -36,13 +36,13 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   isActiveItem: Function,
   onItemClick: Function,
   hasActiveWallet: boolean,
   currentLocale: string,
   currentTheme: Theme,
-};
+|};
 
 @observer
 export default class SettingsMenu extends Component<Props> {

--- a/app/components/settings/menu/SettingsMenuItem.js
+++ b/app/components/settings/menu/SettingsMenuItem.js
@@ -4,13 +4,13 @@ import { observer } from 'mobx-react';
 import classNames from 'classnames';
 import styles from './SettingsMenuItem.scss';
 
-type Props = {
+type Props = {|
   label: string,
   active: boolean,
   onClick: Function,
   className: string,
   disabled?: boolean,
-};
+|};
 
 @observer
 export default class SettingsMenuItem extends Component<Props> {

--- a/app/components/topbar/StaticTopbarTitle.js
+++ b/app/components/topbar/StaticTopbarTitle.js
@@ -2,9 +2,9 @@
 import React, { Component } from 'react';
 import styles from './StaticTopbarTitle.scss';
 
-type Props = {
+type Props = {|
   title: string,
-};
+|};
 
 /** Static text styled for the center-text of a topbar */
 export default class StaticTopbarTitle extends Component<Props> {

--- a/app/components/topbar/TopBar.js
+++ b/app/components/topbar/TopBar.js
@@ -10,14 +10,14 @@ import globalMessages from '../../i18n/global-messages';
 import type { Category } from '../../config/topbarConfig';
 import { GO_BACK_CATEGORIE } from '../../config/topbarConfig';
 
-type Props = {
+type Props = {|
   children?: ?Node,
   title: ?Node,
   categories?: Array<Category>,
   activeTopbarCategory: string,
   onCategoryClicked?: Function,
   areCategoriesHidden?: boolean
-};
+|};
 
 @observer
 export default class TopBar extends Component<Props> {

--- a/app/components/topbar/TopBarCategory.js
+++ b/app/components/topbar/TopBarCategory.js
@@ -7,13 +7,13 @@ import { observer } from 'mobx-react';
 import classNames from 'classnames';
 import styles from './TopBarCategory.scss';
 
-type Props = {
+type Props = {|
   icon: string,
   inlineTextMD: ?MessageDescriptor,
   active: boolean,
   onClick: Function,
   className: string,
-};
+|};
 
 @observer
 export default class TopBarCategory extends Component<Props> {

--- a/app/components/topbar/WalletAccountIcon.js
+++ b/app/components/topbar/WalletAccountIcon.js
@@ -5,11 +5,11 @@ import styles from './WalletAccountIcon.scss';
 import Blockies from 'react-blockies';
 import tinycolor from 'tinycolor2';
 
-type Props = {
+type Props = {|
   iconSeed: string,
   scalePx?: number,
   saturationFactor?: number,
-};
+|};
 
 const mkcolor = (primary, secondary, spots) => ({ primary, secondary, spots });
 const COLORS = [

--- a/app/components/topbar/WalletTopbarTitle.js
+++ b/app/components/topbar/WalletTopbarTitle.js
@@ -18,7 +18,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   wallet: ?Wallet,
   account: ?WalletAccount,
   currentRoute: string,
@@ -26,7 +26,7 @@ type Props = {
   themeProperties?: {
     identiconSaturationFactor: number,
   },
-};
+|};
 
 function constructPlate(account, saturationFactor, divClass): [string, React$Element<any>] {
   const { plate: { hash, id } } = account;

--- a/app/components/topbar/banners/TestnetWarningBanner.js
+++ b/app/components/topbar/banners/TestnetWarningBanner.js
@@ -16,8 +16,8 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
-};
+type Props = {|
+|};
 
 @observer
 export default class TestnetWarningBanner extends Component<Props> {

--- a/app/components/transfer/AnnotatedLoader.js
+++ b/app/components/transfer/AnnotatedLoader.js
@@ -4,11 +4,11 @@ import { observer } from 'mobx-react';
 import LoadingSpinner from '../widgets/LoadingSpinner';
 import styles from './AnnotatedLoader.scss';
 
-type Props = {
+type Props = {|
   title: string,
   details: string,
   warning?: string,
-};
+|};
 
 @observer
 export default class AnnotatedLoader extends Component<Props> {

--- a/app/components/transfer/ErrorPage.js
+++ b/app/components/transfer/ErrorPage.js
@@ -8,13 +8,13 @@ import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import LocalizableError from '../../i18n/LocalizableError';
 import styles from './ErrorPage.scss';
 
-type Props = {
+type Props = {|
   error?: ?LocalizableError,
   onCancel: Function,
   title: string,
   backButtonLabel: string,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class ErrorPage extends Component<Props> {

--- a/app/components/transfer/TransferInstructionsPage.js
+++ b/app/components/transfer/TransferInstructionsPage.js
@@ -45,13 +45,13 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onFollowInstructionsPrerequisites: Function,
   onConfirm: Function,
   onPaperConfirm: Function,
   onMasterKeyConfirm: Function,
   disableTransferFunds: boolean,
-};
+|};
 
 @observer
 export default class TransferInstructionsPage extends Component<Props> {

--- a/app/components/transfer/TransferLayout.js
+++ b/app/components/transfer/TransferLayout.js
@@ -4,9 +4,9 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import styles from './TransferLayout.scss';
 
-type Props = {
+type Props = {|
   children: Node
-};
+|};
 
 @observer
 export default class TransferLayout extends Component<Props> {

--- a/app/components/transfer/TransferMasterKeyPage.js
+++ b/app/components/transfer/TransferMasterKeyPage.js
@@ -29,12 +29,12 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onSubmit: Function,
   onBack: Function,
   step0: string,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class TransferMasterKeyPage extends Component<Props> {

--- a/app/components/transfer/TransferMnemonicPage.js
+++ b/app/components/transfer/TransferMnemonicPage.js
@@ -34,7 +34,7 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onSubmit: Function,
   onBack: Function,
   mnemonicValidator: Function,
@@ -42,7 +42,7 @@ type Props = {
   step0: string,
   mnemonicLength: number,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class TransferMnemonicPage extends Component<Props> {

--- a/app/components/transfer/TransferSummaryPage.js
+++ b/app/components/transfer/TransferSummaryPage.js
@@ -44,7 +44,7 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   formattedWalletAmount: Function,
   selectedExplorer: ExplorerType,
   transferTx: TransferTx,
@@ -54,7 +54,7 @@ type Props = {
   error: ?LocalizableError,
   addressFromSubLabel: string,
   classicTheme: boolean
-};
+|};
 
 /** Show user what the transfer would do to get final confirmation */
 @observer

--- a/app/components/widgets/BigButtonForDialogs.js
+++ b/app/components/widgets/BigButtonForDialogs.js
@@ -2,13 +2,13 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import styles from './BigButtonForDialogs.scss';
 
-type Props = {
+type Props = {|
   label: string,
   description: string,
   onClick: Function,
   isDisabled: boolean,
   className: string,
-};
+|};
 
 export default class BigButtonForDialogs extends Component<Props> {
 

--- a/app/components/widgets/BorderedBox.js
+++ b/app/components/widgets/BorderedBox.js
@@ -4,9 +4,9 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import styles from './BorderedBox.scss';
 
-type Props = {
+type Props = {|
   children?: Node,
-};
+|};
 
 @observer
 export default class BorderedBox extends Component<Props> {

--- a/app/components/widgets/Dialog.js
+++ b/app/components/widgets/Dialog.js
@@ -9,7 +9,7 @@ import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import { ModalSkin } from 'react-polymorph/lib/skins/simple/ModalSkin';
 import styles from './Dialog.scss';
 
-type Props = {
+type Props = {|
   title?: string,
   children?: Node,
   actions?: Node,
@@ -19,7 +19,7 @@ type Props = {
   onClose?: Function,
   closeOnOverlayClick?: boolean,
   classicTheme: boolean
-};
+|};
 
 @observer
 export default class Dialog extends Component<Props> {

--- a/app/components/widgets/DialogBackButton.js
+++ b/app/components/widgets/DialogBackButton.js
@@ -3,9 +3,9 @@ import SvgInline from 'react-svg-inline';
 import backArrow from '../../assets/images/back-arrow-ic.inline.svg';
 import styles from './DialogBackButton.scss';
 
-type Props = {
+type Props = {|
   onBack: Function
-};
+|};
 
 export default class DialogBackButton extends Component<Props> {
 

--- a/app/components/widgets/DialogCloseButton.js
+++ b/app/components/widgets/DialogCloseButton.js
@@ -3,10 +3,10 @@ import SvgInline from 'react-svg-inline';
 import closeCross from '../../assets/images/close-cross.inline.svg';
 import styles from './DialogCloseButton.scss';
 
-type Props = {
+type Props = {|
   onClose: Function,
   icon?: string,
-};
+|};
 
 export default class DialogCloseButton extends Component<Props> {
   static defaultProps = {

--- a/app/components/widgets/ErrorBlock.js
+++ b/app/components/widgets/ErrorBlock.js
@@ -8,9 +8,9 @@ import { Logger, stringifyError } from '../../utils/logging';
 
 import styles from './ErrorBlock.scss';
 
-type Props = {
+type Props = {|
   error: ?LocalizableError,
-};
+|};
 
 @observer
 export default class ErrorBlock extends Component<Props> {

--- a/app/components/widgets/FlagLabel.js
+++ b/app/components/widgets/FlagLabel.js
@@ -3,12 +3,12 @@ import React, { Component } from 'react';
 import styles from './FlagLabel.scss';
 import SvgInline from 'react-svg-inline';
 
-type Props = {
+type Props = {|
   svg: string,
   label: string,
   width?: string,
   height?: string
-};
+|};
 
 export default class FlagLabel extends Component<Props> {
 

--- a/app/components/widgets/InformativeMessage.js
+++ b/app/components/widgets/InformativeMessage.js
@@ -5,12 +5,12 @@ import ReactMarkdown from 'react-markdown';
 import classNames from 'classnames';
 import styles from './InformativeMessage.scss';
 
-type Props = {
+type Props = {|
   title?: string,
   message?: string,
   subclass?: string,
   children?: Children
-};
+|};
 
 @observer
 export default class InformativeMessage extends Component<Props> {

--- a/app/components/widgets/LinkButton.js
+++ b/app/components/widgets/LinkButton.js
@@ -3,13 +3,13 @@ import SvgInline from 'react-svg-inline';
 import { intlShape } from 'react-intl';
 import styles from './LinkButton.scss';
 
-type Props = {
+type Props = {|
   url: string,
   svg: string,
   message: any,
   svgClassName: string,
   textClassName: String
-};
+|};
 
 export default class LinkButton extends Component<Props> {
 

--- a/app/components/widgets/NotificationMessage.js
+++ b/app/components/widgets/NotificationMessage.js
@@ -4,11 +4,11 @@ import SvgInline from 'react-svg-inline';
 import classNames from 'classnames';
 import styles from './NotificationMessage.scss';
 
-type Props = {
+type Props = {|
   icon: string,
   show: boolean,
   children?: Children,
-};
+|};
 
 export default class NotificationMessage extends Component<Props> {
   static defaultProps = {

--- a/app/components/widgets/ProgressSteps.js
+++ b/app/components/widgets/ProgressSteps.js
@@ -9,14 +9,14 @@ import iconCrossSVG from '../../assets/images/widget/cross.inline.svg';
 import iconCrossGreenSVG from '../../assets/images/widget/cross-green.inline.svg';
 import styles from './ProgressSteps.scss';
 
-type Props = {
+type Props = {|
   stepsList: Array<string>,
   progressInfo: {
     currentStep : number, // example, 0 = pointing to stepsList[0]
     stepState: number, // has three states, 0 = LOAD | 1 = PROCESS | 9 = ERROR
   },
   classicTheme: boolean
-};
+|};
 @observer
 export default class ProgressSteps extends Component<Props> {
 

--- a/app/components/widgets/forms/AdaCertificateUploadWidget.js
+++ b/app/components/widgets/forms/AdaCertificateUploadWidget.js
@@ -11,7 +11,7 @@ import closeCrossIcon from '../../../assets/images/close-cross.inline.svg';
 import styles from './AdaCertificateUploadWidget.scss';
 import { messages } from './ImageUploadWidget';
 
-type Props = {
+type Props = {|
   label: string,
   onFileSelected: Function,
   onRemoveCertificate: Function,
@@ -19,7 +19,7 @@ type Props = {
   isCertificateEncrypted: boolean,
   isCertificateSelected: boolean,
   isCertificateInvalid: boolean,
-};
+|};
 
 @observer
 export default class AdaCertificateUploadWidget extends Component<Props> {

--- a/app/components/widgets/forms/ImageUploadWidget.js
+++ b/app/components/widgets/forms/ImageUploadWidget.js
@@ -15,9 +15,9 @@ export const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   label: string
-};
+|};
 
 @observer
 export default class ImageUploadWidget extends Component<Props> {

--- a/app/components/widgets/forms/InlineEditingInput.js
+++ b/app/components/widgets/forms/InlineEditingInput.js
@@ -25,7 +25,7 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   className?: string,
   isActive: boolean,
   inputFieldLabel: string,
@@ -38,7 +38,7 @@ type Props = {
   validationErrorMessage: string,
   successfullyUpdated: boolean,
   classicTheme: boolean,
-};
+|};
 
 type State = {
   isActive: boolean,

--- a/app/components/widgets/forms/PasswordInstructions.js
+++ b/app/components/widgets/forms/PasswordInstructions.js
@@ -3,9 +3,9 @@ import { observer } from 'mobx-react';
 import styles from './PasswordInstructions.scss';
 import { defineMessages, intlShape, MessageDescriptor } from 'react-intl';
 
-type Props = {
+type Props = {|
   instructionDescriptor?: MessageDescriptor
-};
+|};
 
 const messages = defineMessages({
   passwordInstructions: {

--- a/app/components/widgets/forms/ReadOnlyInput.js
+++ b/app/components/widgets/forms/ReadOnlyInput.js
@@ -11,13 +11,13 @@ import { InputOwnSkin } from '../../../themes/skins/InputOwnSkin';
 import editSvg from '../../../assets/images/edit.inline.svg';
 import styles from './ReadOnlyInput.scss';
 
-type Props = {
+type Props = {|
   label: string,
   value: string,
   isSet: boolean,
   onClick: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class ReadOnlyInput extends Component<Props> {

--- a/app/components/widgets/forms/WarningBox.js
+++ b/app/components/widgets/forms/WarningBox.js
@@ -7,9 +7,9 @@ import dangerIcon from '../../../assets/images/danger.inline.svg';
 
 import styles from './WarningBox.scss';
 
-type Props = {
+type Props = {|
   children: ?Node
-};
+|};
 
 export default class WarningBox extends Component<Props> {
 

--- a/app/containers/transfer/DaedalusTransferPage.js
+++ b/app/containers/transfer/DaedalusTransferPage.js
@@ -41,17 +41,6 @@ export default class DaedalusTransferPage extends Component<InjectedProps> {
     });
   }
 
-  goToReceiveScreen = () => {
-    const wallet = this._getWalletsStore().active;
-    this._getRouter().goToRoute.trigger({
-      route: ROUTES.WALLETS.PAGE,
-      params: {
-        id: wallet && wallet.id,
-        page: 'receive'
-      },
-    });
-  }
-
   startTransferFunds = () => {
     this._getDaedalusTransferActions().startTransferFunds.trigger();
   }
@@ -123,7 +112,6 @@ export default class DaedalusTransferPage extends Component<InjectedProps> {
             <TransferLayout>
               <TransferInstructionsPage
                 onFollowInstructionsPrerequisites={this.goToCreateWallet}
-                onAnswerYes={this.goToReceiveScreen}
                 onConfirm={this.startTransferFunds}
                 onPaperConfirm={this.startTransferPaperFunds}
                 onMasterKeyConfirm={this.startTransferMasterKey}


### PR DESCRIPTION
Each commit deals with one components. Summary of changes:
1. Repalce all `type Props = { ... };` with `type Props = {| ... |};` in /components.
2. In https://github.com/Emurgo/yoroi-frontend/commit/efd1f4882568bc4ff0062479a1ce88251b796961#diff-7b6e6bfb5ba2014d37540bc671cfb754, remove unreferenced property `withFooter` from `defaultProps`.
3. In https://github.com/Emurgo/yoroi-frontend/commit/bf52b38320d28c7ab957e7f2aee48ced25a30b19#diff-52dd93a61fe03c81d2f02da67caa4539, remove the unused parameter `onAnswerYes` and hence the unused method `goToReceiveScreen`.