### PR TITLE
Add no-floating-promise

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -94,13 +94,15 @@
     "no-unused-expressions": 0,
     "no-lone-blocks": 0,
     "import/no-cycle": 0, // doesn't work with Flow unfortunately
-    "max-classes-per-file": 0
+    "max-classes-per-file": 0,
+    "no-floating-promise/no-floating-promise": 2
   },
   "plugins": [
     "import",
     "promise",
     "react",
-    "flowtype"
+    "flowtype",
+    "no-floating-promise"
   ],
   "globals": {
     "chrome": true,

--- a/features/step_definitions/common-steps.js
+++ b/features/step_definitions/common-steps.js
@@ -229,8 +229,8 @@ async function exportYoroiSnapshot(client, exportDir: string) {
   if (!fs.existsSync(exportDir)) {
     fs.mkdirSync(exportDir);
   }
-  exportLocalStorage(client, exportDir);
-  exportIndexedDB(client, exportDir);
+  await exportLocalStorage(client, exportDir);
+  await exportIndexedDB(client, exportDir);
 }
 
 async function exportLocalStorage(client, exportDir: string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10025,6 +10025,14 @@
         }
       }
     },
+    "eslint-plugin-no-floating-promise": {
+      "version": "git+https://github.com/SebastienGllmt/eslint-plugin-no-floating-promise.git#ce9669dff2bb5e66d3e033809e3309147e32ef12",
+      "from": "git+https://github.com/SebastienGllmt/eslint-plugin-no-floating-promise.git",
+      "dev": true,
+      "requires": {
+        "requireindex": "1.2.0"
+      }
+    },
     "eslint-plugin-promise": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
@@ -20949,6 +20957,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "requires-port": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.14.3",
+    "eslint-plugin-no-floating-promise": "git+https://github.com/SebastienGllmt/eslint-plugin-no-floating-promise.git",
     "file-loader": "4.2.0",
     "flow-bin": "0.107.0",
     "flow-typed": "2.6.1",


### PR DESCRIPTION
# Background

We've had some bugs in the past that were caused by forgetting to `await` on an async function. It turns out there's no  Flow/ESLint warning for this (but on exists  for Typescript which we can't use).

I tried to implement this myself into Flow but it proved too challenging so I tried implementing it in ESLint instead (I called it `no-floating-promise`). It was a good learning opportunity but the end-result is unfortunately very limited.

# Limitations

1) It cannot make use of Flow inference (you need to explicitly specify types)
2) It does not work across file boundaries (if import a function from a different file, you don't have any information)
3) It doesn't work on member function calls (`foo.bar()` will not detect  an error  even if  `bar` is an async function)

I could put extra work to make (3) work as long as the class  is declared in the same  file but it didn't feel like it would be very useful since usually (by design) classes are in separate files.