### PR TITLE
Fix Transfer from Another Wallet

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -1196,14 +1196,18 @@ export default class AdaApi {
       const cryptoAccount = createCryptoAccount(masterKey, walletPassword, 0);
 
       const savedAddresses = [];
+      const seenAddresses = new Set<string>();
       const _saveAsAdaAddresses = async ({ accountIndex, addresses, offset, addressType }) => {
         addresses.forEach((address, i) => {
-          savedAddresses.push({
-            address,
-            accountIndex,
-            addressType,
-            index: offset + i,
-          });
+          if (!seenAddresses.has(address)) {
+            seenAddresses.add(address);
+            savedAddresses.push({
+              address,
+              accountIndex,
+              addressType,
+              index: offset + i,
+            });
+          }
         });
       };
 

--- a/app/api/ada/lib/storage/adaAddress.js
+++ b/app/api/ada/lib/storage/adaAddress.js
@@ -29,7 +29,7 @@ import type {
   AddressType
 } from '../../adaTypes';
 import type {
-  SaveAsAdaAddressesRequeat,
+  SaveAsAdaAddressesRequest,
   SaveAsAdaAddressesResponse,
 } from './types';
 
@@ -108,7 +108,7 @@ export async function saveAdaAddress(
  * Also updates lastReceiveAddressIndex
  */
 export async function saveAsAdaAddresses(
-  request: SaveAsAdaAddressesRequeat,
+  request: SaveAsAdaAddressesRequest,
 ): Promise<SaveAsAdaAddressesResponse> {
   const mappedAddresses: Array<AdaAddress> = request.addresses.map((hash, index) => (
     toAdaAddress(

--- a/app/api/ada/lib/storage/types.js
+++ b/app/api/ada/lib/storage/types.js
@@ -27,7 +27,7 @@ export type GetAddressListFunc = (
 
 // saveAsAdaAddresses
 
-export type SaveAsAdaAddressesRequeat = {
+export type SaveAsAdaAddressesRequest = {
   accountIndex: number,
   addresses: Array<string>,
   offset: number,
@@ -35,5 +35,5 @@ export type SaveAsAdaAddressesRequeat = {
 };
 export type SaveAsAdaAddressesResponse = void;
 export type SaveAsAdaAddressesFunc = (
-  request: SaveAsAdaAddressesRequeat
+  request: SaveAsAdaAddressesRequest
 ) => Promise<SaveAsAdaAddressesResponse>;

--- a/app/api/ada/restoreAdaWallet.js
+++ b/app/api/ada/restoreAdaWallet.js
@@ -43,11 +43,11 @@ export async function restoreBip44Wallet(
    * If we throw, no new addresses will be added
    * so the user's balance would be stuck at 0 until they reinstall Yoroi.
    */
-  saveInitialAddresses(accountPublicKey, accountIndex, 'External', saveAsAdaAddresses);
-  saveInitialAddresses(accountPublicKey, accountIndex, 'Internal', saveAsAdaAddresses);
+  await saveInitialAddresses(accountPublicKey, accountIndex, 'External', saveAsAdaAddresses);
+  await saveInitialAddresses(accountPublicKey, accountIndex, 'Internal', saveAsAdaAddresses);
 
-  scanAndSaveAddresses(accountPublicKey, accountIndex, 'External', -1, checkAddressesInUse, saveAsAdaAddresses);
-  scanAndSaveAddresses(accountPublicKey, accountIndex, 'Internal', -1, checkAddressesInUse, saveAsAdaAddresses);
+  await scanAndSaveAddresses(accountPublicKey, accountIndex, 'External', -1, checkAddressesInUse, saveAsAdaAddresses);
+  await scanAndSaveAddresses(accountPublicKey, accountIndex, 'Internal', -1, checkAddressesInUse, saveAsAdaAddresses);
 }
 
 async function saveInitialAddresses(


### PR DESCRIPTION
Saving addresses to IndexDB used to be asynchronous. This is fine in the regular restoration case since every address will be saved eventually.

However, for  the "Transfer from Another Wallet"  feature, we need it to be synchronous because we need to accumulate the  addresses into an array to display to the user right away.