### PR TITLE
Revert "Bump @babel/core from 7.5.0 to 7.5.4"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
       }
     },
     "@babel/core": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.4.tgz",
-      "integrity": "sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.0.tgz",
+      "integrity": "sha512-6Isr4X98pwXqHvtigw71CKgmhL1etZjPs5A67jL/w0TkLM9eqmFR40YrnJvEc1WnMZFsskjsmid8bHZyxKEAnw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.5.0",
-        "@babel/helpers": "^7.5.4",
+        "@babel/helpers": "^7.5.0",
         "@babel/parser": "^7.5.0",
         "@babel/template": "^7.4.4",
         "@babel/traverse": "^7.5.0",
@@ -338,9 +338,9 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.4.tgz",
-      "integrity": "sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.1.tgz",
+      "integrity": "sha512-rVOTDv8sH8kNI72Unenusxw6u+1vEepZgLxeV+jHkhsQlYhzVhzL1EpfoWT7Ub3zpWSv2WV03V853dqsnyoQzA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "author": "IOHK & EMURGO",
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "7.5.4",
+    "@babel/core": "7.5.0",
     "@babel/node": "7.5.0",
     "@babel/plugin-proposal-class-properties": "7.5.0",
     "@babel/plugin-proposal-decorators": "7.4.4",


### PR DESCRIPTION
This seems like it broke `npm run dev` (but all other commands work fine) so I'm reverting it for now.