### PR TITLE
shin/ch1628/fix-text-style-in-settings-paper-wallets

### DIFF
--- a/app/components/settings/categories/PaperWalletSettings.scss
+++ b/app/components/settings/categories/PaperWalletSettings.scss
@@ -17,7 +17,7 @@
   }
   
   :global(.CheckboxOwnSkin_checkboxWrapper) {
-    margin-top: 2px;
+    margin-top: 0px;
   }
 
   :global(.SimpleCheckbox_root) {

--- a/app/components/settings/categories/PaperWalletSettings.scss
+++ b/app/components/settings/categories/PaperWalletSettings.scss
@@ -11,6 +11,28 @@
     margin-bottom: 10px;
     padding-top: 10px;
   }
+
+  :global(.SimpleCheckbox_check) {
+    align-self: start;
+  }
+  
+  :global(.CheckboxOwnSkin_checkboxWrapper) {
+    margin-top: 2px;
+  }
+
+  :global(.SimpleCheckbox_root) {
+    margin-top: 14px;
+
+    label {
+      font-family: var(--font-regular);
+    }
+
+    p {
+      cursor: pointer;
+      font-family: var(--font-regular);
+      color: var(--theme-default-color-grey);
+    }
+  }
 }
 
 .numAddressesSelect {
@@ -25,19 +47,16 @@
 }
 
 .button {
-  margin-top: 20px;
+  margin-top: 23px;
 }
 
 .numAddressesSelect {
-  margin-top: 20px;
-}
-
-.paperTypeSelect {
-  margin-top: 20px;
+  margin-top: 34px;
 }
 
 .intro {
-  color: var(--theme-terms-of-use-text-color);
+  color: var(--theme-default-color-grey);
+  font-family: var(--font-regular);
   text-align: justify;
 
   h1, h2 {

--- a/app/components/settings/categories/PaperWalletSettings.scss
+++ b/app/components/settings/categories/PaperWalletSettings.scss
@@ -11,28 +11,6 @@
     margin-bottom: 10px;
     padding-top: 10px;
   }
-
-  :global(.SimpleCheckbox_check) {
-    align-self: start;
-  }
-  
-  :global(.CheckboxOwnSkin_checkboxWrapper) {
-    margin-top: 0px;
-  }
-
-  :global(.SimpleCheckbox_root) {
-    margin-top: 14px;
-
-    label {
-      font-family: var(--font-regular);
-    }
-
-    p {
-      cursor: pointer;
-      font-family: var(--font-regular);
-      color: var(--theme-default-color-grey);
-    }
-  }
 }
 
 .numAddressesSelect {

--- a/app/components/settings/categories/PaperWalletSettings.scss
+++ b/app/components/settings/categories/PaperWalletSettings.scss
@@ -4,7 +4,7 @@
   margin-bottom: 20px;
 
   h1 {
-    color: var(--theme-support-settings-text-color);
+    color: var(--cmn-default-color-grey);
     font-family: var(--font-semibold);
     font-size: 16px;
     line-height: 1.38;
@@ -30,7 +30,7 @@
 }
 
 .intro {
-  color: var(--theme-default-color-grey);
+  color: var(--cmn-default-color-grey);
   font-family: var(--font-regular);
   text-align: justify;
 
@@ -50,6 +50,7 @@
   }
 
   p, li {
+    color: var(--cmn-default-color-grey);
     font-family: var(--font-regular);
     font-size: 14px;
     letter-spacing: 0.5px;

--- a/app/components/settings/categories/PaperWalletSettings.scss
+++ b/app/components/settings/categories/PaperWalletSettings.scss
@@ -14,6 +14,7 @@
 }
 
 .numAddressesSelect {
+  margin: 34px 0 14px 0;
   label {
     background-color: var(--theme-settings-pane-background-color);
   }
@@ -25,10 +26,6 @@
 }
 
 .button {
-  margin-top: 23px;
-}
-
-.numAddressesSelect {
   margin-top: 34px;
 }
 

--- a/app/i18n/locales/paper-wallets/intro/en-US.md
+++ b/app/i18n/locales/paper-wallets/intro/en-US.md
@@ -10,5 +10,5 @@ However, you should stop using a paper wallet after you restore its funds as it 
 
 Yoroi Paper Wallets are protected with a **custom user password** and contain 21 secret words.
 Even if someone gets access to this paper-wallet, they will also need to know your password to gain access to the funds.
-**But if you lose or forget your password, your funds will be lost forever and no one will be able to restore them!**.
+**But if you lose or forget your password, your funds will be lost forever and no one will be able to restore them**.
 Typing the wrong wallet password will give you a different wallet. This allows for plausible deniability.

--- a/app/themes/prebuilt/YoroiClassic.js
+++ b/app/themes/prebuilt/YoroiClassic.js
@@ -53,7 +53,7 @@ const rpCheckbox = {
   '--rp-checkbox-border': '1px solid #daa49a',
   '--rp-checkbox-border-color-disabled': 'rgba(218, 164, 154, 0.2)', // #DAA49A
   '--rp-checkbox-check-bg-color': '#daa49a',
-  '--rp-checkbox-label-text-color': '#121327',
+  '--rp-checkbox-label-text-color': common['--cmn-default-color-grey'],
   '--rp-checkbox-label-text-color-disabled': 'rgba(18, 19, 39, 0.3)', // #121327
 };
 

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -53,7 +53,7 @@ const rpCheckbox = {
   '--rp-checkbox-border': '2px solid #353535',
   '--rp-checkbox-border-color-disabled': 'rgba(21, 209, 170, 0.2)', // #15d1aa
   '--rp-checkbox-check-bg-color': '#15d1aa',
-  '--rp-checkbox-label-text-color': '#353535',
+  '--rp-checkbox-label-text-color': common['--cmn-default-color-grey'],
   '--rp-checkbox-label-text-color-disabled': 'rgba(53, 53, 53, 0.3)', // #353535
 };
 

--- a/app/themes/skins/CheckboxOwnSkin.js
+++ b/app/themes/skins/CheckboxOwnSkin.js
@@ -18,48 +18,73 @@ type Props = {
   label: string | Element<any>,
   description: string | Element<any>,
   theme: Object,
-  themeId: string
+  themeId: string,
+  showCheckInCenter: boolean,
 };
 
-export const CheckboxOwnSkin = (props: Props) => (
-  <div
-    role="presentation"
-    aria-hidden
-    className={classnames([
-      props.className,
-      props.theme[props.themeId].root,
-      props.disabled ? props.theme[props.themeId].disabled : null,
-      props.checked ? props.theme[props.themeId].checked : null
-    ])}
-    onClick={event => {
-      if (!props.disabled && props.onChange) {
-        props.onChange(!props.checked, event);
-      }
-    }}
-  >
-    <input
-      {...pickDOMProps(props)}
-      className={props.theme[props.themeId].input}
-      type="checkbox"
-    />
+/**
+ * This skin provides flexibility of Checkbox icon vertical display position
+ * and props.description provides option to display addition info text about the Checkbox.
+ * If props.description is provided, by default Checkbox icon is displayed
+ * at the top(at same lavel of the label text) and If props.showCheckInCenter is true,
+ * Checkbox icon is displayed at the ceter.
+ * @param {*} props
+ */
+export const CheckboxOwnSkin = (props: Props) => {
+  let checkBlockStyleOverride;
+  if (props.description) {
+    checkBlockStyleOverride = props.showCheckInCenter ?
+      styles.checkBlockCenter :
+      styles.checkBlockTop;
+  }
+
+  return (
     <div
+      role="presentation"
+      aria-hidden
       className={classnames([
-        props.theme[props.themeId].check,
+        props.className,
+        props.theme[props.themeId].root,
+        props.disabled ? props.theme[props.themeId].disabled : null,
         props.checked ? props.theme[props.themeId].checked : null
       ])}
-    />
-    <div
-      className={styles.checkboxWrapper}
+      onClick={event => {
+        if (!props.disabled && props.onChange) {
+          props.onChange(!props.checked, event);
+        }
+      }}
     >
-      {props.label && (
-        // eslint-disable-next-line
-        <label className={props.theme[props.themeId].label}>
-          {props.label}
-        </label>
-      )}
-      {props.description && (
-        <ReactMarkdown source={props.description} escapeHtml={false} />
-      )}
-    </div>
-  </div>
-);
+      <input
+        {...pickDOMProps(props)}
+        className={props.theme[props.themeId].input}
+        type="checkbox"
+      />
+      <div
+        className={classnames([
+          props.theme[props.themeId].check,
+          props.checked ? props.theme[props.themeId].checked : null,
+          checkBlockStyleOverride
+        ])}
+      />
+      <div
+        className={styles.checkboxWrapper}
+      >
+        {props.label && (
+          // eslint-disable-next-line
+          <p className={classnames([
+            props.theme[props.themeId].label,
+            styles.labelText])}
+          >
+            {props.label}
+          </p>
+        )}
+        {props.description && (
+          <ReactMarkdown
+            className={styles.descriptionText}
+            source={props.description}
+            escapeHtml={false}
+          />
+        )}
+      </div>
+    </div>);
+};

--- a/app/themes/skins/CheckboxOwnSkin.scss
+++ b/app/themes/skins/CheckboxOwnSkin.scss
@@ -9,7 +9,7 @@
   p {
     font-family: var(--font-regular);
     color: var(--cmn-default-color-grey);
-    font-size: 13px;
+    font-size: 12px;
     letter-spacing: 0.5px;
     line-height: 1.38;
     margin-top: 5px;

--- a/app/themes/skins/CheckboxOwnSkin.scss
+++ b/app/themes/skins/CheckboxOwnSkin.scss
@@ -3,11 +3,12 @@
 
   label {
     margin: 0;
+    font-family: var(--font-regular);
   }
 
   p {
     font-family: var(--font-regular);
-    color: var(--theme-terms-of-use-text-color);
+    color: var(--cmn-default-color-grey);
     font-size: 13px;
     letter-spacing: 0.5px;
     line-height: 1.38;

--- a/app/themes/skins/CheckboxOwnSkin.scss
+++ b/app/themes/skins/CheckboxOwnSkin.scss
@@ -1,18 +1,28 @@
+
+.checkBlockTop {
+  align-self: start !important;
+}
+
+.checkBlockCenter {
+  align-self: center !important;
+}
+
 .checkboxWrapper {
   margin: var(--rp-checkbox-label-margin, 0 0 0 20px);
 
-  label {
+  .labelText {
     margin: 0;
+    line-height: 20px;
     font-family: var(--font-regular);
   }
 
-  p {
+  .descriptionText {
     font-family: var(--font-regular);
     color: var(--cmn-default-color-grey);
     font-size: 12px;
     letter-spacing: 0.5px;
     line-height: 1.38;
-    margin-top: 5px;
+    margin-top: 8px;
 
     strong, em {
       font-weight: 500;

--- a/app/themes/skins/CheckboxOwnSkin.scss
+++ b/app/themes/skins/CheckboxOwnSkin.scss
@@ -1,5 +1,5 @@
 .checkboxWrapper {
-  margin: var(--rp-checkbox-label-margin, 10px 0 0 20px);
+  margin: var(--rp-checkbox-label-margin, 0 0 0 20px);
 
   label {
     margin: 0;
@@ -12,7 +12,6 @@
     letter-spacing: 0.5px;
     line-height: 1.38;
     margin-top: 5px;
-    margin-bottom: 11px;
 
     strong, em {
       font-weight: 500;


### PR DESCRIPTION
Refer:
https://projects.invisionapp.com/d/main#/console/17855701/370317329/inspect
https://app.clubhouse.io/emurgo/story/1628/fix-text-style-in-settings-paper-wallets

- [X] Made text color darker 
- [X] Change checkbox label position from top to center.
- [X] Fix double punctuation `!.` -> `.`

**Before:**
![image](https://user-images.githubusercontent.com/19986226/60343988-825f5f80-99f0-11e9-9f65-78e3c7c28ec4.png)

**After:**
![image](https://user-images.githubusercontent.com/19986226/60528270-0b4b0380-9d2f-11e9-9077-608d479bb1cc.png)
