### PR TITLE
Fix hot-reload for dialogs

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -1,4 +1,5 @@
 // @flow
+import { hot } from 'react-hot-loader/root';
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { ThemeProvider } from 'react-polymorph/lib/components/ThemeProvider';
@@ -23,7 +24,6 @@ import type { ActionsMap } from './actions';
 import { THEMES } from './themes';
 import ThemeManager from './ThemeManager';
 import environment from './environment';
-import { hot } from 'react-hot-loader';
 
 // https://github.com/yahoo/react-intl/wiki#loading-locale-data
 addLocaleData([...en, ...ko, ...ja, ...zh, ...ru, ...de, ...fr, ...id, ...es, ...it]);
@@ -86,4 +86,4 @@ class App extends Component<{
   }
 }
 
-export default hot(module)(App);
+export default hot(App);

--- a/app/stores/toplevel/UiDialogsStore.js
+++ b/app/stores/toplevel/UiDialogsStore.js
@@ -23,7 +23,10 @@ export default class UiDialogsStore extends Store {
     this.actions.dialogs.updateDataForActiveDialog.listen(this._onUpdateDataForActiveDialog);
   }
 
-  isOpen = (dialog: Function): boolean => this.activeDialog === dialog;
+  isOpen = (dialog: Function): boolean => (this.activeDialog
+    ? this.activeDialog.name === dialog.name
+    : false);
+
   getParam = (key: string): string => this.paramsForActiveDialog[key];
 
   countdownSinceDialogOpened = (countDownTo: number) => (


### PR DESCRIPTION
This should fix hot reloading for basically all dialogs. You may run into edge cases where Mobx throws strange errors which will be fixed once we upgrade to mobx5

Root cause: the `isOpen` function would check function pointers. When hot reload triggers, it changes the React component which creates a new function component and so the reference equality would no longer holder. Instead, I compare on dialog names.