### PR TITLE
Prep work for URI Prompt page

### DIFF
--- a/app/actions/profile-actions.js
+++ b/app/actions/profile-actions.js
@@ -6,10 +6,11 @@ import type { ExplorerType } from '../domain/Explorer';
 
 export default class ProfileActions {
   acceptTermsOfUse: Action<void> = new Action();
+  updateTentativeLocale: Action<{ locale: string }> = new Action();
   updateLocale: Action<{ locale: string }> = new Action();
   updateSelectedExplorer: Action<{ explorer: ExplorerType }> = new Action();
   updateTheme: Action<{ theme: string }> = new Action();
   exportTheme: Action<void> = new Action();
-  redirectToTermsOfUse: Action<{ locale: string }> = new Action();
+  commitLocaleToStorage: Action<{ locale: string }> = new Action();
   updateHideBalance: Action<void> = new Action();
 }

--- a/app/containers/profile/LanguageSelectionPage.js
+++ b/app/containers/profile/LanguageSelectionPage.js
@@ -27,11 +27,11 @@ export default class LanguageSelectionPage extends Component<InjectedProps> {
   };
 
   onSelectLanguage = (values: { locale: string }) => {
-    this.props.actions.profile.updateLocale.trigger(values);
+    this.props.actions.profile.updateTentativeLocale.trigger(values);
   };
 
   onSubmit = (values: { locale: string }) => {
-    this.props.actions.profile.redirectToTermsOfUse.trigger(values);
+    this.props.actions.profile.commitLocaleToStorage.trigger(values);
   };
 
 

--- a/app/containers/profile/LanguageSelectionPage.js
+++ b/app/containers/profile/LanguageSelectionPage.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
+import { runInAction } from 'mobx';
 import { defineMessages, intlShape } from 'react-intl';
 import environment from '../../environment';
 import StaticTopbarTitle from '../../components/topbar/StaticTopbarTitle';
