### PR TITLE
PEM instructions

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -46,9 +46,10 @@ To build production versions of Yoroi that run on `testnet` (or any other networ
 Although the real `pem` is not uploaded to Github for security reasons, you can generate your own `pem` for testing purposes using the following steps:
 
 ```
-openssl genrsa -out temp.pem 2048
-openssl pkcs8 -topk8 -nocrypt -in temp.pem -out your-key-name-here.pem
-rm temp.pem
+npm run compress-keygen
+mv key.pem testnet.pem
+npm run compress-keygen
+mv key.pem mainnet.pem
 ```
 
 Notably, I  recommend running this for `testnet` and `mainnet`.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -40,6 +40,19 @@ To install other Yoroi-frontend related dependencies use:
 $ npm install
 ```
 
+### Generating PEMs
+
+To build production versions of Yoroi that run on `testnet` (or any other network) you need a `pem` file (basically a key to sign your extension).
+Although the real `pem` is not uploaded to Github for security reasons, you can generate your own `pem` for testing purposes using the following steps:
+
+```
+openssl genrsa -out temp.pem 2048
+openssl pkcs8 -topk8 -nocrypt -in temp.pem -out your-key-name-here.pem
+rm temp.pem
+```
+
+Notably, I  recommend running this for `testnet` and `mainnet`.
+
 ### Firefox
 
 Adding unsigned extensions is not supported for the regular version of Firefox.


### PR DESCRIPTION
If you don't follow these steps, `npm run build-compress` will fail saying you're missing a `testnet.pem`