### PR TITLE
Restore spinner when restoring wallet

### DIFF
--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -63,12 +63,12 @@ export default class WalletSummaryPage extends Component<Props> {
     if (searchOptions) {
       const { limit } = searchOptions;
       const noTransactionsFoundLabel = intl.formatMessage(globalMessages.noTransactionsFound);
-      if (recentTransactionsRequest.isExecutingFirstTime || hasAny) {
+      if (!recentTransactionsRequest.wasExecuted || hasAny) {
         walletTransactions = (
           <WalletTransactionsList
             transactions={recent}
             selectedExplorer={this.props.stores.profile.selectedExplorer}
-            isLoadingTransactions={recentTransactionsRequest.isExecuting}
+            isLoadingTransactions={!recentTransactionsRequest.wasExecuted}
             hasMoreToLoad={totalAvailable > limit}
             onLoadMore={() => actions.ada.transactions.loadMoreTransactions.trigger()}
             assuranceMode={wallet.assuranceMode}


### PR DESCRIPTION
# History

It was noticed that we would always send 2 queries to the backend for transaction history (#382)

This is because Yoroi keeps track of two things:
1) Request for ALL transactions for a set of addresses
2) Request for all LATEST transactions for a set of addresses (say latest 20) to display in the  UI

Both (1) and (2) were implemented as queries to the backend. More specifically, we implemented this as PARALLEL requests.

#753 solves this by making (2) only query IndexDB instead of the backend. Now these queries have become SEQUENTIAL. First we do (1) then we do (2)

However, when restoring a wallet, the spinner (indicating wallet still being restored) was only checking if (2) was running (which means it would finish restoring right away since (2) is not executing until later)

# Solution

The solution in this PR is to show the spinner until (2) has been called and finished at least once