### PR TITLE
Attempt to fix some CI test issues

### DIFF
--- a/features/main-ui.feature
+++ b/features/main-ui.feature
@@ -46,11 +46,11 @@ Feature: Main UI
     Then I see transactions buttons are disabled
 
   @serverDown @it-31
-  Scenario: The networkError banner must be displayed if the server is not reachable
+  Scenario: The networkError banner must be displayed if the server is not reachable (IT-31)
   Then I should see the networkError banner
 
   @serverMaintenance @it-32
-  Scenario: The serverError banner must be displayed for as long as the server reports an issue
+  Scenario: The serverError banner must be displayed for as long as the server reports an issue (IT-32)
   Then I should see the serverError banner
 
   @it-110

--- a/features/migration.feature
+++ b/features/migration.feature
@@ -4,7 +4,7 @@ Feature: Migration
     Given I have opened the extension
     
   @it-83
-  Scenario: Version set on first launch
+  Scenario: Version set on first launch (IT-83)
     And I am on the language selection screen
     Then Last launch version is updated
     Then I decrease last launch version

--- a/features/step_definitions/transactions-steps.js
+++ b/features/step_definitions/transactions-steps.js
@@ -59,6 +59,22 @@ When(/^The transaction fees are "([^"]*)"$/, async function (fee) {
 
 When(/^I click on the next button in the wallet send form$/, async function () {
   await this.click('.WalletSendForm_nextButton');
+  /**
+   * Sometimes out tests fail because clicking this button isn't triggering a dialog
+   * However it works flawlessly both locally and on localci
+   *
+   * My only guess is that mobx re-disables this button in a way that only causes
+   * the condition to happen on low-resouruce machines like we use for CI
+   *
+   * I attempt to fix it by just clicking twice after a delay
+   */
+  await this.driver.sleep(500);
+  try {
+    await this.click('.WalletSendForm_nextButton');
+  } catch (e) {
+    // if the first click succeeded, the second will throw an exception
+    // saying that the button can't be clicked because a dialog is in the way
+  }
 });
 
 When(/^I click on "Send all my ADA" checkbox$/, async function () {

--- a/features/step_definitions/tx-history-steps.js
+++ b/features/step_definitions/tx-history-steps.js
@@ -62,6 +62,7 @@ Then(
 
 
 Then(/^I should see no transactions$/, async function () {
+  await this.waitForElement('.WalletNoTransactions_component');
   const actualTxsList = await this.getElementsBy('.Transaction_component');
   chai.expect(actualTxsList.length).to.equal(0);
 });
@@ -71,6 +72,7 @@ Then(
   async function (txsNumber, txExpectedStatus) {
     const txsAmount = parseInt(txsNumber, 10);
 
+    await this.driver.sleep(500);
     // press the show more transaction button until all transactions are visible
     for (let i = 1; i < txsAmount; i++) {
       const webElements = await this.driver.findElements(By.xpath(`//button[contains(@class, 'primary WalletTransactionsList_showMoreTransactionsButton')]`));
@@ -100,6 +102,7 @@ Then(
 Then(
   /^I verify top transaction content ([^"]*)$/,
   async function (walletName) {
+    await this.waitForElement('.Transaction_component');
     const actualTxsList = await this.getElementsBy('.Transaction_component');
     const topTx = actualTxsList[0];
 

--- a/features/transactions.feature
+++ b/features/transactions.feature
@@ -91,7 +91,7 @@ Feature: Send transaction
     And I should not be able to submit
 
   @it-55
-  Scenario Outline: User can send all funds from one Yoroi wallet to another
+  Scenario Outline: User can send all funds from one Yoroi wallet to another (IT-55)
     Given There is a wallet stored named many-tx-wallet
     And I have a wallet with funds
     When I go to the send transaction screen
@@ -113,7 +113,7 @@ Feature: Send transaction
       | 0.221520  |
 
   @invalidWitnessTest @it-20
-  Scenario: Sending a Tx and receiving from the server an invalid signature error
+  Scenario: Sending a Tx and receiving from the server an invalid signature error (IT-20)
     Given There is a wallet stored named many-tx-wallet
     And I have a wallet with funds
     When I go to the send transaction screen
@@ -220,7 +220,7 @@ Feature: Send transaction
     Then I should see the summary screen
 
   @it-61
-  Scenario: Display warning if wallet changes during send screen (IT-59)
+  Scenario: Display warning if wallet changes during send screen (IT-61)
     Given There is a wallet stored named many-tx-wallet
     And I have a wallet with funds
     When I go to the send transaction screen

--- a/features/wallet-restoration.feature
+++ b/features/wallet-restoration.feature
@@ -34,7 +34,7 @@ Feature: Restore Wallet
     Then I delete recovery phrase by clicking "x" signs
   
   @it-86
-  Scenario: Successfully restoring a simple wallet
+  Scenario: Successfully restoring a simple wallet (IT-86)
     When I click the restore button
     And I enter the name "Restored Wallet"
     And I enter the recovery phrase:
@@ -54,8 +54,8 @@ Feature: Restore Wallet
     | Ae2tdPwUPEZ7sn3AQhUFGHXiWuG5aU3XnMi2SNKeh94S9Pp17igo1RwzodB |
     | Ae2tdPwUPEZ73Nh3ALXKwtt9Wmb8bQHa9owoXtkvGEWK3AX6kXNHBK1D261 |
 
-  @it-86
-  Scenario: Ensure that wallet addresses are restored correctly (IT-86)
+  @it-87
+  Scenario: Ensure that wallet addresses are restored correctly (IT-87)
     When I click the restore button
     And I enter the name "Restored Wallet"
     And I enter the recovery phrase:
@@ -80,7 +80,7 @@ Feature: Restore Wallet
     | Ae2tdPwUPEYzErSRwThtfVfBbhM87NCXDwkGHRqSYJcRVP4GS8Lgx3AxAXd |
 
   @it-11
-  Scenario: Fail to completely restore a wallet with addresses generated not following gap from BIP44 protocol
+  Scenario: Fail to completely restore a wallet with addresses generated not following gap from BIP44 protocol (IT-11)
     When I click the restore button
     And I enter the name "Restored Wallet"
     And I enter the recovery phrase:


### PR DESCRIPTION
I noticed some tests recently are failing with the error
```
✖ Then I verify top transaction content many-tx-wallet # features/step_definitions/tx-history-steps.js:100
       TypeError: Cannot read property 'findElements' of undefined
```

This attempts to fix it by waiting for the element to be visible.

Additionally, tests have for some time randomly failed on these steps
```
✔ And I click on the next button in the wallet send form # features/step_definitions/transactions-steps.js:60
   ✖ And I see send money confirmation dialog # features/step_definitions/transactions-steps.js:68
```
I try a hacky fix in hopes it will work but who knows.