### PR TITLE
shin/ch1826/ada-redemption-certificate-upload-not-working

### DIFF
--- a/app/components/widgets/forms/AdaCertificateUploadWidget.js
+++ b/app/components/widgets/forms/AdaCertificateUploadWidget.js
@@ -62,8 +62,9 @@ export default class AdaCertificateUploadWidget extends Component<Props> {
               multiple={false}
               accept={acceptedFileTypes}
             >
-              {({ getRootProps }) => (
+              {({ getRootProps, getInputProps }) => (
                 <div {...getRootProps()}>
+                  <input {...getInputProps()} />
                   <div className={styles.instructions}>
                     <div className={styles.title}>
                       {intl.formatMessage(messages.orClickToUpload)}


### PR DESCRIPTION
Story:
https://app.clubhouse.io/emurgo/story/1826/ada-redemption-certificate-upload-not-working

Probably in version update of `react-dropzone` https://github.com/Emurgo/yoroi-frontend/commit/1c1959fa0fc14acc5be9d3f78681e9afc5cf76a7 we need `<input>` tag as in: https://www.npmjs.com/package/react-dropzone
![image](https://user-images.githubusercontent.com/19986226/61769369-fee53280-ae24-11e9-8a59-1721a9e82043.png)

Hence in this PR added `<input>` tag.
