### PR TITLE
Unregister protocol before trying to register

### DIFF
--- a/app/components/profile/uri-prompt/UriAccept.js
+++ b/app/components/profile/uri-prompt/UriAccept.js
@@ -5,11 +5,10 @@ import SvgInline from 'react-svg-inline';
 import { observer } from 'mobx-react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
-import { defineMessages, intlShape, FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
 import styles from './UriAccept.scss';
 import uriPrompt from '../../../assets/images/uri/uri-prompt.inline.svg';
 import globalMessages from '../../../i18n/global-messages';
-import WarningBox from '../../widgets/WarningBox';
 
 const messages = defineMessages({
   seePrompt: {
@@ -21,7 +20,6 @@ const messages = defineMessages({
 type Props = {|
   onConfirm: void => void,
   onBack: void => void,
-  openSettingsPage: void => void,
   classicTheme: boolean
 |};
 
@@ -43,26 +41,8 @@ export default class UriAccept extends Component<Props> {
       styles.submitButton,
     ]);
 
-    const browserSettingsLink = (
-      <button
-        type="button"
-        onClick={_event => this.props.openSettingsPage()}
-      >
-        {intl.formatMessage(globalMessages.browserSettings)}
-      </button>
-    );
-    const noPromptWarning = (
-      <WarningBox>
-        {intl.formatMessage(globalMessages.promptWarningLine1)}<br />
-        <FormattedMessage {...globalMessages.promptWarningLine2} values={{ browserSettingsLink }} />
-      </WarningBox>
-    );
-
     return (
       <div className={styles.component}>
-        <div className={styles.warningBox}>
-          {noPromptWarning}
-        </div>
         <div className={styles.centeredBox}>
 
           <SvgInline svg={uriPrompt} className={styles.aboutSvg} />

--- a/app/components/profile/uri-prompt/UriAccept.scss
+++ b/app/components/profile/uri-prompt/UriAccept.scss
@@ -6,9 +6,6 @@
   align-content: center;
   overflow: overlay;
 
-  .warningBox {
-    margin: 30px;
-  }
   .centeredBox {
     width: 594px;
     margin: 0 auto;

--- a/app/components/profile/uri-prompt/UriSkip.js
+++ b/app/components/profile/uri-prompt/UriSkip.js
@@ -26,7 +26,6 @@ const messages = defineMessages({
 type Props = {|
   onConfirm: void => void,
   onBack: void => void,
-  openSettingsPage: void => void,
   classicTheme: boolean,
 |};
 

--- a/app/components/settings/categories/general-setting/UriSettingsBlock.js
+++ b/app/components/settings/categories/general-setting/UriSettingsBlock.js
@@ -4,13 +4,12 @@ import classnames from 'classnames';
 import { observer } from 'mobx-react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
-import { intlShape, FormattedMessage } from 'react-intl';
+import { intlShape } from 'react-intl';
 import styles from './UriSettingsBlock.scss';
 import globalMessages from '../../../../i18n/global-messages';
 import { observable, runInAction } from 'mobx';
 
 type Props = {|
-  openSettingsPage: void => void,
   registerUriScheme: void => void,
   isFirefox: boolean,
 |};
@@ -27,32 +26,11 @@ export default class UriSettingsBlock extends Component<Props> {
   render() {
     const { intl } = this.context;
 
-    const browserSettingsLink = (
-      <button
-        type="button"
-        onClick={_event => this.props.openSettingsPage()}
-      >
-        {intl.formatMessage(globalMessages.browserSettings)}
-      </button>
-    );
-
     const allowButtonClasses = classnames([
       'allowButton',
       'primary',
       styles.submitButton,
     ]);
-
-    const promptExplanation = this.props.isFirefox
-      ? null // no prompt for Firefox
-      : (
-        <p>
-          {intl.formatMessage(globalMessages.promptWarningLine1)}&nbsp;
-          <FormattedMessage
-            {...globalMessages.promptWarningLine2}
-            values={{ browserSettingsLink }}
-          />
-        </p>
-      );
 
     // On firefox since there is no prompt,
     // We need to give the user feedback that they pressed the button
@@ -65,7 +43,6 @@ export default class UriSettingsBlock extends Component<Props> {
           {intl.formatMessage(globalMessages.uriSchemeLabel)}
         </h2>
 
-        {promptExplanation}
         <p>
           {intl.formatMessage(globalMessages.uriExplanation)}
         </p>

--- a/app/containers/profile/UriPromptPage.js
+++ b/app/containers/profile/UriPromptPage.js
@@ -4,7 +4,6 @@ import { observer } from 'mobx-react';
 import { observable, runInAction } from 'mobx';
 import { intlShape } from 'react-intl';
 import environment from '../../environment';
-import { openSandboxedTab, handlersSettingUrl } from '../../utils/tabManager';
 
 import StaticTopbarTitle from '../../components/topbar/StaticTopbarTitle';
 import TopBar from '../../components/topbar/TopBar';
@@ -71,14 +70,12 @@ export default class UriPromptPage extends Component<InjectedProps> {
         return <UriAccept
           onConfirm={this.onFinalSubmit}
           onBack={this.onBack}
-          openSettingsPage={() => openSandboxedTab(handlersSettingUrl)}
           classicTheme={profile.isClassicTheme}
         />;
       case Choices.SKIP:
         return <UriSkip
           onConfirm={this.onFinalSubmit}
           onBack={this.onBack}
-          openSettingsPage={() => openSandboxedTab(handlersSettingUrl)}
           classicTheme={profile.isClassicTheme}
         />;
       default:

--- a/app/containers/settings/categories/GeneralSettingsPage.js
+++ b/app/containers/settings/categories/GeneralSettingsPage.js
@@ -8,7 +8,6 @@ import type { InjectedProps } from '../../../types/injectedPropsType';
 import ThemeSettingsBlock from '../../../components/settings/categories/general-setting/ThemeSettingsBlock';
 import UriSettingsBlock from '../../../components/settings/categories/general-setting/UriSettingsBlock';
 import registerProtocols from '../../../uri-protocols';
-import { openSandboxedTab, handlersSettingUrl } from '../../../utils/tabManager';
 import environment from '../../../environment';
 import AboutYoroiSettingsBlock from '../../../components/settings/categories/general-setting/AboutYoroiSettingsBlock';
 import type { ExplorerType } from '../../../domain/Explorer';
@@ -61,7 +60,6 @@ export default class GeneralSettingsPage extends Component<InjectedProps> {
     const uriSettings = environment.userAgentInfo.canRegisterProtocol()
       ? (
         <UriSettingsBlock
-          openSettingsPage={() => openSandboxedTab(handlersSettingUrl)}
           registerUriScheme={() => registerProtocols()}
           isFirefox={environment.userAgentInfo.isFirefox}
         />

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -325,18 +325,6 @@ const globalMessages = defineMessages({
     id: 'global.uriSchemeTitleLabel',
     defaultMessage: '!!!Cardano Payment URLs',
   },
-  promptWarningLine1: {
-    id: 'global.promptWarningLine1',
-    defaultMessage: '!!!You will not see a prompt if you have previously accepted or rejected it in the past.',
-  },
-  promptWarningLine2: {
-    id: 'global.promptWarningLine2',
-    defaultMessage: '!!!You can unblock or remove permission from your {browserSettingsLink}',
-  },
-  browserSettings: {
-    id: 'global.browserSettings',
-    defaultMessage: '!!!browser settings',
-  },
   uriExplanation: {
     id: 'global.uriExplanation',
     defaultMessage: '!!!These allow you to easily share invoices with friends and businesses by simply clicking a URL.',

--- a/app/uri-protocols.js
+++ b/app/uri-protocols.js
@@ -17,6 +17,16 @@ const registerProtocols = () => {
     return;
   }
   try {
+    // Unregistering the protocol before calling register again will make the browser
+    // to always show the allow/block dialog.
+    navigator.unregisterProtocolHandler(
+      cardanoURI.PROTOCOL,
+      cardanoURI.URL,
+    );
+  } catch (err) {
+    Logger.error(`uri-protocols:unregisterProtocols ${stringifyError(err)}`);
+  }
+  try {
     navigator.registerProtocolHandler(
       cardanoURI.PROTOCOL,
       cardanoURI.URL,

--- a/app/uri-protocols.js
+++ b/app/uri-protocols.js
@@ -19,6 +19,7 @@ const registerProtocols = () => {
   try {
     // Unregistering the protocol before calling register again will make the browser
     // to always show the allow/block dialog.
+    // $FlowFixMe
     navigator.unregisterProtocolHandler(
       cardanoURI.PROTOCOL,
       cardanoURI.URL,


### PR DESCRIPTION
Currently there is no way to tell if the user has allowed or blocked the protocol. Going to Yoroi settings and clicking on **Allow** works only if the protocol is not registered, and does **nothing** if the user has already allowed/blocked it.

Making a call to `unregisterProtocolHandler` before trying to register will make the browser to always show the allow/block dialog. This helps if the user blocked it in the first place (or clicked away from the dialog, which also blocks it) and he wants to allow it by going to Yoroi settings instead of going to browser -> handler -> settings.

The `unregisterProtocolHandler` method is not supported by all browsers (e.g. Firefox) but it works in Chrome, and given that in this case the protocol registration is just for Chrome, then it should be OK.

Before:
![unregister_protocol_before](https://user-images.githubusercontent.com/1937074/61632340-89426080-ac84-11e9-8b6c-fe13b7280e70.gif)

After:
![unregister_protocol_after](https://user-images.githubusercontent.com/1937074/61632359-92333200-ac84-11e9-958c-56772b13d499.gif)

