### PR TITLE
Disable buttons in Classic theme if form is not filled

### DIFF
--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -180,7 +180,7 @@ export default class WalletCreateDialog extends Component<Props, State> {
         label: this.context.intl.formatMessage(messages.createPersonalWallet),
         primary: true,
         onClick: this.submit,
-        disabled: isSubmitting || (!classicTheme && disabledCondition)
+        disabled: isSubmitting || disabledCondition
       },
     ];
 

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -338,7 +338,7 @@ export default class WalletRestoreDialog extends Component<Props> {
           isVerificationMode ? messages.verifyButtonLabel : messages.importButtonLabel
         ),
         primary: true,
-        disabled: isSubmitting || (!classicTheme && disabledCondition()),
+        disabled: isSubmitting || disabledCondition(),
         onClick: this.submit,
       },
     ];

--- a/app/components/wallet/hwConnect/ledger/SaveDialog.js
+++ b/app/components/wallet/hwConnect/ledger/SaveDialog.js
@@ -162,11 +162,16 @@ export default class SaveDialog extends Component<Props> {
         break;
     }
 
-    const dailogActions = [{
+    const disabledCondition = (
+      isActionProcessing
+      || !isValidWalletName(walletName)
+    );
+
+    const dialogActions = [{
       className: isActionProcessing ? styles.processing : null,
       label: intl.formatMessage(globalMessages.hwConnectDialogSaveButtonLabel),
       primary: true,
-      disabled: isActionProcessing,
+      disabled: disabledCondition,
       onClick: this.save
     }];
 
@@ -174,7 +179,7 @@ export default class SaveDialog extends Component<Props> {
       <Dialog
         className={classnames([styles.component, 'SaveDialog'])}
         title={intl.formatMessage(globalMessages.ledgerConnectAllDialogTitle)}
-        actions={dailogActions}
+        actions={dialogActions}
         closeOnOverlayClick={false}
         onClose={cancel}
         closeButton={<DialogCloseButton />}

--- a/app/components/wallet/hwConnect/trezor/SaveDialog.js
+++ b/app/components/wallet/hwConnect/trezor/SaveDialog.js
@@ -137,7 +137,6 @@ export default class SaveDialog extends Component<Props> {
 
     let middleBlock = null;
 
-
     switch (progressInfo.stepState) {
       case StepState.LOAD:
         middleBlock = (
@@ -162,11 +161,16 @@ export default class SaveDialog extends Component<Props> {
         break;
     }
 
-    const dailogActions = [{
+    const disabledCondition = (
+      isActionProcessing
+      || !isValidWalletName(walletName)
+    );
+
+    const dialogActions = [{
       className: isActionProcessing ? styles.processing : null,
       label: intl.formatMessage(globalMessages.hwConnectDialogSaveButtonLabel),
       primary: true,
-      disabled: isActionProcessing,
+      disabled: disabledCondition,
       onClick: this.save
     }];
 
@@ -174,7 +178,7 @@ export default class SaveDialog extends Component<Props> {
       <Dialog
         className={classnames([styles.component, 'SaveDialog'])}
         title={intl.formatMessage(globalMessages.trezorConnectAllDialogTitle)}
-        actions={dailogActions}
+        actions={dialogActions}
         closeOnOverlayClick={false}
         onClose={cancel}
         closeButton={<DialogCloseButton />}

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.js
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.js
@@ -164,7 +164,7 @@ export default class ChangeWalletPasswordDialog extends Component<Props> {
         onClick: this.submit,
         primary: true,
         className: confirmButtonClasses,
-        disabled: (!classicTheme && disabledCondition)
+        disabled: disabledCondition
       },
     ];
 

--- a/features/settings-ui.feature
+++ b/features/settings-ui.feature
@@ -14,8 +14,8 @@ Feature: Wallet UI Settings
     And I change wallet password:
     | currentPassword    | password     | repeatedPassword   |
     | <currentPassword>  | <password>   | <repeatedPassword> |
-    And I submit the wallet password dialog
-    Then I should see the following error messages:
+    Then I see the submit button is disabled
+    And I should see the following error messages:
     | message                             |
     | global.errors.invalidWalletPassword |
   Examples:
@@ -138,8 +138,8 @@ Feature: Wallet UI Settings
     | currentPassword    | password     | repeatedPassword |
     | aaSecret_123         | newSecret123 | newSecret123     |
     And I clear the current wallet repeat password newSecret123 
-    And I submit the wallet password dialog
-    Then I should stay in the change password dialog
+    Then I see the submit button is disabled
+    And I should stay in the change password dialog
     And I should see "Doesn't match" error message:
     | message                             |
     | global.errors.invalidRepeatPassword |

--- a/features/step_definitions/wallet-creation-steps.js
+++ b/features/step_definitions/wallet-creation-steps.js
@@ -27,6 +27,19 @@ When(/^I click the "Create personal wallet" button$/, async function () {
   await this.click('.WalletCreateDialog .primary');
 });
 
+Then(/^I should see the invalid password error message:$/, async function (data) {
+  const error = data.hashes()[0];
+  const errorSelector = '.walletPassword .SimpleFormField_error';
+  await checkErrorByTranslationId(this, errorSelector, error);
+});
+
+Then(/^I see the submit button is disabled$/, async function () {
+  const disabledButton = await this.driver.findElement(By.xpath("//div[@class='Dialog_actions']//button[contains(@class, 'SimpleButton_root') and contains(@class, 'disabled')]"));
+  const pageUrl = await this.driver.getCurrentUrl();
+  disabledButton.click();
+  expect(pageUrl).to.be.equal(await this.driver.getCurrentUrl());
+});
+
 When(/^I accept the creation terms$/, async function () {
   await this.click('.SimpleCheckbox_check');
   await this.click('.WalletBackupPrivacyWarningDialog .primary');

--- a/features/wallet-creation.feature
+++ b/features/wallet-creation.feature
@@ -52,8 +52,10 @@ Feature: Wallet creation
     | password   | repeatedPassword  |
     | asdfasdfasdf | asdfasdfasdf        |
     And I clear the created wallet password asdfasdfasdf
-    And I click the "Create personal wallet" button
-    Then I should stay in the create wallet dialog
+    Then I see the submit button is disabled
+    And I should see the invalid password error message:
+    | message                             |
+    | global.errors.invalidWalletPassword |
 
   @it-27
    Scenario: Users will be presented with a security warning prior to seed creation (IT-27)
@@ -75,12 +77,12 @@ Feature: Wallet creation
     | password   | repeatedPassword  |
     | asdfasdfasdf | asdfasdfasdf        |
     And I clear the name "Created Wallet"
-    And I click the "Create personal wallet" button
-    Then I should stay in the create wallet dialog
+    Then I see the submit button is disabled
+    And I should stay in the create wallet dialog
 
     And I enter the name "<invalidWalletName>"
-    And I click the "Create personal wallet" button
-    Then I should stay in the create wallet dialog
+    Then I see the submit button is disabled
+    And I should stay in the create wallet dialog
     And I should see "Wallet name requires at least 1 and at most 40 letters." error message:
     | message                             |
     | global.errors.invalidWalletName     |
@@ -95,8 +97,8 @@ Feature: Wallet creation
     And I enter the created wallet password:
     | password        | repeatedPassword  |
     | <wrongPassword> | <wrongPassword>   |
-    And I click the "Create personal wallet" button
-    Then I should see "Invalid Password" error message:
+    Then I see the submit button is disabled
+    And I should see "Invalid Password" error message:
     | message                             |
     | global.errors.invalidWalletPassword |
   Examples:

--- a/features/wallet-restoration.feature
+++ b/features/wallet-restoration.feature
@@ -109,8 +109,8 @@ Feature: Restore Wallet
     | password   | repeatedPassword |
     | asdfasdfasdf | asdfasdfasdf       |
     And I clear the restored wallet password asdfasdfasdf
-    And I click the "Restore Wallet" button
-    Then I should stay in the restore wallet dialog
+    Then I see the submit button is disabled
+    And I should stay in the restore wallet dialog
     
     @it-70
     Scenario Outline: Wallet restoration Recovery Phrase test (IT-70)
@@ -122,8 +122,8 @@ Feature: Restore Wallet
     And I enter the restored wallet password:
     | password   | repeatedPassword |
     | asdfasdfasdf | asdfasdfasdf       |
-    And I click the "Restore Wallet" button
-    Then I should stay in the restore wallet dialog
+    Then I see the submit button is disabled
+    And I should stay in the restore wallet dialog
     And I should see an "Invalid recovery phrase" error message:
     | message                                                 |
     | wallet.restore.dialog.form.errors.invalidRecoveryPhrase |


### PR DESCRIPTION
Disabling buttons in forms if they are not filled (or filled incorrectly). Same behavior as in Modern theme.

Create wallet:
<img width="805" alt="create_wallet_after" src="https://user-images.githubusercontent.com/1937074/61563224-2c1f9280-aa6b-11e9-9e2e-5d80f2054c8c.png">

Restore wallet:
<img width="807" alt="restore_wallet_after" src="https://user-images.githubusercontent.com/1937074/61563236-36da2780-aa6b-11e9-841d-869e794e760b.png">

Change wallet password:
<img width="593" alt="wallet_password_after" src="https://user-images.githubusercontent.com/1937074/61563249-43f71680-aa6b-11e9-8a52-45d18a55beee.png">

Create paper wallet:
<img width="614" alt="paper_wallet_after" src="https://user-images.githubusercontent.com/1937074/61563399-bc5dd780-aa6b-11e9-8c38-7096a0560e13.png">

Verify paper wallet:
<img width="803" alt="verify_paper_wallet_after" src="https://user-images.githubusercontent.com/1937074/61563412-c67fd600-aa6b-11e9-95b7-43ed647c6d0e.png">

Restore paper wallet:
<img width="807" alt="restore_paper_after" src="https://user-images.githubusercontent.com/1937074/61563421-cf70a780-aa6b-11e9-8d47-e71fe1ba0651.png">
