### PR TITLE
Add browserlist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,4 @@
-last 2 chrome version
-last 2 ChromeAndroid version
-last 2 firefox version
-last 2 FirefoxAndroid version
+Firefox >= 67
+Chrome >= 69
+FirefoxAndroid >= 67
+ChromeAndroid >= 69

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+last 2 chrome version
+last 2 ChromeAndroid version
+last 2 firefox version
+last 2 FirefoxAndroid version


### PR DESCRIPTION
Right now we don't specify what browsers `babel` should perform transforms form. The **default behavior is to perform all transforms for es2015**. I tried restricting it to

```
last 2 chrome version
last 2 ChromeAndroid version
last 2 firefox version
last 2 FirefoxAndroid version
```

This reduces build size by 0.1MB and reduces build time by ~5 seconds (35 seconds => 30 seconds)

There's a certain danger with limiting the # of versions of Chrome & Firefox we support but it seems most people stay up-to-date. You can see the latest stats [here](https://caniuse.com/usage-table). Not sure if the benefits are worth the risk