### PR TITLE
Update localci steps

### DIFF
--- a/features/README.md
+++ b/features/README.md
@@ -14,13 +14,38 @@ Note: The JSON file is just miscellaneous faked data. It is
 
 Sometimes it is useful and faster to simulate running our CI on your local machine. We do this by creating the same docker container that our CI uses and locally copying your code to the docker container.
 
-1) If this is your first time using localci,
-use `npm run localci-setup` to create the docker image.
-Otherwise, start the existing image and use `sudo docker exec -d yoroi_ci /bin/bash CI/connect.sh`
+### Updating an existing LocalCI
+
+#### Updating image
+
+You sometimes need to update your docker image (for example get the latest version of browsers). This requires you to delete your existing image and recreate a new one
+1) `docker pull -a emurgornd/circleci-node-8-browsers`
+1) `docker stop yoroi_ci`
+1) `docker rm yoroi_ci`
+1) See instructions for setting up LocalCI for the first time
+
+#### Starting existing image
+1) Start the docker image with `docker start yoroi_ci`
+1) Reconnect the image with `sudo docker exec -d yoroi_ci /bin/bash CI/connect.sh`
+
+#### Using LocalCI
+
+1) (ONLY FIRST TIME) `npm run localci-setup` to create the docker image.
 1) `npm run localci-newbuild` whenever you make a code change
+1) (MAC ONLY) `npm install` isn't compatible across operating systems you you have to delete `node_modules` inside the docker image and re-run `npm install`.
 1) `npm run localci-test` to run the test (ex: `npm run localci-test test-e2e`)
 
-This localci also allows you to attach a monitor to your container to inspect visually why a test is failing. To do this, you need an application that can run a `VNC` connection. If you are using Ubuntu, I suggest the following steps:
+### See LocalCI browser behavior using a virtual monitor
+
+This localci also allows you to attach a monitor to your container to inspect visually why a test is failing. To do this, you need an application that can run a `VNC` connection. 
+
+#### Ubuntu
+
+If you are using Ubuntu, I suggest the following steps:
 1) Run `Remmina` (comes preinstalled)
 1) Set the protocol to `VNC`
 1) Set `127.0.0.1` as the connection
+
+#### Mac
+
+1) Use Royal TSX with `VNC`

--- a/features/localCI/setup.sh
+++ b/features/localCI/setup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # install same base as our CI build
-sudo docker run --name yoroi_ci -p 5900:5900 -dit rcmorano/circleci-node-8-browsers:firefox-nightly
+# TODO: make this use emurgornd once the emurgornd image auto-updates to latest chromedriver
+sudo docker run --name yoroi_ci -p 5900:5900 -dit circleci/node:8-browsers
 
 sudo docker cp features/localCI/. yoroi_ci:/CI
 user=$(sudo docker exec -t yoroi_ci whoami | tr -d '\r')


### PR DESCRIPTION
The steps were broken since the old image used `chromedriver 73` which is no longer sufficient (we need version `75` and the version requirement will keep increasing overtime)