### PR TITLE
Misc fixes

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,8 +13,7 @@
 ../node_modules/eslint-plugin-jsx-a11y
 
 [untyped]
-.*/node_modules/trezor-connect/lib/popup/PopupManager.js
-.*/node_modules/trezor-connect/lib/iframe/builder.js
+.*/node_modules/trezor-connect/lib/utils/networkUtils.js
 
 [libs]
 flow/declarations/

--- a/app/api/ada/hardwareWallet/newTransaction.js
+++ b/app/api/ada/hardwareWallet/newTransaction.js
@@ -26,8 +26,6 @@ import type {
   PrepareAndBroadcastLedgerSignedTxResponse
 } from '../index';
 import type {
-  CardanoInput,
-  CardanoOutput,
   LedgerSignTxPayload,
 } from '../../../domain/HWSignTx';
 import type {
@@ -39,7 +37,11 @@ import type {
   Witness
 } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { makeCardanoBIP44Path } from 'yoroi-extension-ledger-bridge';
-import type { $CardanoSignTransaction } from 'trezor-connect/lib/types/cardano';
+import type {
+  $CardanoSignTransaction,
+  CardanoInput,
+  CardanoOutput,
+} from 'trezor-connect/lib/types/cardano';
 
 import type { ConfigType } from '../../../../config/config-types';
 

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -776,7 +776,7 @@ export default class AdaApi {
         throw new Error('no account selected');
       }
       const accountPrivateKey = cryptoWallet.bip44_account(
-        RustModule.Wallet.AccountIndex.new(currAccount | HARD_DERIVATION_START)
+        RustModule.Wallet.AccountIndex.new(currAccount + HARD_DERIVATION_START)
       );
       const signedTx = await signTransaction(
         signRequest,

--- a/app/api/ada/lib/cardanoCrypto/cryptoWallet.js
+++ b/app/api/ada/lib/cardanoCrypto/cryptoWallet.js
@@ -213,7 +213,7 @@ export const mnemonicsToAddresses = (
   const masterKey = generateWalletMasterKey(mnemonic, '');
   const cryptoWallet = getCryptoWalletFromMasterKey(masterKey, '');
   const account = cryptoWallet.bip44_account(
-    RustModule.Wallet.AccountIndex.new(accountIndex | HARD_DERIVATION_START)
+    RustModule.Wallet.AccountIndex.new(accountIndex + HARD_DERIVATION_START)
   );
   const accountPublic = account.public();
   const accountPlate = createAccountPlate(accountPublic.key().to_hex());

--- a/app/api/ada/lib/storage/adaAccount.js
+++ b/app/api/ada/lib/storage/adaAccount.js
@@ -16,7 +16,7 @@ export function createCryptoAccount(
   const cryptoWallet = getCryptoWalletFromMasterKey(encryptedMasterKey, walletPassword);
   // create a hardened account
   const account = cryptoWallet.bip44_account(
-    RustModule.Wallet.AccountIndex.new(accountIndex | HARD_DERIVATION_START)
+    RustModule.Wallet.AccountIndex.new(accountIndex + HARD_DERIVATION_START)
   );
   const accountPublic = account.public();
   return {

--- a/app/api/ada/lib/storage/adaMigration.js
+++ b/app/api/ada/lib/storage/adaMigration.js
@@ -90,5 +90,5 @@ async function bip44Migration(): Promise<void> {
    * We need to do this since old wallets may have incorrect history
    * Due to desync issue caused by the incorrect bip44 implementation
    */
-  reset();
+  await reset();
 }

--- a/app/domain/HWSignTx.js
+++ b/app/domain/HWSignTx.js
@@ -1,28 +1,10 @@
 // @flow
 
-// https://github.com/trezor/connect/issues/350
 import type {
   InputTypeUTxO,
   OutputTypeAddress,
   OutputTypeChange,
 } from '@cardano-foundation/ledgerjs-hw-app-cardano';
-import type { $Path } from 'trezor-connect/lib/types/params';
-
-// replace with real types once this PR is merged
-// https://github.com/trezor/connect/pull/404
-export type CardanoInput = {
-  path: $Path,
-  prev_hash: string,
-  prev_index: number,
-  type: number,
-}
-export type CardanoOutput = {
-  path: $Path,
-  amount: string,
-} | {
-  address: string,
-  amount: string,
-}
 
 export type LedgerSignTxPayload = {
   inputs: Array<InputTypeUTxO>,

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,62 +1,62 @@
-module.exports = function(api) {
+module.exports = function (api) {
   // when running jest we need to use nodejs and not browser configurations
   const nodePlugins = api.env('jest')
-    ? [ "dynamic-import-node" ]
+    ? ['dynamic-import-node']
     : [];
 
   return {
-    "presets": [
+    presets: [
       [
-        "@babel/preset-env",
+        '@babel/preset-env',
         {
-          "corejs": 2,
-          "modules": api.env('jest') ? "commonjs" : 'auto',
-          "useBuiltIns": "entry"
+          corejs: 2,
+          modules: api.env('jest') ? 'commonjs' : 'auto',
+          useBuiltIns: 'entry'
         }
       ],
-      "@babel/preset-flow",
-      "@babel/preset-react"
+      '@babel/preset-flow',
+      '@babel/preset-react'
     ],
-    "plugins": [
+    plugins: [
       [
-        "@babel/plugin-proposal-decorators",
+        '@babel/plugin-proposal-decorators',
         {
-          "legacy": true
+          legacy: true
         }
       ],
       [
-        "@babel/plugin-transform-runtime",
+        '@babel/plugin-transform-runtime',
         {
-          "corejs": 2,
-          "helpers": true,
-          "regenerator": true
+          corejs: 2,
+          helpers: true,
+          regenerator: true
         }
       ],
       [
-        "react-intl",
+        'react-intl',
         {
-          "messagesDir": "./translations/messages/",
-          "enforceDescriptions": false,
-          "extractSourceLocation": true
+          messagesDir: './translations/messages/',
+          enforceDescriptions: false,
+          extractSourceLocationß: true
         }
       ],
-      "@babel/plugin-syntax-dynamic-import",
-      "add-module-exports",
+      '@babel/plugin-syntax-dynamic-import',
+      'add-module-exports',
       [
-        "@babel/plugin-proposal-class-properties",
+        '@babel/plugin-proposal-class-properties',
         {
-          "loose": true
+          loose: true
         }
       ],
-      "@babel/plugin-proposal-export-default-from",
-      "@babel/plugin-proposal-export-namespace-from",
+      '@babel/plugin-proposal-export-default-from',
+      '@babel/plugin-proposal-export-namespace-from',
       ...nodePlugins,
     ],
-    "env": {
-      "development": {
-        "plugins": [
-          "react-hot-loader/babel",
-          "@babel/plugin-transform-runtime"
+    env: {
+      development: {
+        plugins: [
+          'react-hot-loader/babel',
+          '@babel/plugin-transform-runtime'
         ]
       }
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,11 @@
 module.exports = {
-  "moduleNameMapper": {
+  moduleNameMapper: {
     // mock out the browser version of WASM bindings with the nodejs bindings
-    "cardano-wallet-browser": "cardano-wallet",
-    "\\.png$": "lodash/noop.js",
-    "pdfParser$": "lodash/noop.js",
+    'cardano-wallet-browser': 'cardano-wallet',
+    '\\.png$': 'lodash/noop.js',
+    pdfParser$: 'lodash/noop.js',
   },
-  "transformIgnorePatterns": [
-    "<rootDir>/node_modules/(?!yoroi-extension-ledger-bridge)"
+  transformIgnorePatterns: [
+    '<rootDir>/node_modules/(?!yoroi-extension-ledger-bridge)'
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,10 +1554,11 @@
       }
     },
     "@cardano-foundation/ledgerjs-hw-app-cardano": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-1.0.6.tgz",
-      "integrity": "sha512-XBC9VDo4q/cnbe1qlpSfu2ySR6ojvfocSEc0AuEgoi5mkjiY87OVbptT2HAYxqrYcfXfG3kcf7bzUFL0yrG3Mw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-1.0.7.tgz",
+      "integrity": "sha512-jiJrH2KNF4IQkEaYt14KUe+DrEdRwz1Mc6/1UOc55tlynI3ApHkxGzokjv/1GaJ5dkkcgWLDU9N5SZxXJAoGVA==",
       "requires": {
+        "@ledgerhq/hw-transport": "^4.35.0",
         "babel-polyfill": "^6.26.0",
         "babel-runtime": "^6.26.0",
         "base-x": "^3.0.5",
@@ -2268,6 +2269,36 @@
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^12.0.9"
       }
+    },
+    "@ledgerhq/devices": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-4.68.2.tgz",
+      "integrity": "sha512-vqdJ4nOjB3Q9O8SMtzbqn843mbqf+fOC3iYXdA88SNUujR70joGMZlyKE8LSQbLWhFnCm3SSjxWuHkgDpHOC+w==",
+      "requires": {
+        "@ledgerhq/errors": "^4.68.2",
+        "@ledgerhq/logs": "^4.68.2",
+        "rxjs": "^6.5.2"
+      }
+    },
+    "@ledgerhq/errors": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-4.68.2.tgz",
+      "integrity": "sha512-JxMr4wj/9d7EQuTQ9khhJxQSzv5B6ZoLUm4spOY+FDfQo0ywx9qvD1NyBHHVzyn7uRtWvz/hOSfTSrlw2joM3w=="
+    },
+    "@ledgerhq/hw-transport": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-4.68.2.tgz",
+      "integrity": "sha512-erGPXBXavw4V5CP2aG/04guPKJKJl50+Z3kl3PbI4RwUijVeWsCw3UwEyEor01AANJ480CwfGB8vhcRt4hkGeQ==",
+      "requires": {
+        "@ledgerhq/devices": "^4.68.2",
+        "@ledgerhq/errors": "^4.68.2",
+        "events": "^3.0.0"
+      }
+    },
+    "@ledgerhq/logs": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-4.68.2.tgz",
+      "integrity": "sha512-iFwGIzPmAMDvxVLtTvBUo0DCWz8vVaD0C4IsprNaXbxu+AsDmlc9kO9CKLB5YFEZblKNNKqJMJDfKvg5brIpTw=="
     },
     "@octokit/rest": {
       "version": "15.18.1",
@@ -15101,7 +15132,6 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16671,9 +16701,9 @@
       "dev": true
     },
     "trezor-connect": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-7.0.3.tgz",
-      "integrity": "sha512-1Y1ajCDF8dC5d2yrCUmVkNqXeOlucamQ6j6Ko7kaqNdge3g9KZ+O48jUwP/eGzei8oUvPZUHd7o4OhDHTlpLCw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-7.0.5.tgz",
+      "integrity": "sha512-cGHcNuO/kGVF6b1mp5VB/RwXcXwqZJDPLp3opx7vM+BQ8xB4oDAUdL+T8aCKRbDv6HwP/wvGwoaok/+9kYOPfA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "events": "^3.0.0",
@@ -18126,6 +18156,17 @@
         "events": "^2.0.0"
       },
       "dependencies": {
+        "@cardano-foundation/ledgerjs-hw-app-cardano": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-1.0.6.tgz",
+          "integrity": "sha512-XBC9VDo4q/cnbe1qlpSfu2ySR6ojvfocSEc0AuEgoi5mkjiY87OVbptT2HAYxqrYcfXfG3kcf7bzUFL0yrG3Mw==",
+          "requires": {
+            "babel-polyfill": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "base-x": "^3.0.5",
+            "node-int64": "^0.4.0"
+          }
+        },
         "events": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "ws": "7.1.1"
   },
   "dependencies": {
-    "@cardano-foundation/ledgerjs-hw-app-cardano": "1.0.6",
+    "@cardano-foundation/ledgerjs-hw-app-cardano": "1.0.7",
     "@download/blockies": "1.0.3",
     "aes-js": "3.1.2",
     "axios": "0.19.0",
@@ -168,7 +168,7 @@
     "route-parser": "0.0.5",
     "semver": "6.2.0",
     "tinycolor2": "1.4.1",
-    "trezor-connect": "7.0.3",
+    "trezor-connect": "7.0.5",
     "ua-parser-js": "0.7.20",
     "unorm": "1.6.0",
     "validator": "11.1.0",


### PR DESCRIPTION
Some misc fixed in this PR

1) Missing `await` in migration call
1) Update Trezor dependency so we can get rid of copy-pasted types
1) Change `jest.config.js` and `babel.config.js` so they match our `eslint` rules
1) Change derivation levels to use `0x80000000 + x` instead of `0x80000000 | x` because in Javascript using `|` transforms your number to an **signed** 32-bit integer but bip32 spec says you should use **unsigned**. Fortunately, the Rust codebase generates the same key regardless of which one we use.
1) Bump `@cardano-foundation/ledgerjs-hw-app-cardano` to fix lodash issue