### PR TITLE
Fix two Jest errors

### DIFF
--- a/app/api/ada/adaTransactions/adaNewTransactions.test.js
+++ b/app/api/ada/adaTransactions/adaNewTransactions.test.js
@@ -1,6 +1,7 @@
 
 // @flow
 import '../lib/test-config';
+import { schema } from 'lovefield';
 import type { UTXO, AdaAddress } from '../adaTypes';
 import {
   newAdaUnsignedTx,
@@ -11,6 +12,10 @@ import {
 import {
   NotEnoughMoneyToSendError,
 } from '../errors';
+
+import {
+  loadLovefieldDB,
+} from '../lib/storage/lovefieldDatabase';
 
 import { RustModule } from '../lib/cardanoCrypto/rustLoader';
 
@@ -76,6 +81,9 @@ const sampleAdaAddresses: Array<AdaAddress> = [
 
 beforeAll(async () => {
   await RustModule.load();
+  await loadLovefieldDB({
+    storeType: schema.DataStoreType.MEMORY,
+  });
 });
 
 describe('Create unsigned TX from UTXO', () => {

--- a/app/api/ada/adaWallet.test.js
+++ b/app/api/ada/adaWallet.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 // @flow
 import './lib/test-config';
+import { schema } from 'lovefield';
 import {
   isValidPaperMnemonic,
   unscramblePaperMnemonic
@@ -16,6 +17,9 @@ import { RustModule } from './lib/cardanoCrypto/rustLoader';
 import {
   silenceLogsForTesting,
 } from '../../utils/logging';
+import {
+  loadLovefieldDB,
+} from './lib/storage/lovefieldDatabase';
 
 const VALID_DD_PAPER = {
   words: 'fire shaft radar three ginger receive result phrase song staff scorpion food undo will have expire nice uncle dune until lift unlock exist step world slush disagree',
@@ -31,6 +35,9 @@ const UNEXPECTED_DD_ADDRESS =
 
 beforeAll(async () => {
   await RustModule.load();
+  await loadLovefieldDB({
+    storeType: schema.DataStoreType.MEMORY,
+  });
   silenceLogsForTesting();
 });
 

--- a/app/api/ada/daedalusTransfer.test.js
+++ b/app/api/ada/daedalusTransfer.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 // @flow
 import './lib/test-config';
+import { schema } from 'lovefield';
 import {
   getCryptoDaedalusWalletFromMnemonics,
 } from './lib/cardanoCrypto/cryptoWallet';
@@ -15,10 +16,17 @@ import {
   silenceLogsForTesting,
 } from '../../utils/logging';
 
+import {
+  loadLovefieldDB,
+} from './lib/storage/lovefieldDatabase';
+
 import { RustModule } from './lib/cardanoCrypto/rustLoader';
 
 beforeAll(async () => {
   await RustModule.load();
+  await loadLovefieldDB({
+    storeType: schema.DataStoreType.MEMORY,
+  });
   silenceLogsForTesting();
 });
 

--- a/app/api/ada/index.test.js
+++ b/app/api/ada/index.test.js
@@ -1,5 +1,6 @@
 // @flow
 import './lib/test-config';
+import { schema } from 'lovefield';
 import AdaApi from './index';
 import { RustModule } from './lib/cardanoCrypto/rustLoader';
 import {
@@ -11,8 +12,15 @@ import type {
   FilterUsedResponse,
 } from './lib/state-fetch/types';
 
+import {
+  loadLovefieldDB,
+} from './lib/storage/lovefieldDatabase';
+
 beforeAll(async () => {
   await RustModule.load();
+  await loadLovefieldDB({
+    storeType: schema.DataStoreType.MEMORY,
+  });
   silenceLogsForTesting();
 });
 

--- a/app/api/ada/lib/storage/lovefieldDatabase.js
+++ b/app/api/ada/lib/storage/lovefieldDatabase.js
@@ -1,7 +1,7 @@
 // Client-side database to avoid having to query Yoroi servers when state doesn't change
 
 // $FlowFixMe Flow doesn't like lovefield
-import lf, { Type } from 'lovefield';
+import lf, { Type, schema } from 'lovefield';
 import type {
   AdaAddress,
   AdaAddresses,
@@ -64,7 +64,11 @@ const txAddressesTableSchema = {
 let db;
 
 /** Ensure we are only creating a single instance of the lovefield database */
-export const loadLovefieldDB = () => {
+export const loadLovefieldDB = (
+  options = {
+    storeType: schema.DataStoreType.INDEXED_DB,
+  },
+) => {
   if (db) return Promise.resolve(db);
 
   const schemaBuilder = lf.schema.create('yoroi-schema', 1);
@@ -100,8 +104,7 @@ export const loadLovefieldDB = () => {
       ref: `${txsTableSchema.name}.${txsTableSchema.properties.id}`
     });
 
-  return schemaBuilder.connect(
-  ).then(newDb => {
+  return schemaBuilder.connect(options).then(newDb => {
     db = newDb;
     return db;
   });

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,7 @@ module.exports = {
   transformIgnorePatterns: [
     '<rootDir>/node_modules/(?!yoroi-extension-ledger-bridge)'
   ],
+  setupFiles: [
+    'jest-canvas-mock'
+  ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5226,6 +5226,12 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
+      "dev": true
+    },
     "cssom": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
@@ -9880,6 +9886,16 @@
         }
       }
     },
+    "jest-canvas-mock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.1.0.tgz",
+      "integrity": "sha512-1yWLNr6xcmhmADLc5ITOYjXnNl2EWUDlXYpplYqgGdATgZaP8IBp241ihVIfrORM8AhuZW8PXRPdzWBEQOpjBQ==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "parse-color": "^1.0.0"
+      }
+    },
     "jest-changed-files": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
@@ -13619,6 +13635,23 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
+      "dev": true,
+      "requires": {
+        "color-convert": "~0.5.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
+          "dev": true
+        }
       }
     },
     "parse-entities": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "html-webpack-plugin": "4.0.0-beta.8",
     "husky": "3.0.1",
     "jest": "24.8.0",
+    "jest-canvas-mock": "2.1.0",
     "json-server": "0.15.0",
     "markdown-loader": "5.0.0",
     "minimist": "1.2.0",


### PR DESCRIPTION
Two Jest errors. Both are caused by Jest running as a node application which behaves differently from browsers (which we use for production builds)

# Unable to run Lovefield DB queries
```
(node:67929) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'getSchema' of undefined
```

Two reasons for this error:
1) Jest tests weren't calling `loadLovefieldDB` (meaning table queries were all failing)
2) Jest runs in `node` mode which can't use `IndexDB`. Have to instead use `Memory` mode (which runs in memory)

# Unable to mock canvas

```
 Error: Not implemented: HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)
```

This is caused by `jspdf` usage which tries to access the canvas. We don't use the pdf  in the actual test so we just mock it out.