### PR TITLE
Shin/ch1699/fix classic theme block title style

### DIFF
--- a/app/components/transfer/TransferInstructionsPage.scss
+++ b/app/components/transfer/TransferInstructionsPage.scss
@@ -5,11 +5,11 @@
   min-width: 650px;
 
   .buttonTitle {
+    font-size: 18px;
+    font-family: var(--font-semibold);
     margin-bottom: 30px;
     line-height: 1.38;
     text-align: left;
-    font-size: 11px;
-    font-family: var(--font-medium);
   }
   
   .button {
@@ -27,10 +27,10 @@
     .infoBlock {
       padding-right: 60px;
       .title {
+        font-size: 18px;
+        font-family: var(--font-semibold);
         line-height: 1.38;
         margin-bottom: 16px;
-        font-size: 11px;
-        font-family: var(--font-medium);
       }
 
       .text {
@@ -44,35 +44,6 @@
     .operationBlock {
       padding-right: 40px;
       margin-left: auto;
-    }
-  }
-}
-
-:global(.YoroiClassic) .component {
-  .buttonTitle {
-    font-weight: 600;
-    text-transform: uppercase;
-  }
-
-  .body {
-    .title {
-      font-weight: 600;
-      padding-left: 10px;
-      text-transform: uppercase;
-    }
-  }  
-}
-
-:global(.YoroiModern) .component {
-  .buttonTitle {
-    font-size: 18px;
-    font-family: var(--font-semibold);
-  }
-    
-  .body {
-    .title {
-      font-size: 18px;
-      font-family: var(--font-semibold);
     }
   }
 }

--- a/app/components/transfer/TransferMasterKeyPage.scss
+++ b/app/components/transfer/TransferMasterKeyPage.scss
@@ -17,6 +17,8 @@
     .title {
       line-height: 1.38;
       margin-bottom: 4px;
+      font-size: 18px;
+      font-family: var(--font-semibold);
     }
   
     .text {
@@ -49,23 +51,4 @@
   .button {
     margin: 0 auto 0;
   }
-
-  .body {
-    .title {
-      font-size: 11px;
-      font-family: var(--font-medium);
-      font-weight: 600;
-      padding-left: 10px;
-      text-transform: uppercase;
-    }
-  }  
-}
-
-:global(.YoroiModern) .component {
-  .body {
-    .title {
-      font-size: 18px;
-      font-family: var(--font-semibold);
-    }
-  }  
 }

--- a/app/components/transfer/TransferMnemonicPage.scss
+++ b/app/components/transfer/TransferMnemonicPage.scss
@@ -18,7 +18,7 @@
       line-height: 1.38;
       margin-bottom: 4px;
       font-size: 18px;
-      font-family: var(--font-semibold);      
+      font-family: var(--font-semibold);
     }
   
     .text {

--- a/app/components/transfer/TransferMnemonicPage.scss
+++ b/app/components/transfer/TransferMnemonicPage.scss
@@ -17,6 +17,8 @@
     .title {
       line-height: 1.38;
       margin-bottom: 4px;
+      font-size: 18px;
+      font-family: var(--font-semibold);      
     }
   
     .text {
@@ -49,27 +51,10 @@
   .button {
     margin: 0 auto 0;
   }
-
-  .body {
-    .title {
-      font-size: 11px;
-      font-family: var(--font-medium);
-      font-weight: 600;
-      padding-left: 10px;
-      text-transform: uppercase;
-    }
-  }
 }
 
 :global(.YoroiModern) .component {
   .inputWrapper span[class*='selectedWordBox'] {
     background-color: var(--rp-autocomplete-selected-word-box-bg-color-secondary);
-  }
-
-  .body {
-    .title {
-      font-size: 18px;
-      font-family: var(--font-semibold);
-    }
   }
 }

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -45,7 +45,7 @@
       letter-spacing: 0;
 
       .postCopyMargin {
-        margin-bottom: 6px;
+        margin-bottom: 16px;
       }
 
       .copyableHash {
@@ -54,8 +54,11 @@
       }
 
       .hashLabel {
-        font-size: 11px;
-        margin-bottom: 6px;
+        font-size: 18px;
+        font-family: var(--font-medium);
+        font-weight: 500;
+        line-height: 22px;
+        margin-bottom: 16px;
       }
 
       .instructionsText {
@@ -89,18 +92,20 @@
     line-height: 22px;
 
     h2 {
+      font-size: 18px;
       font-family: var(--font-medium);
-      font-size: 11px;
+      font-weight: 500;
+      margin-bottom: 10px;
+      line-height: 22px;
 
       button {
         color: var(--theme-label-button-color);
         cursor: pointer;
         float: right;
-        font-family: var(--font-regular);
-        font-size: 14px;
-        line-height: 22px;
+        font-family: var(--font-medium);
+        font-size: 16px;
         margin-left: 12px;
-        opacity: 0.55;
+        text-transform: uppercase;
 
         &:hover {
           text-decoration: underline;
@@ -193,25 +198,6 @@
       padding-bottom: 6px;
     }
   }
-
-  .qrCodeAndInstructions {
-    .instructions {
-      .hashLabel {
-        font-family: var(--font-medium);
-        font-weight: 600;
-        margin-bottom: 10px;
-        text-transform: uppercase;
-      }
-    }
-  }
-
-  .generatedAddresses {
-    h2 {
-      font-weight: 600;
-      margin-bottom: 10px;
-      text-transform: uppercase;
-    }
-  }
 }
 
 :global(.YoroiModern) .component {
@@ -224,13 +210,6 @@
         line-height: 1.57;
       }
 
-      .hashLabel {
-        font-size: 18px;
-        margin-bottom: 30px;
-        line-height: 1.31;
-        font-family: var(--font-medium);
-      }
-
       .instructionsText {
         font-size: 14px;
         letter-spacing: 0;
@@ -241,19 +220,6 @@
 
   .generatedAddresses {
     font-size: 14px;
-
-    h2 {
-      font-size: 18px;
-      line-height: 1.31;
-      letter-spacing: 0;
-      margin-bottom: 20px;
-
-      button {
-        font-family: var(--font-medium);
-        text-transform: uppercase;
-        font-size: 16px;
-      }
-    }
 
     .walletAddress {
       padding: 12px 0;

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -56,7 +56,6 @@
       .hashLabel {
         font-size: 18px;
         font-family: var(--font-medium);
-        font-weight: 500;
         line-height: 22px;
         margin-bottom: 16px;
       }
@@ -94,7 +93,6 @@
     h2 {
       font-size: 18px;
       font-family: var(--font-medium);
-      font-weight: 500;
       margin-bottom: 10px;
       line-height: 22px;
 


### PR DESCRIPTION
**Background:**
We depreciated the pattern of using uppercase for block titles in Classic Theme but few screens still using uppercase(font size is also on smaller side.). This PR fixes some of those.

## 1. Wallet Receive Page
![image](https://user-images.githubusercontent.com/19986226/60781434-6771b580-a17d-11e9-8e13-798ed5397a0a.png)

## 2. TransferInstructionsPage
![image](https://user-images.githubusercontent.com/19986226/60781489-b7e91300-a17d-11e9-869b-19837c27248f.png)

## 3. Daedalus Wallet Transfer Page
![image](https://user-images.githubusercontent.com/19986226/60781569-f1ba1980-a17d-11e9-817e-b71d98c2d557.png)

## 4. Daedalus Paper Wallet Transfer Page
![image](https://user-images.githubusercontent.com/19986226/60781681-51b0c000-a17e-11e9-8620-0d0ef0a03397.png)

## 5. Daedalus Master Key Transfer Page
![image](https://user-images.githubusercontent.com/19986226/60781746-8b81c680-a17e-11e9-8288-e62bb2639adf.png)
