### PR TITLE
Update docker to node12

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,10 +1,9 @@
-FROM circleci/node:8-browsers AS circleci-node-8-browsers
+FROM circleci/node:12-browsers AS circleci-node-12-browsers
 
-FROM circleci-node-8-browsers AS brave
+FROM circleci-node-12-browsers AS brave
 
 # hardcode ubuntu version for circleci's debian-9 based image
 ENV UBUNTU_CODENAME=cosmic
-ENV BRAVE_CHROMEDRIVER_VER=2.33
 RUN /bin/bash -c 'set -e; \
     sudo apt-get install apt-transport-https; \
     curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key --keyring /etc/apt/trusted.gpg.d/brave-browser-release.gpg add -a; \
@@ -12,20 +11,9 @@ RUN /bin/bash -c 'set -e; \
     sudo apt update; \
     sudo apt install brave-keyring brave-browser'
 
-# add chromedriver tho it's not configurable on selenium-webdriver 
-RUN /bin/bash -c 'set -e; \
-    BRAVE_VERSION=$(apt-cache policy brave-browser|grep -i installed | awk "{print \$NF}"); \
-    cd /tmp; \
-    curl -o chromedriver_linux64.zip -L https://github.com/brave/brave-browser/releases/download/v${BRAVE_VERSION}/chromedriver-v${BRAVE_CHROMEDRIVER_VER}-linux-x64.zip; \
-    unzip chromedriver_linux64.zip; \
-    rm -rf chromedriver_linux64.zip; \
-    sudo mv chromedriver /usr/local/bin/chromedriver; \
-    sudo chmod +x /usr/local/bin/chromedriver; \
-    chromedriver --version'
+FROM circleci-node-12-browsers AS firefox-dev
 
-FROM circleci-node-8-browsers AS firefox-dev
-
-ENV FIREFOX_VERSION=67.0b9
+ENV FIREFOX_VERSION=70.0b9
 
 RUN /bin/bash -c 'set -xe; \
     curl -o /tmp/firefox.bz2 -sL https://download-installer.cdn.mozilla.net/pub/devedition/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2; \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -4,12 +4,23 @@ FROM circleci-node-12-browsers AS brave
 
 # hardcode ubuntu version for circleci's debian-9 based image
 ENV UBUNTU_CODENAME=cosmic
+ENV BRAVE_CHROMEDRIVER_VER=2.44
 RUN /bin/bash -c 'set -e; \
     sudo apt-get install apt-transport-https; \
     curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key --keyring /etc/apt/trusted.gpg.d/brave-browser-release.gpg add -a; \
     echo "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/brave-browser-release-${UBUNTU_CODENAME}.list; \
     sudo apt update; \
     sudo apt install brave-keyring brave-browser'
+
+# add chromedriver tho it's not configurable on selenium-webdriver
+RUN /bin/bash -c 'set -e; \
+    cd /tmp; \
+    curl -o chromedriver_linux64.zip -L https://chromedriver.storage.googleapis.com/${BRAVE_CHROMEDRIVER_VER}/chromedriver_linux64.zip; \
+    unzip chromedriver_linux64.zip; \
+    rm -rf chromedriver_linux64.zip; \
+    sudo mv chromedriver /usr/local/bin/chromedriver; \
+    sudo chmod +x /usr/local/bin/chromedriver; \
+    chromedriver --version'
 
 FROM circleci-node-12-browsers AS firefox-dev
 

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,8 +1,17 @@
 # Build circleci-derivated docker images
 
-Execute from git repo root:
+Execute from `.circleci` repo dir:
 ```
-docker build --target circleci-node-8-browsers emurgornd/circleci-node-8-browsers
-docker build --target firefox-dev -t emurgornd/circleci-node-8-browsers:firefox-dev .
-docker build --target brave -t emurgornd/circleci-node-8-browsers:brave .
+# This one is the generic one inherited as it is (by the moment) from CircleCI
+docker build --target circleci-node-12-browsers -t emurgornd/circleci-node-12-browsers:latest .
+docker build --target firefox-dev -t emurgornd/circleci-node-12-browsers:firefox-dev .
+docker build --target brave -t emurgornd/circleci-node-12-browsers:brave .
+```
+
+Images push snippet:
+```
+for tag in latest brave firefox-dev
+do
+  docker push emurgornd/circleci-node-12-browsers:${tag}
+done
 ```


### PR DESCRIPTION
I wanted to take advantage of a feature available in Node 10 so I just bumped to Node 12

I also took the time to bump the Firefox version used.

Note: this only updates the `Dockerfile` and not the  actual CI (which I updated in my storage  v2  branch).

You can find  find  the docker  image here: https://cloud.docker.com/repository/docker/emurgornd/circleci-node-12-browsers

**TODO**: I'm not sure what to do about Brave since we used to  download chromedriver for the  specific version off of Github. However, Brave now reuses the same chromedriver as Chrome so they don't package it in Github.
Example: 
- Old version that had  chromedriver: https://github.com/brave/brave-browser/releases/tag/v0.63.48
- New version that doesn't: https://github.com/brave/brave-browser/releases/tag/v0.69.132