### PR TITLE
Force path from root to private deriver (storage v2)

### DIFF
--- a/app/api/ada/lib/storage/bridge/lovefieldDerive.js
+++ b/app/api/ada/lib/storage/bridge/lovefieldDerive.js
@@ -27,7 +27,7 @@ import type {
 } from './utils';
 
 export type LovefieldDeriveRequest = {|
-  ...DerivePublicFromPrivateRequest<{}>,
+  ...DerivePublicFromPrivateRequest,
   decryptPrivateDeriverPassword: ?string,
   publicDeriverPublicKey?: KeyInfo,
   publicDeriverPrivateKey?: KeyInfo,

--- a/app/api/ada/lib/storage/tests/index.test.js
+++ b/app/api/ada/lib/storage/tests/index.test.js
@@ -77,7 +77,8 @@ test('Can add and fetch address in wallet', async () => {
       )
       .addPrivateDeriver(
         finalState => ({
-          addLevelRequest: {
+          pathToPrivate: [],
+          addLevelRequest: parent => ({
             privateKeyInfo: {
               Hash: rootPk.key().to_hex(),
               IsEncrypted: false,
@@ -87,14 +88,13 @@ test('Can add and fetch address in wallet', async () => {
             derivationInfo: keys => ({
               PublicKeyId: keys.public,
               PrivateKeyId: keys.private,
-              Parent: null, // TODO
-              Index: 0,
+              Parent: parent,
+              Index: null,
             }),
             levelInfo: id => ({
               KeyDerivationId: id,
             })
-          },
-          level: DerivationLevels.ROOT.level,
+          }),
           addPrivateDeriverRequest: derivationId => ({
             Bip44WrapperId: finalState.bip44WrapperRow.Bip44WrapperId,
             KeyDerivationId: derivationId,

--- a/app/api/ada/lib/storage/tests/snapshot.js
+++ b/app/api/ada/lib/storage/tests/snapshot.js
@@ -45,7 +45,7 @@ export const snapshot = {
       PublicKeyId: null,
       PrivateKeyId: 1,
       Parent: null,
-      Index: 0,
+      Index: null,
       KeyDerivationId: 1
     }, {
       // Bip44PurposeId: 1


### PR DESCRIPTION
We need to ensure there is always a path from root level to the private deriver so that we can infer which BIP is used (44 or otherwise)

Note: draft since it depends on #896 