### PR TITLE
fix mockServer returning 500 for status endpoint

### DIFF
--- a/features/mock-chain/mockServer.js
+++ b/features/mock-chain/mockServer.js
@@ -144,6 +144,7 @@ export function getMockServer(
     });
 
     server.get('/api/status', (
+      req,
       res: { send(arg: ServerStatusResponse): any }
     ): void => {
       const isServerOk = mockImporter.getApiStatus();


### PR DESCRIPTION
The status endpoint in mockServer is returning 500. This doesn't seem to affect the result of the tests though.

For example, logs in [this link](https://circleci.com/gh/Emurgo/yoroi-frontend/11144?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) show that tests passed, but clicking on **bash .circleci/e2e_tests.sh** to see more details:

```
GET /api/status 500 1.096 ms - -
TypeError: res.send is not a function
    at send (/home/circleci/repo/features/mock-chain/mockServer.js:150:11)
    at Layer.handle [as handle_request] (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/layer.js:95:5)
    at /home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/index.js:335:12)
    at next (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/index.js:275:10)
    at urlencodedParser (/home/circleci/repo/node_modules/body-parser/lib/types/urlencoded.js:91:7)
    at Layer.handle [as handle_request] (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/index.js:317:13)
    at /home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/index.js:335:12)
    at next (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/index.js:275:10)
    at jsonParser (/home/circleci/repo/node_modules/body-parser/lib/types/json.js:110:7)
    at Layer.handle [as handle_request] (/home/circleci/repo/node_modules/json-server/node_modules/express/lib/router/layer.js:95:5)
```