### PR TITLE
[bugfix] Use fit-content on checkbox

### DIFF
--- a/app/components/wallet/send/WalletSendForm.scss
+++ b/app/components/wallet/send/WalletSendForm.scss
@@ -39,6 +39,7 @@
 
   .checkbox {
     font-family: var(--font-mono-light);
+    width: fit-content;
   }
 }
 

--- a/app/themes/overrides/CheckboxOverrides.scss
+++ b/app/themes/overrides/CheckboxOverrides.scss
@@ -2,6 +2,10 @@
 
 .root {
   align-items: center;
+
+  // Remove once this PR is merged
+  // https://github.com/input-output-hk/react-polymorph/pull/118
+  width: fit-content;
   
   .checked {
     background-color: var(--rp-checkbox-check-bg-color);

--- a/app/themes/overrides/CheckboxOverridesClassic.scss
+++ b/app/themes/overrides/CheckboxOverridesClassic.scss
@@ -1,5 +1,11 @@
 // Css module overrides go here …
 
+.root {
+  // Remove once this PR is merged
+  // https://github.com/input-output-hk/react-polymorph/pull/118
+  width: fit-content;
+}
+
 .check {
   // manually setting the z-index is a temporary fix until this PR is merged & we upgrade the lib
   // https://github.com/input-output-hk/react-polymorph/pull/99


### PR DESCRIPTION
We're stuck on a fork of React-Polymorph for a little while so I'm copying the contents of the below PR here as a hotfix.

We can merge it now but it may be better to wait for the React-Polymorph team to sign off on the fix

https://github.com/input-output-hk/react-polymorph/pull/118