### PR TITLE
shin/ch1631/increase-line-space-in-trezor-ledger-prerequisites

### DIFF
--- a/app/components/wallet/hwConnect/common/CheckDialog.scss
+++ b/app/components/wallet/hwConnect/common/CheckDialog.scss
@@ -8,12 +8,13 @@
       font-size: 18px;
       line-height: 22px;
     }
+
     li {
       list-style-type: disc;
       margin-left: 18px;
       font-family: var(--font-regular);
       line-height: 22px;
-      font-size: 14px;
+      font-size: 16px;
       letter-spacing: 0;
 
       &:first-child {
@@ -25,6 +26,7 @@
       }
     }
   }
+
   .hwImageBlock {
     vertical-align: baseline;
     display: inline-block;
@@ -33,7 +35,6 @@
 
 :global(.YoroiClassic) {
   .component {
-
     .prerequisiteBlock {
       width: 520px;
       height: 280px;
@@ -46,9 +47,7 @@
     }
 
     li {
-      margin-left: 18px;
       margin-top: 12px;
-      font-size: 16px;
       opacity: $opacityCommon;
     }
   }
@@ -56,7 +55,6 @@
 
 :global(.YoroiModern) {
   .component {
-
     .prerequisiteBlock {
       margin-top: 16px;
     }
@@ -67,13 +65,7 @@
     }
 
     li {
-      margin-left: 18px;
       font-size: 14px;
-      letter-spacing: 0;
-
-      &:first-child {
-        margin-top: 8px;
-      }
     }
   }
 }

--- a/app/components/wallet/hwConnect/common/CheckDialog.scss
+++ b/app/components/wallet/hwConnect/common/CheckDialog.scss
@@ -16,6 +16,7 @@
       line-height: 22px;
       font-size: 16px;
       letter-spacing: 0;
+      margin-top: 6px;
 
       &:first-child {
         margin-top: 8px;


### PR DESCRIPTION
Refer:
https://projects.invisionapp.com/d/main#/console/17855701/370317289/preview
https://app.clubhouse.io/emurgo/story/1631/increase-line-space-in-trezor-ledger-prerequisites

- [X] https://github.com/Emurgo/yoroi-frontend/pull/716/commits/08f854c83cb26e706a5d3cd60351531972e82cb6 Remove redundant style in themes (**NFC/Only cleanup**)
- [X] Increase line gap on Check dialog of both HW dialog.

![image](https://user-images.githubusercontent.com/19986226/60405640-750ec480-9bec-11e9-9d9f-ef30261a57e6.png)

![image](https://user-images.githubusercontent.com/19986226/60405645-7cce6900-9bec-11e9-8364-702d69f4aa62.png)

