### PR TITLE
Exactify prop types

### DIFF
--- a/app/ThemeManager.js
+++ b/app/ThemeManager.js
@@ -3,10 +3,10 @@ import React, { Component } from 'react';
 import type { Node } from 'react';
 import _ from 'lodash';
 
-type Props = {
+type Props = {|
   variables: { [key: string]: string },
   children?: Node,
-};
+|};
 
 /** Allow to swap the CSS used at runtime to allow user-defined themes */
 export default class ThemeManager extends Component<Props> {

--- a/app/components/wallet/skins/AmountInputSkin.js
+++ b/app/components/wallet/skins/AmountInputSkin.js
@@ -15,7 +15,9 @@ const messages = defineMessages({
   },
 });
 
-type Props = {|
+// This type should be kept open (not "exact") because it is a react-polymorph skin
+// and should be able to pass any extra properties from react-polymorph down.
+type Props = {
   currency: string,
   fees: BigNumber,
   total: BigNumber,
@@ -27,7 +29,7 @@ type Props = {|
   themeId: string,
   value: string,
   type: string,
-|};
+};
 
 export default class AmountInputSkin extends Component<Props> {
   static defaultProps = {
@@ -39,33 +41,12 @@ export default class AmountInputSkin extends Component<Props> {
   };
 
   render() {
-    const {
-      currency,
-      fees,
-      total,
-      error,
-      classicTheme,
-      inputRef,
-      theme,
-      themeId,
-      value,
-      type,
-    } = this.props;
+    const { error, fees, total, currency, classicTheme } = this.props;
     const { intl } = this.context;
 
     return (
       <div className={styles.component}>
-        {classicTheme ?
-          <InputSkin {...this.props} /> :
-          <InputOwnSkin
-            error={error}
-            inputRef={inputRef}
-            theme={theme}
-            themeId={themeId}
-            value={value}
-            type={type}
-          />
-        }
+        {classicTheme ? <InputSkin {...this.props} /> : <InputOwnSkin {...this.props} />}
         {!error && (
           <span className={styles.fees}>
             {intl.formatMessage(messages.feesLabel, { amount: fees })}

--- a/app/components/wallet/skins/AmountInputSkin.js
+++ b/app/components/wallet/skins/AmountInputSkin.js
@@ -27,7 +27,6 @@ type Props = {|
   themeId: string,
   value: string,
   type: string,
-  classicTheme: boolean
 |};
 
 export default class AmountInputSkin extends Component<Props> {
@@ -40,12 +39,33 @@ export default class AmountInputSkin extends Component<Props> {
   };
 
   render() {
-    const { error, fees, total, currency, classicTheme } = this.props;
+    const {
+      currency,
+      fees,
+      total,
+      error,
+      classicTheme,
+      inputRef,
+      theme,
+      themeId,
+      value,
+      type,
+    } = this.props;
     const { intl } = this.context;
 
     return (
       <div className={styles.component}>
-        {classicTheme ? <InputSkin {...this.props} /> : <InputOwnSkin {...this.props} />}
+        {classicTheme ?
+          <InputSkin {...this.props} /> :
+          <InputOwnSkin
+            error={error}
+            inputRef={inputRef}
+            theme={theme}
+            themeId={themeId}
+            value={value}
+            type={type}
+          />
+        }
         {!error && (
           <span className={styles.fees}>
             {intl.formatMessage(messages.feesLabel, { amount: fees })}

--- a/app/containers/transfer/DaedalusTransferErrorPage.js
+++ b/app/containers/transfer/DaedalusTransferErrorPage.js
@@ -13,11 +13,11 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   error?: ?LocalizableError,
   onCancel: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class DaedalusTransferErrorPage extends Component<Props> {

--- a/app/containers/transfer/DaedalusTransferFormPage.js
+++ b/app/containers/transfer/DaedalusTransferFormPage.js
@@ -15,14 +15,14 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onSubmit: Function,
   onBack: Function,
   mnemonicValidator: Function,
   validWords: Array<string>,
   mnemonicLength: number,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class DaedalusTransferFormPage extends Component<Props> {

--- a/app/containers/transfer/DaedalusTransferMasterKeyFormPage.js
+++ b/app/containers/transfer/DaedalusTransferMasterKeyFormPage.js
@@ -11,11 +11,11 @@ const messages = defineMessages({
   },
 });
 
-type Props = {
+type Props = {|
   onSubmit: Function,
   onBack: Function,
   classicTheme: boolean,
-};
+|};
 
 @observer
 export default class DaedalusTransferMasterKeyFormPage extends Component<Props> {

--- a/app/containers/transfer/DaedalusTransferSummaryPage.js
+++ b/app/containers/transfer/DaedalusTransferSummaryPage.js
@@ -14,7 +14,7 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   formattedWalletAmount: Function,
   selectedExplorer: ExplorerType,
   transferTx: TransferTx,
@@ -23,7 +23,7 @@ type Props = {
   onCancel: Function,
   error: ?LocalizableError,
   classicTheme: boolean
-};
+|};
 
 /** Show user what the transfer would do to get final confirmation */
 @observer

--- a/app/containers/transfer/DaedalusTransferWaitingPage.js
+++ b/app/containers/transfer/DaedalusTransferWaitingPage.js
@@ -27,9 +27,9 @@ const messages = defineMessages({
   }
 });
 
-type Props = {
+type Props = {|
   status: string
-};
+|};
 
 @observer
 export default class DaedalusTransferWaitingPage extends Component<Props> {

--- a/app/containers/wallet/WalletAddPage.js
+++ b/app/containers/wallet/WalletAddPage.js
@@ -83,7 +83,6 @@ export default class WalletAddPage extends Component<Props> {
     } else if (uiDialogs.isOpen(WalletRestoreOptionDialog)) {
       activeDialog = (
         <WalletRestoreOptionDialogContainer
-          stores={stores}
           onClose={this.onClose}
           classicTheme={profile.isClassicTheme}
           onRestore={() => actions.dialogs.open.trigger({ dialog: WalletRestoreDialog })}
@@ -104,8 +103,6 @@ export default class WalletAddPage extends Component<Props> {
     } else if (uiDialogs.isOpen(WalletConnectHWOptionDialog)) {
       activeDialog = (
         <WalletConnectHWOptionDialogContainer
-          actions={actions}
-          stores={stores}
           onClose={this.onClose}
           classicTheme={profile.isClassicTheme}
           onTrezor={openTrezorConnectDialog}

--- a/app/containers/wallet/dialogs/WalletConnectHWOptionDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletConnectHWOptionDialogContainer.js
@@ -3,12 +3,12 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import WalletConnectHWOptionDialog from '../../../components/wallet/add/option-dialog/WalletConnectHWOptionDialog';
 
-type Props = {
+type Props = {|
   onClose: Function,
   classicTheme: boolean,
   onTrezor: Function,
   onLedger: Function,
-};
+|};
 
 @observer
 export default class WalletConnectHWOptionDialogContainer extends Component<Props> {

--- a/app/containers/wallet/dialogs/WalletRestoreOptionDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreOptionDialogContainer.js
@@ -3,12 +3,12 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import WalletRestoreOptionDialog from '../../../components/wallet/add/option-dialog/WalletRestoreOptionDialog';
 
-type Props = {
+type Props = {|
   onClose: Function,
   classicTheme: boolean,
   onRestore: Function,
   onPaperRestore: Function,
-};
+|};
 @observer
 export default class WalletRestoreOptionDialogContainer extends Component<Props> {
 

--- a/app/themes/skins/AutocompleteOwnSkin.js
+++ b/app/themes/skins/AutocompleteOwnSkin.js
@@ -14,7 +14,7 @@ import { Options } from 'react-polymorph/lib/components/Options';
 import { FormFieldOwnSkin } from './FormFieldOwnSkin';
 import { OptionsSkin } from 'react-polymorph/lib/skins/simple/OptionsSkin';
 
-type Props = {
+type Props = {|
   className: string,
   error: string,
   filteredOptions: Array<any>,
@@ -45,7 +45,7 @@ type Props = {
   toggleMouseLocation: Function,
   toggleOpen: Function,
   done: Boolean
-};
+|};
 
 export const AutocompleteOwnSkin = (props: Props) => {
   const theme = props.theme[props.themeId];

--- a/app/themes/skins/AutocompleteOwnSkin.js
+++ b/app/themes/skins/AutocompleteOwnSkin.js
@@ -14,7 +14,9 @@ import { Options } from 'react-polymorph/lib/components/Options';
 import { FormFieldOwnSkin } from './FormFieldOwnSkin';
 import { OptionsSkin } from 'react-polymorph/lib/skins/simple/OptionsSkin';
 
-type Props = {|
+// This type should be kept open (not "exact") because it is a react-polymorph skin
+// and should be able to pass any extra properties from react-polymorph down.
+type Props = {
   className: string,
   error: string,
   filteredOptions: Array<any>,
@@ -45,7 +47,7 @@ type Props = {|
   toggleMouseLocation: Function,
   toggleOpen: Function,
   done: Boolean
-|};
+};
 
 export const AutocompleteOwnSkin = (props: Props) => {
   const theme = props.theme[props.themeId];

--- a/app/themes/skins/CheckboxOwnSkin.js
+++ b/app/themes/skins/CheckboxOwnSkin.js
@@ -8,7 +8,7 @@ import { pickDOMProps } from 'react-polymorph/lib/utils/props';
 import ReactMarkdown from 'react-markdown';
 import styles from './CheckboxOwnSkin.scss';
 
-type Props = {
+type Props = {|
   checked: boolean,
   className: string,
   disabled: boolean,
@@ -17,7 +17,7 @@ type Props = {
   description: string | Element<any>,
   theme: Object,
   themeId: string
-};
+|};
 
 export const CheckboxOwnSkin = (props: Props) => (
   <div

--- a/app/themes/skins/CheckboxOwnSkin.js
+++ b/app/themes/skins/CheckboxOwnSkin.js
@@ -8,7 +8,9 @@ import { pickDOMProps } from 'react-polymorph/lib/utils/props';
 import ReactMarkdown from 'react-markdown';
 import styles from './CheckboxOwnSkin.scss';
 
-type Props = {|
+// This type should be kept open (not "exact") because it is a react-polymorph skin
+// and should be able to pass any extra properties from react-polymorph down.
+type Props = {
   checked: boolean,
   className: string,
   disabled: boolean,
@@ -17,7 +19,7 @@ type Props = {|
   description: string | Element<any>,
   theme: Object,
   themeId: string
-|};
+};
 
 export const CheckboxOwnSkin = (props: Props) => (
   <div

--- a/app/themes/skins/FormFieldOwnSkin.js
+++ b/app/themes/skins/FormFieldOwnSkin.js
@@ -10,7 +10,9 @@ import PasswordHiddenSvg from '../../assets/images/input/password.hiden.inline.s
 import SuccessSvg from '../../assets/images/widget/tick-green.inline.svg';
 import styles from './FormFieldOwnSkin.scss';
 
-type Props = {|
+// This type should be kept open (not "exact") because it is a react-polymorph skin
+// and should be able to pass any extra properties from react-polymorph down.
+type Props = {
   className: string,
   disabled: boolean,
   error: string | Element<any>,
@@ -24,7 +26,7 @@ type Props = {|
   done?: boolean,
   type: string,
   focused: boolean,
-|};
+};
 
 type State = {
   isPasswordShown: boolean,

--- a/app/themes/skins/FormFieldOwnSkin.js
+++ b/app/themes/skins/FormFieldOwnSkin.js
@@ -10,7 +10,7 @@ import PasswordHiddenSvg from '../../assets/images/input/password.hiden.inline.s
 import SuccessSvg from '../../assets/images/widget/tick-green.inline.svg';
 import styles from './FormFieldOwnSkin.scss';
 
-type Props = {
+type Props = {|
   className: string,
   disabled: boolean,
   error: string | Element<any>,
@@ -24,7 +24,7 @@ type Props = {
   done?: boolean,
   type: string,
   focused: boolean,
-};
+|};
 
 type State = {
   isPasswordShown: boolean,

--- a/app/themes/skins/InputOwnSkin.js
+++ b/app/themes/skins/InputOwnSkin.js
@@ -16,7 +16,7 @@ import { pickDOMProps } from 'react-polymorph/lib/utils/props';
 
 import styles from './InputOwnSkin.scss';
 
-type Props = {
+type Props = {|
   className?: ?string,
   disabled?: boolean,
   error?: string,
@@ -33,7 +33,7 @@ type Props = {
   value: string,
   done?: boolean,
   type: string,
-};
+|};
 
 type State = {
   focused: boolean,

--- a/app/themes/skins/InputOwnSkin.js
+++ b/app/themes/skins/InputOwnSkin.js
@@ -16,7 +16,9 @@ import { pickDOMProps } from 'react-polymorph/lib/utils/props';
 
 import styles from './InputOwnSkin.scss';
 
-type Props = {|
+// This type should be kept open (not "exact") because it is a react-polymorph skin
+// and should be able to pass any extra properties from react-polymorph down.
+type Props = {
   className?: ?string,
   disabled?: boolean,
   error?: string,
@@ -33,7 +35,7 @@ type Props = {|
   value: string,
   done?: boolean,
   type: string,
-|};
+};
 
 type State = {
   focused: boolean,


### PR DESCRIPTION
Summary of changes:
1. Replace `type Props = { ... }` with `type Props = {| ... |}`. Now the code base is free of such pattern except in skin components.
2. In https://github.com/Emurgo/yoroi-frontend/commit/482c8fbefb44b3a87f034391d16345eb50f5e069#diff-eb964c5702091af0927b33c347e96961 , remove unused parameter passings.
3. In https://github.com/Emurgo/yoroi-frontend/commit/5d525be70fe5b1a7deda5a5b2b22dfe86e2d944a#diff-41248b6193806412a01d9511ec0a43ee , remove the duplicate `classicTheme` property <del>and remove unused parameters passings</del>.