### PR TITLE
Fix deprecation warning on componentWillMount

### DIFF
--- a/app/components/wallet/hwConnect/ledger/SaveDialog.js
+++ b/app/components/wallet/hwConnect/ledger/SaveDialog.js
@@ -65,7 +65,8 @@ export default class SaveDialog extends Component<Props> {
 
   form: typeof ReactToolboxMobxForm;
 
-  componentWillMount() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillMount() {
     const { intl } = this.context;
     const { defaultWalletName } = this.props;
 

--- a/app/components/wallet/hwConnect/trezor/SaveDialog.js
+++ b/app/components/wallet/hwConnect/trezor/SaveDialog.js
@@ -64,7 +64,8 @@ export default class SaveDialog extends Component<Props> {
 
   form: typeof ReactToolboxMobxForm;
 
-  componentWillMount() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillMount() {
     const { intl } = this.context;
     const { defaultWalletName } = this.props;
 

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -49,7 +49,8 @@ export default class WalletTransactionsList extends Component<Props> {
     intl: intlShape.isRequired,
   };
 
-  componentWillMount() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillMount() {
     this.localizedDateFormat = moment.localeData().longDateFormat('L');
     // Localized dateFormat:
     // English - MM/DD/YYYY


### PR DESCRIPTION
React starts warning users that componentWillMount will be removed in the next version of React. We need to use this method because we need it in a few places to both
A) Run once before the render method is called
B) Have access to the context

I believe we can get rid of these once we migrate to the new Context api by React but we can't do that until the react-intl upgrade ticket is done (which requires the react-intl library to finish upgrading to the latest React)

You can read more about it here: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
