### PR TITLE
Flow server.max_workers fix

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,6 +19,7 @@
 flow/declarations/
 
 [options]
+server.max_workers=1
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable


### PR DESCRIPTION
Flow often fails on CI recently with the error

```
Lost connection to the flow server (0 retries remaining): -Out of retries, exiting!
```

We fixed it on mobile [here](https://github.com/Emurgo/yoroi-mobile/commit/56537cfb9b48a5b3f3a432ac63184e996b9b5e60) so I'm simply porting the fix.

This makes starting the Flow server slower unfortunately (but once it's started it doesn't feel any slower)