### PR TITLE
Fix password input spacing for create/restore dialogs in Classic theme

### DIFF
--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -226,7 +226,6 @@ export default class WalletCreateDialog extends Component<Props, State> {
               error={repeatedPasswordField.error}
               skin={InputOwnSkin}
             />
-            <div />
           </div>
         </div>
 

--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -38,6 +38,10 @@
       & > div {
         margin-top: 0;
       }
+
+      :global .walletPassword {
+        margin-right: 25px;
+      }
   
       @include place-form-field-error-below-input;
     }

--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -39,6 +39,9 @@
         margin-top: 0;
       }
 
+      // Seems like this is the same class name as parent, but it's different.
+      // This class will apply to the child Input tag.
+      // Unfortunately for fixing this problem we also need to carefully fix basic E2E cases, as its used there.
       :global .walletPassword {
         margin-right: 25px;
       }

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -428,7 +428,6 @@ export default class WalletRestoreDialog extends Component<Props> {
                 error={repeatedPasswordField.error}
                 skin={InputOwnSkin}
               />
-              <div />
             </div>
           </div>
         )}

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -57,6 +57,10 @@
           margin-top: 0;
           width: 350px;
         }
+
+        :global .walletPassword {
+          margin-right: 25px;
+        }
     
         @include place-form-field-error-below-input;
       }

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -58,6 +58,9 @@
           width: 350px;
         }
 
+        // Seems like this is the same class name as parent, but it's different.
+        // This class will apply to the child Input tag.
+        // Unfortunately for fixing this problem we also need to carefully fix basic E2E cases, as its used there.
         :global .walletPassword {
           margin-right: 25px;
         }


### PR DESCRIPTION
After the password instructions component was removed (#852 ), the password inputs in the create/restore dialog were not displaying correctly in Classic theme:

<img width="783" alt="create_nofix" src="https://user-images.githubusercontent.com/1937074/62565538-e6dacd80-b87e-11e9-9e55-c7a2c66936e0.png">

There was a quick fix which consisted in adding an empty div, but this adds extra space in Modern theme:

After quick fix:
<img width="799" alt="create_classic_after_fix" src="https://user-images.githubusercontent.com/1937074/62565259-59977900-b87e-11e9-8656-a8ec4e31c7f2.png">

<img width="574" alt="Screen Shot 2019-08-06 at 5 45 05 PM" src="https://user-images.githubusercontent.com/1937074/62565292-6916c200-b87e-11e9-94e4-08da95e4bc93.png">

After new fix:
<img width="800" alt="create_classic_after" src="https://user-images.githubusercontent.com/1937074/62565332-792ea180-b87e-11e9-8617-6c75b526df07.png">

<img width="575" alt="create_modern_after" src="https://user-images.githubusercontent.com/1937074/62565339-7e8bec00-b87e-11e9-86c9-79c34d3f84b8.png">
