### PR TITLE
Rename Bip44Derivation

### DIFF
--- a/app/api/ada/lib/storage/bridge/walletBuilder.js
+++ b/app/api/ada/lib/storage/bridge/walletBuilder.js
@@ -14,7 +14,7 @@ import {
 import type {
   Bip44WrapperInsert,
   PublicDeriverRow,
-  Bip44DerivationRow,
+  KeyDerivationRow,
 } from '../database/genericBip44/tables';
 import {
   AddBip44Wrapper,
@@ -297,7 +297,7 @@ type HasPublicDeriver<Row> = {
   publicDeriver: Array<{
     publicDeriverResult: PublicDeriverRow,
     levelResult: {
-      Bip44Derivation: Bip44DerivationRow,
+      KeyDerivation: KeyDerivationRow,
       specificDerivationResult: Row
     }
   }>,

--- a/app/api/ada/lib/storage/database/genericBip44/api/get.js
+++ b/app/api/ada/lib/storage/database/genericBip44/api/get.js
@@ -8,7 +8,7 @@ import type {
 import { op } from 'lovefield';
 
 import type {
-  Bip44DerivationRow,
+  KeyDerivationRow,
   Bip44WrapperRow,
   PublicDeriverRow,
   PrivateDeriverRow,
@@ -28,7 +28,7 @@ export class GetDerivation {
     [Tables.Bip44AccountSchema.name]: Tables.Bip44AccountSchema,
     [Tables.Bip44ChainSchema.name]: Tables.Bip44ChainSchema,
     [Tables.Bip44AddressSchema.name]: Tables.Bip44AddressSchema,
-    [Tables.Bip44DerivationSchema.name]: Tables.Bip44DerivationSchema,
+    [Tables.KeyDerivationSchema.name]: Tables.KeyDerivationSchema,
   });
   static depTables = Object.freeze({});
 
@@ -45,7 +45,7 @@ export class GetDerivation {
     return await getRowIn<Row>(
       db, tx,
       tableName,
-      GetDerivation.ownTables[Tables.Bip44DerivationSchema.name].properties.Bip44DerivationId,
+      GetDerivation.ownTables[Tables.KeyDerivationSchema.name].properties.KeyDerivationId,
       derivationIds,
     );
   }
@@ -53,7 +53,7 @@ export class GetDerivation {
 
 export class GetChildIfExists {
   static ownTables = Object.freeze({
-    [Tables.Bip44DerivationSchema.name]: Tables.Bip44DerivationSchema,
+    [Tables.KeyDerivationSchema.name]: Tables.KeyDerivationSchema,
   });
   static depTables = Object.freeze({});
 
@@ -62,8 +62,8 @@ export class GetChildIfExists {
     tx: lf$Transaction,
     parentId: number,
     childIndex: number,
-  ): Promise<void | Bip44DerivationRow> {
-    const derivationSchema = GetChildIfExists.ownTables[Tables.Bip44DerivationSchema.name];
+  ): Promise<void | KeyDerivationRow> {
+    const derivationSchema = GetChildIfExists.ownTables[Tables.KeyDerivationSchema.name];
 
     const derivationTable = db.getSchema().table(derivationSchema.name);
     const conditions: Array<lf$Predicate> = [
@@ -76,7 +76,7 @@ export class GetChildIfExists {
       .from(derivationTable)
       .where(op.and(...conditions));
 
-    const queryResult: Array<Bip44DerivationRow> = await tx.attach(query);
+    const queryResult: Array<KeyDerivationRow> = await tx.attach(query);
 
     return queryResult.length === 1
       ? queryResult[0]
@@ -93,7 +93,7 @@ type PathMapType = Map<number, Array<number>>;
 
 export class GetDerivationsByPath {
   static ownTables = Object.freeze({
-    [Tables.Bip44DerivationSchema.name]: Tables.Bip44DerivationSchema,
+    [Tables.KeyDerivationSchema.name]: Tables.KeyDerivationSchema,
   });
   static depTables = Object.freeze({});
 
@@ -126,7 +126,7 @@ const _getDerivationsByPath = async (
   if (currPathIndex === queryPath.length) {
     return pathMap;
   }
-  const derivationSchema = GetDerivationsByPath.ownTables[Tables.Bip44DerivationSchema.name];
+  const derivationSchema = GetDerivationsByPath.ownTables[Tables.KeyDerivationSchema.name];
 
   const derivationTable = db.getSchema().table(derivationSchema.name);
   const conditions = [
@@ -148,14 +148,14 @@ const _getDerivationsByPath = async (
     .from(derivationTable)
     .where(op.and(...conditions));
 
-  const queryResult: Array<Bip44DerivationRow> = await tx.attach(query);
+  const queryResult: Array<KeyDerivationRow> = await tx.attach(query);
   const nextPathMap = new Map(queryResult.map(row => {
     if (row.Parent == null) throw new Error('genericBip44::_getDerivationsByPath Should never happen');
     const path = pathMap.get(row.Parent);
     if (path == null) throw new Error('genericBip44::_getDerivationsByPath Should never happen');
     if (row.Index === null) throw new Error('genericBip44::_getDerivationsByPath null child index');
     return [
-      row.Bip44DerivationId,
+      row.KeyDerivationId,
       path.concat([row.Index])
     ];
   }));
@@ -233,9 +233,9 @@ export class GetBip44Wrapper {
   }
 }
 
-export class GetBip44Derivation {
+export class GetKeyDerivation {
   static ownTables = Object.freeze({
-    [Tables.Bip44DerivationSchema.name]: Tables.Bip44DerivationSchema,
+    [Tables.KeyDerivationSchema.name]: Tables.KeyDerivationSchema,
   });
   static depTables = Object.freeze({});
 
@@ -243,12 +243,12 @@ export class GetBip44Derivation {
     db: lf$Database,
     tx: lf$Transaction,
     key: number,
-  ): Promise<Bip44DerivationRow | void> {
-    return await getRowFromKey<Bip44DerivationRow>(
+  ): Promise<KeyDerivationRow | void> {
+    return await getRowFromKey<KeyDerivationRow>(
       db, tx,
       key,
-      GetBip44Derivation.ownTables[Tables.Bip44DerivationSchema.name].name,
-      GetBip44Derivation.ownTables[Tables.Bip44DerivationSchema.name].properties.Bip44DerivationId,
+      GetKeyDerivation.ownTables[Tables.KeyDerivationSchema.name].name,
+      GetKeyDerivation.ownTables[Tables.KeyDerivationSchema.name].properties.KeyDerivationId,
     );
   }
 }

--- a/app/api/ada/lib/storage/database/genericBip44/tables.js
+++ b/app/api/ada/lib/storage/database/genericBip44/tables.js
@@ -7,23 +7,23 @@ import {
 import { Type } from 'lovefield';
 import type { lf$schema$Builder } from 'lovefield';
 
-export type Bip44DerivationInsert = {|
+export type KeyDerivationInsert = {|
   PublicKeyId: number | null,
   PrivateKeyId: number | null,
   Parent: number | null,
   Index: number | null,
 |};
-export type Bip44DerivationRow = {|
-  Bip44DerivationId: number, // serial
-  ...Bip44DerivationInsert,
+export type KeyDerivationRow = {|
+  KeyDerivationId: number, // serial
+  ...KeyDerivationInsert,
 |};
-export const Bip44DerivationSchema: {
-  +name: 'Bip44Derivation',
-  properties: $ObjMapi<Bip44DerivationRow, ToSchemaProp>
+export const KeyDerivationSchema: {
+  +name: 'KeyDerivation',
+  properties: $ObjMapi<KeyDerivationRow, ToSchemaProp>
 } = {
-  name: 'Bip44Derivation',
+  name: 'KeyDerivation',
   properties: {
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
     PrivateKeyId: 'PrivateKeyId',
     PublicKeyId: 'PublicKeyId',
     Parent: 'Parent',
@@ -59,7 +59,7 @@ export const Bip44WrapperSchema: {
 
 export type PrivateDeriverInsert = {|
   Bip44WrapperId: number,
-  Bip44DerivationId: number,
+  KeyDerivationId: number,
   Level: number,
 |};
 export type PrivateDeriverRow = {|
@@ -74,13 +74,13 @@ export const PrivateDeriverSchema: {
   properties: {
     PrivateDeriverId: 'PrivateDeriverId',
     Bip44WrapperId: 'Bip44WrapperId',
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
     Level: 'Level',
   }
 };
 
 export type PublicDeriverInsert = {|
-  Bip44DerivationId: number,
+  KeyDerivationId: number,
   Name: string,
   LastBlockSync: number,
 |};
@@ -95,14 +95,14 @@ export const PublicDeriverSchema: {
   name: 'PublicDeriver',
   properties: {
     PublicDeriverId: 'PublicDeriverId',
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
     Name: 'Name',
     LastBlockSync: 'LastBlockSync',
   }
 };
 
 export type Bip44RootInsert = {|
-  Bip44DerivationId: number,
+  KeyDerivationId: number,
 |};
 export type Bip44RootRow = {|
   Bip44RootId: number,
@@ -115,11 +115,11 @@ export const Bip44RootSchema: {
   name: 'Bip44Root',
   properties: {
     Bip44RootId: 'Bip44RootId',
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
   }
 };
 export type Bip44PurposeInsert = {|
-  Bip44DerivationId: number,
+  KeyDerivationId: number,
 |};
 export type Bip44PurposeRow = {|
   Bip44PurposeId: number,
@@ -132,11 +132,11 @@ export const Bip44PurposeSchema: {
   name: 'Bip44Purpose',
   properties: {
     Bip44PurposeId: 'Bip44PurposeId',
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
   }
 };
 export type Bip44CoinTypeInsert = {|
-  Bip44DerivationId: number,
+  KeyDerivationId: number,
 |};
 export type Bip44CoinTypeRow = {|
   Bip44CoinTypeId: number,
@@ -149,11 +149,11 @@ export const Bip44CoinTypeSchema: {
   name: 'Bip44CoinType',
   properties: {
     Bip44CoinTypeId: 'Bip44CoinTypeId',
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
   }
 };
 export type Bip44AccountInsert = {|
-  Bip44DerivationId: number,
+  KeyDerivationId: number,
 |};
 export type Bip44AccountRow = {|
   Bip44AccountId: number,
@@ -166,11 +166,11 @@ export const Bip44AccountSchema: {
   name: 'Bip44Account',
   properties: {
     Bip44AccountId: 'Bip44AccountId',
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
   }
 };
 export type Bip44ChainInsert = {|
-  Bip44DerivationId: number,
+  KeyDerivationId: number,
   LastReceiveIndex: number | null,
 |};
 export type Bip44ChainRow = {|
@@ -184,12 +184,12 @@ export const Bip44ChainSchema: {
   name: 'Bip44Chain',
   properties: {
     Bip44ChainId: 'Bip44ChainId',
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
     LastReceiveIndex: 'LastReceiveIndex',
   }
 };
 export type Bip44AddressInsert = {|
-  Bip44DerivationId: number,
+  KeyDerivationId: number,
   Hash: string,
 |};
 export type Bip44AddressRow = {|
@@ -203,41 +203,41 @@ export const Bip44AddressSchema: {
   name: 'Bip44Address',
   properties: {
     Bip44AddressId: 'Bip44AddressId',
-    Bip44DerivationId: 'Bip44DerivationId',
+    KeyDerivationId: 'KeyDerivationId',
     Hash: 'Hash',
   }
 };
 
 /** Ensure we are only creating a single instance of the lovefield database */
 export const populateBip44Db = (schemaBuilder: lf$schema$Builder) => {
-  // Bip44Derivation Table
-  schemaBuilder.createTable(Bip44DerivationSchema.name)
-    .addColumn(Bip44DerivationSchema.properties.Bip44DerivationId, Type.INTEGER)
-    .addColumn(Bip44DerivationSchema.properties.PrivateKeyId, Type.INTEGER)
-    .addColumn(Bip44DerivationSchema.properties.PublicKeyId, Type.INTEGER)
-    .addColumn(Bip44DerivationSchema.properties.Parent, Type.INTEGER)
-    .addColumn(Bip44DerivationSchema.properties.Index, Type.INTEGER)
+  // KeyDerivation Table
+  schemaBuilder.createTable(KeyDerivationSchema.name)
+    .addColumn(KeyDerivationSchema.properties.KeyDerivationId, Type.INTEGER)
+    .addColumn(KeyDerivationSchema.properties.PrivateKeyId, Type.INTEGER)
+    .addColumn(KeyDerivationSchema.properties.PublicKeyId, Type.INTEGER)
+    .addColumn(KeyDerivationSchema.properties.Parent, Type.INTEGER)
+    .addColumn(KeyDerivationSchema.properties.Index, Type.INTEGER)
     .addPrimaryKey(
-      ([Bip44DerivationSchema.properties.Bip44DerivationId]: Array<string>),
+      ([KeyDerivationSchema.properties.KeyDerivationId]: Array<string>),
       true
     )
     .addForeignKey('Bip44Derivation_Parent', {
-      local: Bip44DerivationSchema.properties.Parent,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: KeyDerivationSchema.properties.Parent,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     })
     .addForeignKey('Bip44Derivation_PrivateKeyId', {
-      local: Bip44DerivationSchema.properties.PrivateKeyId,
+      local: KeyDerivationSchema.properties.PrivateKeyId,
       ref: `${KeySchema.name}.${KeySchema.properties.KeyId}`
     })
     .addForeignKey('Bip44Derivation_PublicKeyId', {
-      local: Bip44DerivationSchema.properties.PublicKeyId,
+      local: KeyDerivationSchema.properties.PublicKeyId,
       ref: `${KeySchema.name}.${KeySchema.properties.KeyId}`
     })
     .addNullable([
-      Bip44DerivationSchema.properties.PrivateKeyId,
-      Bip44DerivationSchema.properties.PublicKeyId,
-      Bip44DerivationSchema.properties.Parent,
-      Bip44DerivationSchema.properties.Index,
+      KeyDerivationSchema.properties.PrivateKeyId,
+      KeyDerivationSchema.properties.PublicKeyId,
+      KeyDerivationSchema.properties.Parent,
+      KeyDerivationSchema.properties.Index,
     ]);
 
   // Bip44Wrapper Table
@@ -264,7 +264,7 @@ export const populateBip44Db = (schemaBuilder: lf$schema$Builder) => {
   schemaBuilder.createTable(PrivateDeriverSchema.name)
     .addColumn(PrivateDeriverSchema.properties.PrivateDeriverId, Type.INTEGER)
     .addColumn(PrivateDeriverSchema.properties.Bip44WrapperId, Type.INTEGER)
-    .addColumn(PrivateDeriverSchema.properties.Bip44DerivationId, Type.INTEGER)
+    .addColumn(PrivateDeriverSchema.properties.KeyDerivationId, Type.INTEGER)
     .addColumn(PrivateDeriverSchema.properties.Level, Type.INTEGER)
     .addPrimaryKey(
       ([PrivateDeriverSchema.properties.PrivateDeriverId]: Array<string>),
@@ -275,14 +275,14 @@ export const populateBip44Db = (schemaBuilder: lf$schema$Builder) => {
       ref: `${Bip44WrapperSchema.name}.${Bip44WrapperSchema.properties.Bip44WrapperId}`
     })
     .addForeignKey('PrivateDeriver_Bip44Derivation', {
-      local: PrivateDeriverSchema.properties.Bip44DerivationId,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: PrivateDeriverSchema.properties.KeyDerivationId,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     });
 
   // PublicDeriver
   schemaBuilder.createTable(PublicDeriverSchema.name)
     .addColumn(PublicDeriverSchema.properties.PublicDeriverId, Type.INTEGER)
-    .addColumn(PublicDeriverSchema.properties.Bip44DerivationId, Type.INTEGER)
+    .addColumn(PublicDeriverSchema.properties.KeyDerivationId, Type.INTEGER)
     .addColumn(PublicDeriverSchema.properties.Name, Type.STRING)
     .addColumn(PublicDeriverSchema.properties.LastBlockSync, Type.INTEGER)
     .addPrimaryKey(
@@ -290,70 +290,70 @@ export const populateBip44Db = (schemaBuilder: lf$schema$Builder) => {
       true
     )
     .addForeignKey('PublicDeriver_Bip44Derivation', {
-      local: PublicDeriverSchema.properties.Bip44DerivationId,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: PublicDeriverSchema.properties.KeyDerivationId,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     });
 
   // Bip44Root
   schemaBuilder.createTable(Bip44RootSchema.name)
     .addColumn(Bip44RootSchema.properties.Bip44RootId, Type.INTEGER)
-    .addColumn(Bip44RootSchema.properties.Bip44DerivationId, Type.INTEGER)
+    .addColumn(Bip44RootSchema.properties.KeyDerivationId, Type.INTEGER)
     .addPrimaryKey(
       ([Bip44RootSchema.properties.Bip44RootId]: Array<string>),
       true
     )
     .addForeignKey('Bip44Root_Bip44Derivation', {
-      local: Bip44RootSchema.properties.Bip44DerivationId,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: Bip44RootSchema.properties.KeyDerivationId,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     });
   // Bip44Purpose
   schemaBuilder.createTable(Bip44PurposeSchema.name)
     .addColumn(Bip44PurposeSchema.properties.Bip44PurposeId, Type.INTEGER)
-    .addColumn(Bip44PurposeSchema.properties.Bip44DerivationId, Type.INTEGER)
+    .addColumn(Bip44PurposeSchema.properties.KeyDerivationId, Type.INTEGER)
     .addPrimaryKey(
       ([Bip44PurposeSchema.properties.Bip44PurposeId]: Array<string>),
       true
     )
     .addForeignKey('Bip44Purpose_Bip44Derivation', {
-      local: Bip44PurposeSchema.properties.Bip44DerivationId,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: Bip44PurposeSchema.properties.KeyDerivationId,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     });
   // Bip44CoinType
   schemaBuilder.createTable(Bip44CoinTypeSchema.name)
     .addColumn(Bip44CoinTypeSchema.properties.Bip44CoinTypeId, Type.INTEGER)
-    .addColumn(Bip44CoinTypeSchema.properties.Bip44DerivationId, Type.INTEGER)
+    .addColumn(Bip44CoinTypeSchema.properties.KeyDerivationId, Type.INTEGER)
     .addPrimaryKey(
       ([Bip44CoinTypeSchema.properties.Bip44CoinTypeId]: Array<string>),
       true
     )
     .addForeignKey('Bip44CoinType_Bip44Derivation', {
-      local: Bip44CoinTypeSchema.properties.Bip44DerivationId,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: Bip44CoinTypeSchema.properties.KeyDerivationId,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     });
   // Bip44Account
   schemaBuilder.createTable(Bip44AccountSchema.name)
     .addColumn(Bip44AccountSchema.properties.Bip44AccountId, Type.INTEGER)
-    .addColumn(Bip44AccountSchema.properties.Bip44DerivationId, Type.INTEGER)
+    .addColumn(Bip44AccountSchema.properties.KeyDerivationId, Type.INTEGER)
     .addPrimaryKey(
       ([Bip44AccountSchema.properties.Bip44AccountId]: Array<string>),
       true
     )
     .addForeignKey('Bip44Account_Bip44Derivation', {
-      local: Bip44AccountSchema.properties.Bip44DerivationId,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: Bip44AccountSchema.properties.KeyDerivationId,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     });
   // Bip44Chain
   schemaBuilder.createTable(Bip44ChainSchema.name)
     .addColumn(Bip44ChainSchema.properties.Bip44ChainId, Type.INTEGER)
-    .addColumn(Bip44ChainSchema.properties.Bip44DerivationId, Type.INTEGER)
+    .addColumn(Bip44ChainSchema.properties.KeyDerivationId, Type.INTEGER)
     .addColumn(Bip44ChainSchema.properties.LastReceiveIndex, Type.INTEGER)
     .addPrimaryKey(
       ([Bip44ChainSchema.properties.Bip44ChainId]: Array<string>),
       true
     )
     .addForeignKey('Bip44Chain_Bip44Derivation', {
-      local: Bip44ChainSchema.properties.Bip44DerivationId,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: Bip44ChainSchema.properties.KeyDerivationId,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     })
     .addNullable([
       Bip44ChainSchema.properties.LastReceiveIndex,
@@ -361,13 +361,13 @@ export const populateBip44Db = (schemaBuilder: lf$schema$Builder) => {
   // Bip44Address
   schemaBuilder.createTable(Bip44AddressSchema.name)
     .addColumn(Bip44AddressSchema.properties.Bip44AddressId, Type.INTEGER)
-    .addColumn(Bip44AddressSchema.properties.Bip44DerivationId, Type.INTEGER)
+    .addColumn(Bip44AddressSchema.properties.KeyDerivationId, Type.INTEGER)
     .addPrimaryKey(
       ([Bip44AddressSchema.properties.Bip44AddressId]: Array<string>),
       true
     )
     .addForeignKey('Bip44Address_Bip44Derivation', {
-      local: Bip44AddressSchema.properties.Bip44DerivationId,
-      ref: `${Bip44DerivationSchema.name}.${Bip44DerivationSchema.properties.Bip44DerivationId}`
+      local: Bip44AddressSchema.properties.KeyDerivationId,
+      ref: `${KeyDerivationSchema.name}.${KeyDerivationSchema.properties.KeyDerivationId}`
     });
 };

--- a/app/api/ada/lib/storage/database/transactions/tables.js
+++ b/app/api/ada/lib/storage/database/transactions/tables.js
@@ -116,7 +116,7 @@ export const populateTransactionsDb = (schemaBuilder: lf$schema$Builder) => {
     })
     .addForeignKey('UtxoTransactionInput_Bip44Address', {
       local: UtxoTransactionInputSchema.properties.Bip44AddressId,
-      ref: `${Bip44AddressSchema.name}.${Bip44AddressSchema.properties.Bip44DerivationId}`
+      ref: `${Bip44AddressSchema.name}.${Bip44AddressSchema.properties.KeyDerivationId}`
     });
 
   // UtxoTransactionOutput Table
@@ -134,6 +134,6 @@ export const populateTransactionsDb = (schemaBuilder: lf$schema$Builder) => {
     })
     .addForeignKey('UtxoTransactionOutput_Bip44Address', {
       local: UtxoTransactionOutputSchema.properties.Bip44AddressId,
-      ref: `${Bip44AddressSchema.name}.${Bip44AddressSchema.properties.Bip44DerivationId}`
+      ref: `${Bip44AddressSchema.name}.${Bip44AddressSchema.properties.KeyDerivationId}`
     });
 };

--- a/app/api/ada/lib/storage/tests/index.test.js
+++ b/app/api/ada/lib/storage/tests/index.test.js
@@ -91,13 +91,13 @@ test('Can add and fetch address in wallet', async () => {
               Index: 0,
             }),
             levelInfo: id => ({
-              Bip44DerivationId: id,
+              KeyDerivationId: id,
             })
           },
           level: DerivationLevels.ROOT.level,
           addPrivateDeriverRequest: derivationId => ({
             Bip44WrapperId: finalState.bip44WrapperRow.Bip44WrapperId,
-            Bip44DerivationId: derivationId,
+            KeyDerivationId: derivationId,
             Level: DerivationLevels.ROOT.level,
           }),
         })
@@ -114,7 +114,7 @@ test('Can add and fetch address in wallet', async () => {
             lastUpdate: null, // purposely null to avoid  diff in test
           },
           publicDeriverInsert: id => ({
-            Bip44DerivationId: id,
+            KeyDerivationId: id,
             Name: 'First account',
             LastBlockSync: 0,
           }),
@@ -137,7 +137,7 @@ test('Can add and fetch address in wallet', async () => {
       .deriveFromPublic(
         finalState => ({
           tree: {
-            derivationId: finalState.publicDeriver[0].levelResult.Bip44Derivation.Bip44DerivationId,
+            derivationId: finalState.publicDeriver[0].levelResult.KeyDerivation.KeyDerivationId,
             children: [
               {
                 index: 0, // external chain,
@@ -178,7 +178,7 @@ test('Can add and fetch address in wallet', async () => {
     await bipWallet.derive(
       {
         publicDeriverInsert: id => ({
-          Bip44DerivationId: id,
+          KeyDerivationId: id,
           Name: 'Checking account',
           LastBlockSync: 0,
         }),
@@ -221,7 +221,7 @@ test('Can add and fetch address in wallet', async () => {
       const addressesForAccount = await GetDerivationsByPath.get(
         db,
         tx,
-        state.publicDeriver[0].levelResult.Bip44Derivation.Bip44DerivationId,
+        state.publicDeriver[0].levelResult.KeyDerivation.KeyDerivationId,
         [purposeIndex, coinTypeIndex, firstAccountIndex],
         [null, null]
       );
@@ -232,7 +232,7 @@ test('Can add and fetch address in wallet', async () => {
         DerivationLevels.ADDRESS.level,
       );
       const result = dbAddresses.map(row => (
-        { hash: row.Hash, addressing: addressesForAccount.get(row.Bip44DerivationId) }
+        { hash: row.Hash, addressing: addressesForAccount.get(row.KeyDerivationId) }
       ));
 
       expect(result.length).toEqual(1);

--- a/app/api/ada/lib/storage/tests/snapshot.js
+++ b/app/api/ada/lib/storage/tests/snapshot.js
@@ -40,62 +40,62 @@ export const snapshot = {
       PasswordLastUpdate: null,
       KeyId: 5
     }],
-    Bip44Derivation: [{
+    KeyDerivation: [{
       // Bip44RootId: 1
       PublicKeyId: null,
       PrivateKeyId: 1,
       Parent: null,
       Index: 0,
-      Bip44DerivationId: 1
+      KeyDerivationId: 1
     }, {
       // Bip44PurposeId: 1
       PublicKeyId: null,
       PrivateKeyId: null,
       Parent: 1,
       Index: 2147483692,
-      Bip44DerivationId: 2
+      KeyDerivationId: 2
     }, {
       // Bip44CoinTypeId: 1
       PublicKeyId: null,
       PrivateKeyId: null,
       Parent: 2,
       Index: 2147485463,
-      Bip44DerivationId: 3
+      KeyDerivationId: 3
     }, {
       // Bip44AccountId: 1
       PublicKeyId: 3,
       PrivateKeyId: 2,
       Parent: 3,
       Index: 2147483648,
-      Bip44DerivationId: 4
+      KeyDerivationId: 4
     }, {
       // Bip44ChainId: 1
       PublicKeyId: null,
       PrivateKeyId: null,
       Parent: 4,
       Index: 0,
-      Bip44DerivationId: 5
+      KeyDerivationId: 5
     }, {
       // Bip44AddressId: 1
       PublicKeyId: null,
       PrivateKeyId: null,
       Parent: 5,
       Index: 0,
-      Bip44DerivationId: 6
+      KeyDerivationId: 6
     }, {
       // Bip44ChainId: 2
       PublicKeyId: null,
       PrivateKeyId: null,
       Parent: 4,
       Index: 1,
-      Bip44DerivationId: 7
+      KeyDerivationId: 7
     }, {
       // Bip44AccountId: 2
       PublicKeyId: 5,
       PrivateKeyId: 4,
       Parent: 3,
       Index: 2147483649,
-      Bip44DerivationId: 8
+      KeyDerivationId: 8
     }],
     Bip44Wrapper: [{
       ConceptualWalletId: 1,
@@ -107,55 +107,55 @@ export const snapshot = {
     }],
     PrivateDeriver: [{
       Bip44WrapperId: 1,
-      Bip44DerivationId: 1,
+      KeyDerivationId: 1,
       Level: 0,
       PrivateDeriverId: 1
     }],
     PublicDeriver: [{
-      Bip44DerivationId: 4,
+      KeyDerivationId: 4,
       Name: 'First account',
       LastBlockSync: 0,
       PublicDeriverId: 1
     }, {
-      Bip44DerivationId: 8,
+      KeyDerivationId: 8,
       Name: 'Checking account',
       LastBlockSync: 0,
       PublicDeriverId: 2
     }],
     Bip44Root: [{
-      Bip44DerivationId: 1,
+      KeyDerivationId: 1,
       Bip44RootId: 1
     }],
     Bip44Purpose: [{
-      Bip44DerivationId: 2,
+      KeyDerivationId: 2,
       Bip44PurposeId: 1
     }],
     Bip44CoinType: [{
-      Bip44DerivationId: 3,
+      KeyDerivationId: 3,
       Bip44CoinTypeId: 1
     }],
     Bip44Account: [{
       // First account
-      Bip44DerivationId: 4,
+      KeyDerivationId: 4,
       Bip44AccountId: 1
     }, {
       // Checking account
-      Bip44DerivationId: 8,
+      KeyDerivationId: 8,
       Bip44AccountId: 2
     }],
     Bip44Chain: [{
       // external chain
-      Bip44DerivationId: 5,
+      KeyDerivationId: 5,
       LastReceiveIndex: 0,
       Bip44ChainId: 1
     }, {
       // internal chain
-      Bip44DerivationId: 7,
+      KeyDerivationId: 7,
       LastReceiveIndex: null,
       Bip44ChainId: 2
     }],
     Bip44Address: [{
-      Bip44DerivationId: 6,
+      KeyDerivationId: 6,
       Hash: 'Ae2tdPwUPEZCfyggUgSxD1E5UCx5f5hrXCdvQjJszxE7epyZ4ox9vRNUbHf',
       Bip44AddressId: 1
     }]


### PR DESCRIPTION
As we discussed, we want to rename all instance of `Bip44Derivation`to just `KeyDerivation` that way. we can reuse this table for other standards. that also use key. derivation.

Note: this. PR is made as a draft since I want. #895 merged first