### PR TITLE
Black label for input fields in classic theme

### DIFF
--- a/app/themes/skins/FormFieldOwnSkin.scss
+++ b/app/themes/skins/FormFieldOwnSkin.scss
@@ -47,11 +47,6 @@
   }
 }
 
-.error {
-  border-color: var(--rp-theme-color-error);
-  color: var(--rp-theme-color-error)!important;
-}
-
 :global(.YoroiModern) {
   .legend {
     margin-left: 9px;
@@ -68,12 +63,17 @@
    * The following fix delays webkit-autofill transition to avoid Chrome setting its
    * own style and thus floating fields are not overlapped.
    */
-   input:-webkit-autofill,
-   input:-webkit-autofill:hover,
-   input:-webkit-autofill:focus,
-   input:-webkit-autofill:active {
-     -webkit-transition-delay: 99999s;
-   }
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    -webkit-transition-delay: 99999s;
+  }
+
+  .error {
+    border-color: var(--rp-theme-color-error);
+    color: var(--rp-theme-color-error)!important;
+  }
 }
 
 :global(.YoroiClassic) {


### PR DESCRIPTION
Keep black labels for input fields in error state for Classic Theme. Currently, labels are red and it's an overwhelming amount of error state.

**Before**
![red_labels_errors](https://user-images.githubusercontent.com/1937074/60531982-3b13f000-9cca-11e9-912e-49ab6c3d2dab.png)

**After**
![black_labels_error](https://user-images.githubusercontent.com/1937074/60532000-4404c180-9cca-11e9-8b49-b90ca7bfbdba.png)
