### PR TITLE
Add missing scrollbar on HW dialogs

### DIFF
--- a/app/components/wallet/hwConnect/common/DialogCommonStyle.scss
+++ b/app/components/wallet/hwConnect/common/DialogCommonStyle.scss
@@ -3,7 +3,6 @@
 $opacityCommon: 0.7;
 
 .component {
-  overflow: hidden;
 }
 
 .processing {


### PR DESCRIPTION
Scrollbar was missing on both Trezor and Ledger dialogs on Modern theme

### Before

![image](https://user-images.githubusercontent.com/2608559/59842057-9ff94d00-9390-11e9-8aac-ff8f9607eed5.png)

### After

![image](https://user-images.githubusercontent.com/2608559/59841956-69233700-9390-11e9-99f5-1fde0358b4e0.png)