### PR TITLE
Matching the style of address and derivation path with InVision slide

### DIFF
--- a/app/components/wallet/receive/VerifyAddressDialog.js
+++ b/app/components/wallet/receive/VerifyAddressDialog.js
@@ -131,7 +131,7 @@ export default class VerifyAddressDialog extends Component<Props> {
                   hash={walletAddress}
                   linkType="address"
                 >
-                  <RawHash light={false}>
+                  <RawHash light>
                     {walletAddress}
                   </RawHash>
                 </ExplorableHashContainer>

--- a/app/components/wallet/receive/VerifyAddressDialog.scss
+++ b/app/components/wallet/receive/VerifyAddressDialog.scss
@@ -29,6 +29,7 @@
   text-align: center;
 
   .data {
+    color: var(--theme-default-color-grey-3);
     line-height: 30px;
     height: 30px;
     padding-left: 5px;


### PR DESCRIPTION
Refer
https://projects.invisionapp.com/d/main#/console/17855701/370317305/preview

Modern theme
Before:
<img width="678" alt="60359533-49e76380-99a7-11e9-814d-3f45bb371ca1" src="https://user-images.githubusercontent.com/28831006/60516932-c2eb0180-9cac-11e9-80a8-5b53c3c487fd.png">


After:
<img width="682" alt="60359367-e1988200-99a6-11e9-9486-9fae125b3e08" src="https://user-images.githubusercontent.com/28831006/60516939-c5e5f200-9cac-11e9-8785-da37f94bd44e.png">

Classic theme
Before:
<img width="824" alt="Screen Shot 2019-07-02 at 09 42 35" src="https://user-images.githubusercontent.com/28831006/60517699-1e69bf00-9cae-11e9-915a-32b1a7cfa9b4.png">

After:
<img width="832" alt="Screen Shot 2019-07-02 at 09 43 40" src="https://user-images.githubusercontent.com/28831006/60517712-23c70980-9cae-11e9-86a6-d641e27afd6e.png">
