### PR TITLE
Add "I see" to patterns that trigger screenshot during test

### DIFF
--- a/features/step_definitions/common-steps.js
+++ b/features/step_definitions/common-steps.js
@@ -67,7 +67,12 @@ After(async function () {
 const writeFile = promisify(fs.writeFile);
 
 // Steps that contain these patterns will trigger screenshots:
-const SCREENSHOT_STEP_PATTERNS = ['I should see', 'I click', 'by clicking'];
+const SCREENSHOT_STEP_PATTERNS = [
+  'I should see',
+  'I see',
+  'I click',
+  'by clicking',
+];
 
 /** Wrap every step to take screenshots for UI-based testing */
 setDefinitionFunctionWrapper((fn, _, pattern) => {


### PR DESCRIPTION
Originally the pattern "I should see" triggers screenshot. Then I just noticed some steps use the phrase "I see" so I add "I see"  to the pattern list that trigger screenshots.