### PR TITLE
shin/ch1887/test-new-react-polymorph 

### DIFF
--- a/app/components/uri/URIGenerateDialog.js
+++ b/app/components/uri/URIGenerateDialog.js
@@ -18,7 +18,6 @@ import globalMessages from '../../i18n/global-messages';
 import type { TokenRow } from '../../api/ada/lib/storage/database/primitives/tables';
 import { formattedAmountToNaturalUnits } from '../../utils/formatters';
 import config from '../../config';
-import { calcMaxBeforeDot } from '../../utils/validations';
 import { getTokenName } from '../../stores/stateless/tokenHelpers';
 
 import styles from './URIGenerateDialog.scss';
@@ -83,14 +82,13 @@ export default class URIGenerateDialog extends Component<Props> {
       amount: {
         label: this.getAmountLabel(),
         placeholder: `0.${'0'.repeat(this.props.tokenInfo.Metadata.numberOfDecimals)}`,
-        value: '',
+        value: null,
         validators: [async ({ field }) => {
-          const amountValue = field.value;
-          if (amountValue === '') {
+          if (field.value === null) {
             return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           }
           const formattedAmount = formattedAmountToNaturalUnits(
-            amountValue,
+            field.value.toString(),
             this.props.tokenInfo.Metadata.numberOfDecimals
           );
           return await this.props.validateAmount(formattedAmount, this.props.tokenInfo);
@@ -158,8 +156,9 @@ export default class URIGenerateDialog extends Component<Props> {
               {...amountField.bind()}
               label={this.getAmountLabel()}
               error={amountField.error}
-              maxBeforeDot={calcMaxBeforeDot(this.props.tokenInfo.Metadata.numberOfDecimals)}
-              maxAfterDot={this.props.tokenInfo.Metadata.numberOfDecimals}
+              numberLocaleOptions={{
+                minimumFractionDigits: this.props.tokenInfo.Metadata.numberOfDecimals,
+              }}
               skin={InputOwnSkin}
               done={amountField.isValid}
               classicTheme={classicTheme}

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -11,7 +11,7 @@ import { NumericInput } from 'react-polymorph/lib/components/NumericInput';
 import { Checkbox } from 'react-polymorph/lib/components/Checkbox';
 import { CheckboxSkin } from 'react-polymorph/lib/skins/simple/CheckboxSkin';
 import { defineMessages, intlShape } from 'react-intl';
-import { isValidMemoOptional, isValidMemo, calcMaxBeforeDot } from '../../../utils/validations';
+import { isValidMemoOptional, isValidMemo, } from '../../../utils/validations';
 import ReactToolboxMobxForm from '../../../utils/ReactToolboxMobxForm';
 import vjf from 'mobx-react-form/lib/validators/VJF';
 import AmountInputSkin from '../skins/AmountInputSkin';
@@ -202,20 +202,20 @@ export default class WalletSendForm extends Component<Props> {
             ? formatValue(
               this.props.uriParams.amount.getDefaultEntry(),
             )
-            : ''
+            : null
         })(),
         validators: [async ({ field }) => {
           if (this.props.shouldSendAll) {
             // sendall doesn't depend on the amount so always succeed
             return true;
           }
-          const amountValue = field.value;
-          if (amountValue === '') {
+
+          if (field.value === null) {
             this.props.updateAmount();
             return [false, this.context.intl.formatMessage(globalMessages.fieldIsRequired)];
           }
           const formattedAmount = formattedAmountToNaturalUnits(
-            amountValue,
+            field.value.toString(),
             this.props.defaultToken.Metadata.numberOfDecimals,
           );
           const isValidAmount = await this.props.validateAmount(
@@ -336,8 +336,9 @@ export default class WalletSendForm extends Component<Props> {
               {...amountFieldProps}
               className="amount"
               label={intl.formatMessage(globalMessages.amountLabel)}
-              maxBeforeDot={calcMaxBeforeDot(this.props.defaultToken.Metadata.numberOfDecimals)}
-              maxAfterDot={this.props.defaultToken.Metadata.numberOfDecimals}
+              numberLocaleOptions={{
+                minimumFractionDigits: this.props.defaultToken.Metadata.numberOfDecimals,
+              }}
               disabled={this.props.shouldSendAll}
               error={(transactionFeeError || amountField.error)}
               // AmountInputSkin props

--- a/app/components/wallet/staking/DelegationTxDialog.js
+++ b/app/components/wallet/staking/DelegationTxDialog.js
@@ -22,7 +22,6 @@ import RawHash from '../../widgets/hashWrappers/RawHash';
 import { SelectedExplorer } from '../../../domain/SelectedExplorer';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import SpendingPasswordInput from '../../widgets/forms/SpendingPasswordInput';
-import { calcMaxBeforeDot } from '../../../utils/validations';
 import {
   MultiToken,
 } from '../../../api/common/lib/MultiToken';
@@ -201,16 +200,11 @@ export default class DelegationTxDialog extends Component<Props> {
           <NumericInput
             className="amount"
             label={intl.formatMessage(globalMessages.amountLabel)}
-            maxBeforeDot={calcMaxBeforeDot(
-              this.props.getTokenInfo(
+            numberLocaleOptions={{
+              minimumFractionDigits: this.props.getTokenInfo(
                 this.props.amountToDelegate.getDefaultEntry()
-              ).Metadata.numberOfDecimals
-            )}
-            maxAfterDot={
-              this.props.getTokenInfo(
-                this.props.amountToDelegate.getDefaultEntry()
-              ).Metadata.numberOfDecimals
-            }
+              ).Metadata.numberOfDecimals,
+            }}
             disabled
             // AmountInputSkin props
             currency={getTokenName(
@@ -222,7 +216,7 @@ export default class DelegationTxDialog extends Component<Props> {
             // note: we purposely don't put "total" since it doesn't really make sense here
             // since the fee is unrelated to the amount you're about to stake
             total=""
-            value={formatValue(this.props.amountToDelegate.getDefaultEntry())}
+            value={this.props.amountToDelegate.getDefaultEntry().amount.toNumber()}
             skin={AmountInputSkin}
             classicTheme={this.props.classicTheme}
           />

--- a/app/components/wallet/voting/VotingRegTxDialog.js
+++ b/app/components/wallet/voting/VotingRegTxDialog.js
@@ -23,7 +23,6 @@ import { NumericInput } from 'react-polymorph/lib/components/NumericInput';
 import {
   MultiToken,
 } from '../../../api/common/lib/MultiToken';
-import { calcMaxBeforeDot, } from '../../../utils/validations';
 import type {
   TokenLookupKey,
 } from '../../../api/common/lib/MultiToken';
@@ -148,8 +147,9 @@ export default class VotingRegTxDialog extends Component<Props> {
           <NumericInput
             className="amount"
             label={intl.formatMessage(globalMessages.amountLabel)}
-            maxBeforeDot={calcMaxBeforeDot(tokenInfo.Metadata.numberOfDecimals)}
-            maxAfterDot={tokenInfo.Metadata.numberOfDecimals}
+            numberLocaleOptions={{
+              minimumFractionDigits: tokenInfo.Metadata.numberOfDecimals,
+            }}
             disabled
             // AmountInputSkin props
             currency={getTokenName(tokenInfo)}
@@ -157,8 +157,7 @@ export default class VotingRegTxDialog extends Component<Props> {
             // note: we purposely don't put "total" since it doesn't really make sense here
             // since the fee is unrelated to the amount you're about to stake
             total=""
-            value={new BigNumber(0).toFormat(tokenInfo.Metadata.numberOfDecimals)
-            }
+            value={new BigNumber(0).toNumber()}
             skin={AmountInputSkin}
             classicTheme={this.props.classicTheme}
           />

--- a/app/utils/formatters.js
+++ b/app/utils/formatters.js
@@ -27,9 +27,12 @@ export const formattedAmountWithoutLovelace = (amount: BigNumber): string => (
 );
 
 /** removes commas */
-export const formattedAmountToBigNumber = (amount: string): BigNumber => {
-  const cleanedAmount = amount.replace(/,/g, '');
-  return new BigNumber(cleanedAmount !== '' ? cleanedAmount : 0);
+export const formattedAmountToBigNumber: string => BigNumber = (amount) => {
+  try {
+    return new BigNumber(amount);
+  } catch (error) {
+    return new BigNumber(0);
+  }
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -25546,8 +25546,9 @@
       }
     },
     "react-polymorph": {
-      "version": "git+https://github.com/rcmorano/react-polymorph-fix.git#ccd0cf94f947960dbdf6a0aab28a049ef1bd551b",
-      "from": "git+https://github.com/rcmorano/react-polymorph-fix.git",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/react-polymorph/-/react-polymorph-0.9.1.tgz",
+      "integrity": "sha512-3tk70sOD1lQ7n49uAw/N8yLGSLXHVNj7Mhjy+PYwSkQimzmrnGTO0FOAp0FEqOY/6V6xIDYT2xi6HTe6OFicSg==",
       "requires": {
         "create-react-context": "0.2.2",
         "create-react-ref": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "react-dom": "16.13.1",
     "react-intl": "2.9.0",
     "react-markdown": "5.0.3",
-    "react-polymorph": "git+https://github.com/rcmorano/react-polymorph-fix.git",
+    "react-polymorph": "0.9.1",
     "react-resize-detector": "5.2.0",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",


### PR DESCRIPTION
Story:
https://app.clubhouse.io/emurgo/story/1887/test-new-react-polymorph

**This PR should not be merged as its just for testing purpose.** 

## List of differences
**1. Crashing on typing in Input box**
![image](https://user-images.githubusercontent.com/19986226/62759495-67d2d880-babc-11e9-93d5-4ed53223bce9.png)

**Cause:**
`NumericInput.value` return type changed
Before: `string` 
Now: `number`

**2. Different style**
![image](https://user-images.githubusercontent.com/19986226/62761213-03fede80-bac1-11e9-837b-5382c1086a0b.png)

**3. Maximum Lovelace digits input count has been changed**
Before: **6 digits**
Now: **3 digits**
A
![image](https://user-images.githubusercontent.com/19986226/62762434-0d3d7a80-bac4-11e9-9a2d-30bc9eff91c6.png)


B
![image](https://user-images.githubusercontent.com/19986226/62762493-3231ed80-bac4-11e9-8fee-7527c00e1915.png)

**4. Number of input digits has been changed before decimal place**
Before: could enter **11 digits** before decimal place
After: could enter **12 digits** before decimal place
![image](https://user-images.githubusercontent.com/19986226/62763644-0b28eb00-bac7-11e9-890b-b90357ae33c6.png)

**5. Crashing on typing `.`(dot)**
![image](https://user-images.githubusercontent.com/19986226/62764658-60fe9280-bac9-11e9-8150-9737e8e97539.png)
**Cause:**
`NumericInput.value` return type changed
Before: `0.000000` 
Now: `.`

## Note
Could not reproduce https://github.com/input-output-hk/react-polymorph/issues/112 (movement of cursor to the left )
**But if you type any non digit characters(i.e. except 1,2,3,4,5,6,7,8,9,0) two times then cursor goes to right most**
