### PR TITLE
[WIP]restoreWallet function saves the restoration information to memory instead of saving it to the storage layer

### DIFF
--- a/app/api/ada/index.test.js
+++ b/app/api/ada/index.test.js
@@ -1,0 +1,33 @@
+// @flow
+import './lib/test-config';
+import AdaApi from './index';
+import { RustModule } from './lib/cardanoCrypto/rustLoader';
+import {
+  silenceLogsForTesting,
+} from '../../utils/logging';
+
+import type {
+  FilterUsedRequest,
+  FilterUsedResponse,
+} from './lib/state-fetch/types';
+
+beforeAll(async () => {
+  await RustModule.load();
+  //silenceLogsForTesting();
+});
+
+test('Restore wallet', async () => {
+  async function checkAddressesInUse(_body: FilterUsedRequest): Promise<FilterUsedResponse> {
+    return [];
+  }
+
+  const restoreRequest = {
+    recoveryPhrase: 'prevent company field green slot measure chief hero apple task eagle sunset endorse dress seed',
+    walletName: 'mywallet',
+    walletPassword: '123',
+    checkAddressesInUse
+  };
+
+  const response : any = await AdaApi.prototype.restoreWallet(restoreRequest);
+  expect(response.accounts[0].plate.id).toEqual('DBJL-9530');
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,11 @@ module.exports = {
     // get rid of the fake module we use to trick flow
     "CardanoWallet": "lodash/noop.js",
     // mock out the browser version of WASM bindings with the nodejs bindings
-    "cardano-wallet-browser": "cardano-wallet"
+    "cardano-wallet-browser": "cardano-wallet",
+    "\\.png$": "lodash/noop.js",
+    "pdfParser$": "lodash/noop.js",
   },
   "transformIgnorePatterns": [
-    "<rootDir>/node_modules/"
-  ]
+    "<rootDir>/node_modules/(?!yoroi-extension-ledger-bridge)"
+  ],
 };


### PR DESCRIPTION
Progress:
1. Add unit test against  current `restoreWallet` implementation.