### PR TITLE
Make NODE_ENV always either `production` or `development`

### DIFF
--- a/app/environment.js
+++ b/app/environment.js
@@ -5,6 +5,7 @@ import { NetworkType } from '../config/config-types';
 import type { UserAgentInfo } from './utils/userAgentInfo';
 import userAgentInfo from './utils/userAgentInfo';
 
+// populated by ConfigWebpackPlugin
 declare var CONFIG: ConfigType;
 
 declare type Currency = 'ada';
@@ -14,14 +15,14 @@ export const environment = (Object.assign({
   NETWORK: CONFIG.network.name,
   version: require('../chrome/manifest.' + CONFIG.network.name + '.json').version,
   /** Environment used during webpack build */
-  current: process.env.NODE_ENV,
+  env_type: process.env.NODE_ENV,
 
   API: ('ada': Currency), // Note: can't change at runtime
   MOBX_DEV_TOOLS: process.env.MOBX_DEV_TOOLS,
   commit: process.env.COMMIT || '',
   branch: process.env.BRANCH || '',
-  isDev: () => environment.current === NetworkType.DEVELOPMENT,
-  isTest: () => environment.current === NetworkType.TEST,
+  isDev: () => CONFIG.network.name === NetworkType.DEVELOPMENT,
+  isTest: () => CONFIG.network.name === NetworkType.TEST,
   isMainnet: () => environment.NETWORK === NetworkType.MAINNET,
   isAdaApi: () => environment.API === 'ada',
   walletRefreshInterval: CONFIG.app.walletRefreshInterval,
@@ -29,7 +30,7 @@ export const environment = (Object.assign({
 }, process.env): {
   NETWORK: Network,
   version: string,
-  current: ?string,
+  env_type: ?string,
   API: Currency,
   MOBX_DEV_TOOLS: ?string,
   commit: string,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,7 @@
 const tasks = require('./tasks');
 const argv = require('minimist')(process.argv.slice(2));
 
-process.env.NODE_ENV = 'production';
+// ovrerride NODE_ENV for ConfigWebpackPlugin
 process.env.NODE_CONFIG_ENV = argv.env;
 
 tasks.replaceWebpack();

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,8 @@
 const tasks = require('./tasks');
 const argv = require('minimist')(process.argv.slice(2));
 
-process.env.NODE_ENV = argv.env;
+process.env.NODE_ENV = 'production';
+process.env.NODE_CONFIG_ENV = argv.env;
 
 tasks.replaceWebpack();
 console.log('[Copy assets]');

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -6,6 +6,8 @@ const argv = require('minimist')(process.argv.slice(2));
 
 const config = require(`../webpack/devConfig`);
 
+process.env.NODE_CONFIG_ENV = argv.env;
+
 tasks.replaceWebpack();
 console.log('[Copy assets]');
 console.log('-'.repeat(80));

--- a/webpack/commonConfig.js
+++ b/webpack/commonConfig.js
@@ -39,6 +39,7 @@ const plugins = (folder) => ([
    * But we need this written to disk so the extension can be loaded by Chrome
    */
   new HtmlWebpackHarddiskPlugin(),
+  // populates the CONFIG global based on ENV
   new ConfigWebpackPlugin(),
 ]);
 
@@ -149,9 +150,9 @@ const resolve = {
   extensions: ['*', '.js', '.wasm']
 };
 
-const definePlugin = (networkName) => ({
+const definePlugin = (networkName, isProd) => ({
   'process.env': {
-    NODE_ENV: JSON.stringify(networkName),
+    NODE_ENV: JSON.stringify(isProd ? 'production' : 'development'),
     COMMIT: JSON.stringify(shell.exec('git rev-parse HEAD', { silent: true }).trim()),
     BRANCH: JSON.stringify(shell.exec('git rev-parse --abbrev-ref HEAD', { silent: true }).trim())
   }

--- a/webpack/devConfig.js
+++ b/webpack/devConfig.js
@@ -46,7 +46,7 @@ const baseDevConfig = (networkName) => ({
   },
   plugins: [
     ...commonConfig.plugins('dev'),
-    new webpack.DefinePlugin(commonConfig.definePlugin(networkName)),
+    new webpack.DefinePlugin(commonConfig.definePlugin(networkName, false)),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.IgnorePlugin(/[^/]+\/[\S]+.prod$/),

--- a/webpack/prodConfig.js
+++ b/webpack/prodConfig.js
@@ -28,7 +28,7 @@ const baseProdConfig = (networkName) => ({
   },
   plugins: [
     ...commonConfig.plugins('build'),
-    new webpack.DefinePlugin(commonConfig.definePlugin(networkName)),
+    new webpack.DefinePlugin(commonConfig.definePlugin(networkName, true)),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.IgnorePlugin(/[^/]+\/[\S]+.dev$/),
   ],


### PR DESCRIPTION
Some libraries depend on `NODE_ENV` being either `production` or `development` such as `react-hot-reload` and `mobx`. We can swap around our code a bit to accommodate for this.