### PR TITLE
silence the mock server during e2e tests

### DIFF
--- a/features/mock-chain/mockServer.js
+++ b/features/mock-chain/mockServer.js
@@ -14,8 +14,6 @@ import type {
 import chai from 'chai';
 import mockImporter from './mockImporter';
 
-const middlewares = [...defaults(), bodyParser];
-
 const port = 8080;
 
 // MockData should always be consistent with the following values
@@ -62,10 +60,14 @@ export function getMockServer(
         send(arg: SignedResponse): any,
         status: Function
       }
-    ) => void
+    ) => void,
+    // Whether to output request logs. Defaults to false.
+    outputLog?: boolean
   }
 ) {
   if (!MockServer) {
+    const middlewares = [...defaults({ logger: !!settings.outputLog }), bodyParser];
+
     const server = create();
 
     server.use(middlewares);

--- a/scripts/startWithMockServer.js
+++ b/scripts/startWithMockServer.js
@@ -2,7 +2,7 @@
 const { getMockServer } = require('../features/mock-chain/mockServer');
 const  { resetChain } = require('../features/mock-chain/mockImporter');
 
-getMockServer({});
+getMockServer({ outputLog: true });
 resetChain();
 
 const tasks = require('./tasks');


### PR DESCRIPTION
Currently the mock server logs every request. This is too noisy during the e2e tests. This PR silences it.