@@ -25,6 +26,23 @@ export default class LanguageSelectionPage extends Component<InjectedProps> {
   static contextTypes = {
     intl: intlShape.isRequired,
   };
+
+  async componentDidMount() {
+    const profileStore = this.props.stores.profile;
+
+    // if user uses back button to get back to this page
+    // we need to undo saving the language to storage so they can pick a new language
+    if (profileStore.isCurrentLocaleSet) {
+      const prevLang = profileStore.currentLocale;
+      runInAction(() => {
+        // tentatively set language to their previous selection
+        profileStore.inMemoryLanguage = prevLang;
+      });
+    }
+
+    await this.props.stores.profile.unsetProfileLocaleRequest.execute();
+    await this.props.stores.profile.getProfileLocaleRequest.execute();
+  }
 
   onSelectLanguage = (values: { locale: string }) => {
     this.props.actions.profile.updateTentativeLocale.trigger(values);

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -103,7 +103,7 @@ export default class TrezorConnectStore
 
       const trezorManifest = {};
       trezorManifest.email = manifest.EMAIL;
-      if (environment.userAgentInfo.isFirefoxExtension) {
+      if (environment.userAgentInfo.isFirefox) {
         // Set appUrl for `moz-extension:` protocol using browser (like Firefox)
         trezorManifest.appUrl = manifest.appURL.FIREFOX;
       } else {

--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -2,7 +2,6 @@
 import { action, observable, computed, when, runInAction } from 'mobx';
 import { defineMessages } from 'react-intl';
 import Store from '../base/Store';
-import Wallet from '../../domain/Wallet';
 import environment from '../../environment';
 import { ROUTES } from '../../routes-config';
 import { matchRoute } from '../../utils/routing';
@@ -66,7 +65,6 @@ export default class LoadingStore extends Store {
           currVersion: environment.version
         }).promise;
         await this.validateUriPath();
-        await this._openPageAfterLoad();
         runInAction(() => {
           this.error = null;
           this._loading = false;
@@ -128,32 +126,6 @@ export default class LoadingStore extends Store {
       // note: we don't validate the path since we need to wait for the WASM bindings to load first
     });
     this.actions.router.goToRoute.trigger({ route: ROUTES.ROOT });
-  }
-
-  /** Select which page to open after app is done loading */
-  _openPageAfterLoad = async (): Promise<void> => {
-    const { app } = this.stores;
-    const { wallets } = this.stores.substores[environment.API];
-    await wallets.refreshWalletsData();
-    if (app.currentRoute === ROUTES.ROOT) {
-      if (wallets.first) {
-        const firstWallet: Wallet = wallets.first;
-
-        // Dynamic Initialization of Topbar Categories
-        this.stores.topbar.updateCategories();
-
-        if (this.fromUriScheme) {
-          this.actions.router.goToRoute.trigger({ route: ROUTES.SEND_FROM_URI.ROOT });
-        } else {
-          this.actions.router.goToRoute.trigger({
-            route: ROUTES.WALLETS.TRANSACTIONS,
-            params: { id: firstWallet.id }
-          });
-        }
-      } else {
-        this.actions.router.goToRoute.trigger({ route: ROUTES.WALLETS.ADD });
-      }
-    }
   }
 }
 

--- a/app/uri-protocols.js
+++ b/app/uri-protocols.js
@@ -2,6 +2,7 @@
 
 import { ROUTES } from './routes-config';
 import { Logger, stringifyError } from './utils/logging';
+import environment from './environment';
 
 
 const cardanoURI = {
@@ -11,13 +12,11 @@ const cardanoURI = {
 };
 
 const registerProtocols = () => {
-
-  // $FlowFixMe InstallTrigger is a global from the browser
-  const isFirefox = typeof InstallTrigger !== 'undefined';
-  const isChrome = !!window.chrome &&
-    (!!window.chrome.webstore || !!window.chrome.runtime) &&
-    !isFirefox;
-  if (isChrome) {
+  if (!environment.userAgentInfo.isExtension) {
+    Logger.error(`uri-protocols:registerProtocols URI Scheme not supported if not an extension`);
+  }
+  // protocol is automatically registered by manifest in Firefox
+  if (environment.userAgentInfo.isChrome) {
     try {
       navigator.registerProtocolHandler(
         cardanoURI.PROTOCOL,

--- a/app/utils/userAgentInfo.js
+++ b/app/utils/userAgentInfo.js
@@ -3,18 +3,34 @@
 import UAParser from 'ua-parser-js';
 
 export class UserAgentInfo {
-  // Refer: Refer: https://www.npmjs.com/package/ua-parser-js
+  // Refer: https://www.npmjs.com/package/ua-parser-js
   ua: UAParser.getResult;
-  isChromeExtension: boolean;
-  isFirefoxExtension: boolean;
+
+  isChrome: boolean;
+  isFirefox: boolean;
+  isExtension: boolean;
 
   constructor() {
     this.ua = (new UAParser()).getResult();
 
     /** This method returns true for all browser that uses `chrome-extension:` protocol,
       * hence it will return true for browsers like Google Chrome, Brave */
-    this.isChromeExtension = (location.protocol === 'chrome-extension:');
-    this.isFirefoxExtension = (location.protocol === 'moz-extension:');
+    this.isChrome = (location.protocol === 'chrome-extension:');
+    this.isFirefox = (location.protocol === 'moz-extension:');
+    if (this.isChrome || this.isFirefox) {
+      this.isExtension = true;
+      return;
+    }
+
+    this.isExtension = false;
+    // if running Yoroi in browser mode
+    // we need to rely on detecting what features of the API are enabled
+
+    // $FlowFixMe InstallTrigger is a global from the browser
+    this.isFirefox = (typeof InstallTrigger !== 'undefined');
+    this.isChrome = !!window.chrome &&
+      (!!window.chrome.webstore || !!window.chrome.runtime) &&
+      !this.isFirefox;
   }
 }
 

--- a/features/migration.feature
+++ b/features/migration.feature
@@ -7,10 +7,13 @@ Feature: Migration
   Scenario: Version set on first launch
     And I am on the language selection screen
     Then Last launch version is updated
-    Then I decreast last launch version
+    Then I decrease last launch version
+    # refreshing language select page causes the language to be unset
+    # to avoid this, move to next page
+    Then I submit the language selection form
     Given I refresh the page
     # this will trigger migration to start
-    And I am on the language selection screen
+    And I am on the "Terms of use" screen
     Given I refresh the page
     # refesh UI to take into account migration changes
     Given I am on the "Terms of use" screen

--- a/features/step_definitions/migration-steps.js
+++ b/features/step_definitions/migration-steps.js
@@ -11,7 +11,7 @@ Then(/^Last launch version is updated$/, async function () {
   });
 });
 
-Then(/^I decreast last launch version$/, async function () {
+Then(/^I decrease last launch version$/, async function () {
   this.driver.wait(async () => {
     await setLastLaunchVersion(this.driver, '0.0.1');
     return true;

--- a/features/support/helpers/i18n-helpers.js
+++ b/features/support/helpers/i18n-helpers.js
@@ -12,7 +12,7 @@ export default {
     { language }: { language: string } = {}
   ) => (
     await client.executeScript(locale => {
-      yoroi.actions.profile.updateLocale.trigger({ locale });
+      yoroi.actions.profile.updateTentativeLocale.trigger({ locale });
     }, language || DEFAULT_LANGUAGE)
   ),
 


### PR DESCRIPTION
The new app start flow will be the following

Pick language => Accept ToS => Accept/decline URI scheme
Thn, based on the accept or decline, we have another page that either tells them to press OK for Chrome permission OR says sorry you aren’t interested but you can enable it in the settings page at any time

To do this, I have to make it cleaner to add new steps to app start. In the same PR, I also modify `isChrome` and `isFirefox` so that they work in browser mode also.