### PR TITLE
Fixing input labels on Modern Theme

### DIFF
--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -262,7 +262,7 @@ export default {
   '--theme-dialog-big-button-description-color': '#353535',
   '--theme-dialog-title-color': '#2b2c32',
   '--theme-dialog-title-margin': '0 0 38px 0',
-  '--theme-dialog-input-margin': '2px 0 24px 0',
+  '--theme-dialog-input-margin': '10px 0 24px 0',
   '--theme-dialog-input-actions-margin': '34px 0 0 0',
 
   '--theme-main-body-background-color': '#ffffff',


### PR DESCRIPTION
Story:
https://app.clubhouse.io/emurgo/story/1878/input-label-is-not-fully-displayed-at-some-places

Input labels are not displayed correctly after the merge of #848 and #517 . The first one was considering space from input labels to sum up into a padding of 10px. The latter doesn't have this space anymore as labels are inside the input. Increasing the space to 10px solves it.

Before merging:
<img width="574" alt="label_spacing_before" src="https://user-images.githubusercontent.com/1937074/62560926-f6094d80-b875-11e9-8f91-a96467901875.png">

After merging (bug):
<img width="578" alt="label_spacing_bug" src="https://user-images.githubusercontent.com/1937074/62560933-f9043e00-b875-11e9-90b1-cdd5b18a66bb.png">

After fix:
<img width="590" alt="label_spacing_updated" src="https://user-images.githubusercontent.com/1937074/62560942-fdc8f200-b875-11e9-8a8a-3b2f41f4e371.png">

<img width="573" alt="label_spacing_after" src="https://user-images.githubusercontent.com/1937074/62560948-00c3e280-b876-11e9-8345-adb1e7e51c26.png">