### PR TITLE
Fix hmr on css

### DIFF
--- a/webpack/commonConfig.js
+++ b/webpack/commonConfig.js
@@ -52,7 +52,12 @@ const rules = [
   {
     test: /\.css$/,
     use: [
-      'style-loader',
+      {
+        loader: 'style-loader',
+        options: {
+          hmr: false,
+        },
+      },
       {
         loader: 'css-loader',
         options: {
@@ -75,7 +80,13 @@ const rules = [
   {
     test: /\.global\.scss$/,
     use: [
-      'style-loader?sourceMap',
+      {
+        loader: 'style-loader',
+        options: {
+          hmr: false,
+          sourceMap: true,
+        },
+      },
       {
         loader: 'css-loader',
         options: {
@@ -91,7 +102,13 @@ const rules = [
   {
     test: /^((?!\.global).)*\.scss$/,
     use: [
-      'style-loader?sourceMap',
+      {
+        loader: 'style-loader',
+        options: {
+          hmr: false,
+          sourceMap: true,
+        },
+      },
       {
         loader: 'css-loader',
         options: {


### PR DESCRIPTION
`style-loader` has its own HMR that conflicts with the hot reload from `react-hot-loader` which causes it to throw errors if you add new CSS classes. The recommended fix is to disable the HMR for `style-loader` and let `react-hot-loader` deal with it.