### PR TITLE
Offline transaction support

### DIFF
--- a/app/api/ada/hardwareWallet/hwTransactions.js
+++ b/app/api/ada/hardwareWallet/hwTransactions.js
@@ -54,7 +54,7 @@ export async function createTrezorSignTxPayload(
   signRequest: BaseSignRequest,
   getTxsBodiesForUTXOs: TxBodiesFunc,
 ): Promise<$CardanoSignTransaction> {
-  const txJson: TransactionType = signRequest.unsignedTx.to_json();
+  const txJson = signRequest.unsignedTx.to_json();
 
   const utxoMap = utxosToLookupMap(
     signRequest.senderUtxos.map(utxo => ({
@@ -145,7 +145,7 @@ function _transformToTrezorInputs(
 }
 
 function _generateTrezorOutputs(
-  txOutputs: Array<TxOutType>,
+  txOutputs: Array<TxOutType<number>>,
   changeAddr: Array<{| ...Address, ...Value, ...Addressing |}>,
 ): Array<CardanoOutput> {
   return txOutputs.map(txOutput => {
@@ -174,7 +174,7 @@ export async function createLedgerSignTxPayload(
   signRequest: BaseSignRequest,
   getTxsBodiesForUTXOs: TxBodiesFunc,
 ): Promise<LedgerSignTxPayload> {
-  const txJson: TransactionType = signRequest.unsignedTx.to_json();
+  const txJson = signRequest.unsignedTx.to_json();
   // Map inputs to UNIQUE tx hashes (there might be multiple inputs from the same tx)
   const txsHashes = [...new Set(txJson.inputs.map(x => x.id))];
   const txsBodiesMap = await getTxsBodiesForUTXOs({ txsHashes });
@@ -239,7 +239,7 @@ function _transformToLedgerInputs(
 }
 
 function _transformToLedgerOutputs(
-  txOutputs: Array<TxOutType>,
+  txOutputs: Array<TxOutType<number>>,
   changeAddr: Array<{| ...Address, ...Value, ...Addressing |}>,
 ): Array<OutputTypeAddress | OutputTypeChange> {
   return txOutputs.map(txOutput => ({
@@ -249,7 +249,7 @@ function _transformToLedgerOutputs(
 }
 
 function _ledgerOutputAddress58OrPath(
-  txOutput: TxOutType,
+  txOutput: TxOutType<number>,
   changeAddr: Array<{| ...Address, ...Value, ...Addressing |}>,
 ): { address58: string } | { path: BIP32Path }  {
   const change = changeAddr.find(addr => addr.address === txOutput.address);
@@ -275,7 +275,7 @@ export async function prepareAndBroadcastLedgerSignedTx(
   try {
     Logger.debug('hwTransactions::prepareAndBroadcastLedgerSignedTx: called');
 
-    const unsignedTxJson: TransactionType = unsignedTx.to_json();
+    const unsignedTxJson = unsignedTx.to_json();
     Logger.debug(`hwTransactions::prepareAndBroadcastLedgerSignedTx unsignedTx: ${stringifyData(
       unsignedTxJson
     )}`);

--- a/app/api/ada/lib/storage/bridge/tests/multiwallet.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/multiwallet.test.js
@@ -116,23 +116,30 @@ async function checkPub1HasTx(
   {
     const response = await basePubDeriver.getAllUtxos();
     expect(response).toEqual([{
-      Transaction: {
-        ErrorMessage: null,
-        Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
-        Digest: 8.191593645542673e-27,
-        Ordinal: 0,
-        BlockId: 1,
-        LastUpdateTime: 1568392636000,
-        Status: 1,
-        TransactionId: 1
+      address: '2cWKMJemoBam9FHms2YNoTSaKGn5xCbN5FRhAa3seKgkfrAYujWrX8PRiFF2jVVMuM455',
+      addressing: {
+        path: [2147483692, 2147485463, 2147483648, 0, 4],
+        startLevel: 1,
       },
-      UtxoTransactionOutput: {
-        AddressId: 5,
-        Amount: '2100000',
-        IsUnspent: true,
-        OutputIndex: 0,
-        TransactionId: 1,
-        UtxoTransactionOutputId: 1
+      output: {
+        Transaction: {
+          ErrorMessage: null,
+          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
+          Digest: 8.191593645542673e-27,
+          Ordinal: 0,
+          BlockId: 1,
+          LastUpdateTime: 1568392636000,
+          Status: 1,
+          TransactionId: 1
+        },
+        UtxoTransactionOutput: {
+          AddressId: 5,
+          Amount: '2100000',
+          IsUnspent: true,
+          OutputIndex: 0,
+          TransactionId: 1,
+          UtxoTransactionOutputId: 1
+        }
       }
     }]);
   }
@@ -201,25 +208,33 @@ async function checkPub2HasTx(
   }
 
   {
+    console.log('sadf');
     const response = await basePubDeriver.getAllUtxos();
     expect(response).toEqual([{
-      Transaction: {
-        ErrorMessage: null,
-        Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
-        Digest: 8.191593645542673e-27,
-        Ordinal: 0,
-        BlockId: 1,
-        LastUpdateTime: 1568392636000,
-        Status: 1,
-        TransactionId: 2
+      address: '2cWKMJemoBajuCcDYHncArxP5JVaJ8FZeVtH1X49NEizHfSFAp6bSKppwhUyPZzi3mYMZ',
+      addressing: {
+        path: [2147483692, 2147485463, 2147483648, 0, 0],
+        startLevel: 1,
       },
-      UtxoTransactionOutput: {
-        AddressId: 41,
-        Amount: '2700000',
-        IsUnspent: true,
-        OutputIndex: 1,
-        TransactionId: 2,
-        UtxoTransactionOutputId: 4
+      output: {
+        Transaction: {
+          ErrorMessage: null,
+          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
+          Digest: 8.191593645542673e-27,
+          Ordinal: 0,
+          BlockId: 1,
+          LastUpdateTime: 1568392636000,
+          Status: 1,
+          TransactionId: 2
+        },
+        UtxoTransactionOutput: {
+          AddressId: 41,
+          Amount: '2700000',
+          IsUnspent: true,
+          OutputIndex: 1,
+          TransactionId: 2,
+          UtxoTransactionOutputId: 4
+        }
       }
     }]);
   }

--- a/app/api/ada/lib/storage/bridge/tests/multiwallet.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/multiwallet.test.js
@@ -19,7 +19,7 @@ import {
 import { loadLovefieldDB } from '../../database/index';
 
 import {
-  asGetAllAddresses,
+  asGetAllUtxos,
   asGetUtxoBalance,
   asDisplayCutoff,
   PublicDeriver,
@@ -251,14 +251,14 @@ test('Syncing simple transaction', async (done) => {
   );
   const getBestBlock = genGetBestBlock(networkTransactions);
 
-  const asGetAllAddressesInstance1 = asGetAllAddresses(publicDeriver1);
-  expect(asGetAllAddressesInstance1 != null).toEqual(true);
-  if (asGetAllAddressesInstance1 == null) {
+  const withUtxos1 = asGetAllUtxos(publicDeriver1);
+  expect(withUtxos1 != null).toEqual(true);
+  if (withUtxos1 == null) {
     throw new Error('Syncing txs publicDeriver1 != GetAllAddressesInstance');
   }
-  const asGetAllAddressesInstance2 = asGetAllAddresses(publicDeriver2);
-  expect(asGetAllAddressesInstance2 != null).toEqual(true);
-  if (asGetAllAddressesInstance2 == null) {
+  const withUtxos2 = asGetAllUtxos(publicDeriver2);
+  expect(withUtxos2 != null).toEqual(true);
+  if (withUtxos2 == null) {
     throw new Error('Syncing txs publicDeriver2 != GetAllAddressesInstance');
   }
 
@@ -266,7 +266,7 @@ test('Syncing simple transaction', async (done) => {
   {
     await updateTransactions(
       db,
-      asGetAllAddressesInstance1,
+      withUtxos1,
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
@@ -305,7 +305,7 @@ test('Syncing simple transaction', async (done) => {
     // now sync and make sure it updated
     await updateTransactions(
       db,
-      asGetAllAddressesInstance2,
+      withUtxos2,
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
@@ -331,7 +331,7 @@ test('Syncing simple transaction', async (done) => {
   {
     await updateTransactions(
       db,
-      asGetAllAddressesInstance2,
+      withUtxos2,
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,

--- a/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
@@ -20,7 +20,7 @@ import {
 import { loadLovefieldDB } from '../../database/index';
 
 import {
-  asGetAllAddresses,
+  asGetAllUtxos,
   asGetUtxoBalance,
   asDisplayCutoff,
 } from '../../models/PublicDeriver/index';
@@ -171,9 +171,9 @@ test('Syncing simple transaction', async (done) => {
   if (!withDisplayCutoff) throw new Error('missing display cutoff functionality');
   const withUtxoBalance = asGetUtxoBalance(withDisplayCutoff);
   if (!withUtxoBalance) throw new Error('missing utxo balance functionality');
-  const withGetAllAddresses = asGetAllAddresses(withUtxoBalance);
-  if (!withGetAllAddresses) throw new Error('missing get all addresses functionality');
-  const basePubDeriver = withGetAllAddresses;
+  const withUtxos = asGetAllUtxos(withUtxoBalance);
+  if (!withUtxos) throw new Error('missing get all addresses functionality');
+  const basePubDeriver = withUtxos;
 
   expect(basePubDeriver != null).toEqual(true);
   if (basePubDeriver == null) {
@@ -448,11 +448,11 @@ test('Utxo created and used in same sync', async (done) => {
 
   const withDisplayCutoff = asDisplayCutoff(publicDeriver);
   if (!withDisplayCutoff) throw new Error('missing display cutoff functionality');
-  const withUtxoBalance = asGetUtxoBalance(withDisplayCutoff);
+  const withUtxos = asGetAllUtxos(withDisplayCutoff);
+  if (!withUtxos) throw new Error('missing get all utxos functionality');
+  const withUtxoBalance = asGetUtxoBalance(withUtxos);
   if (!withUtxoBalance) throw new Error('missing utxo balance functionality');
-  const withGetAllAddresses = asGetAllAddresses(withUtxoBalance);
-  if (!withGetAllAddresses) throw new Error('missing get all addresses functionality');
-  const basePubDeriver = withGetAllAddresses;
+  const basePubDeriver = withUtxoBalance;
 
   expect(basePubDeriver != null).toEqual(true);
   if (basePubDeriver == null) {

--- a/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
@@ -193,23 +193,30 @@ test('Syncing simple transaction', async (done) => {
     {
       const response = await basePubDeriver.getAllUtxos();
       expect(response).toEqual([{
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
-          Digest: 8.191593645542673e-27,
-          Ordinal: 0,
-          BlockId: 1,
-          LastUpdateTime: 1568392636000,
-          Status: 1,
-          TransactionId: 1
+        address: '2cWKMJemoBam9FHms2YNoTSaKGn5xCbN5FRhAa3seKgkfrAYujWrX8PRiFF2jVVMuM455',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 0, 4],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 5,
-          Amount: '2100000',
-          IsUnspent: true,
-          OutputIndex: 0,
-          TransactionId: 1,
-          UtxoTransactionOutputId: 1
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
+            Digest: 8.191593645542673e-27,
+            Ordinal: 0,
+            BlockId: 1,
+            LastUpdateTime: 1568392636000,
+            Status: 1,
+            TransactionId: 1
+          },
+          UtxoTransactionOutput: {
+            AddressId: 5,
+            Amount: '2100000',
+            IsUnspent: true,
+            OutputIndex: 0,
+            TransactionId: 1,
+            UtxoTransactionOutputId: 1
+          }
         }
       }]);
     }
@@ -275,45 +282,59 @@ test('Syncing simple transaction', async (done) => {
     {
       const response = await basePubDeriver.getAllUtxos();
       expect(response).toEqual([{
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
-          Digest: 1.249559827714551e-31,
-          Ordinal: 0,
-          BlockId: 2,
-          LastUpdateTime: 1568392656000,
-          Status: 1,
-          TransactionId: 2
+        address: '2cWKMJemoBai5YBzrvj8yR7AxofNVRRQ3HeGZ6ze2jedGJWAZuv1kk83DDHhbM4etgZoX',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 1, 0],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 21,
-          Amount: '1100000',
-          IsUnspent: true,
-          OutputIndex: 0,
-          TransactionId: 2,
-          UtxoTransactionOutputId: 3
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
+            Digest: 1.249559827714551e-31,
+            Ordinal: 0,
+            BlockId: 2,
+            LastUpdateTime: 1568392656000,
+            Status: 1,
+            TransactionId: 2
+          },
+          UtxoTransactionOutput: {
+            AddressId: 21,
+            Amount: '1100000',
+            IsUnspent: true,
+            OutputIndex: 0,
+            TransactionId: 2,
+            UtxoTransactionOutputId: 3
+          }
         }
       },
       {
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
-          Digest: 1.249559827714551e-31,
-          Ordinal: 0,
-          BlockId: 2,
-          LastUpdateTime: 1568392656000,
-          Status: 1,
-          TransactionId: 2
+        address: '2cWKMJemoBajxKobGHH4FWX8MYipNcYd8QWU6GJNfam6H7HJ4CJFvv42jqiPayM6skcPs',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 0, 19],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 20,
-          Amount: '900000',
-          IsUnspent: true,
-          OutputIndex: 1,
-          TransactionId: 2,
-          UtxoTransactionOutputId: 4
-        }
-      },
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
+            Digest: 1.249559827714551e-31,
+            Ordinal: 0,
+            BlockId: 2,
+            LastUpdateTime: 1568392656000,
+            Status: 1,
+            TransactionId: 2
+          },
+          UtxoTransactionOutput: {
+            AddressId: 20,
+            Amount: '900000',
+            IsUnspent: true,
+            OutputIndex: 1,
+            TransactionId: 2,
+            UtxoTransactionOutputId: 4
+          }
+        },
+      }
       ]);
     }
 
@@ -474,43 +495,57 @@ test('Utxo created and used in same sync', async (done) => {
     {
       const response = await basePubDeriver.getAllUtxos();
       expect(response).toEqual([{
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
-          Digest: 1.249559827714551e-31,
-          Ordinal: 0,
-          BlockId: 2,
-          LastUpdateTime: 1568392656000,
-          Status: 1,
-          TransactionId: 2
+        address: '2cWKMJemoBai5YBzrvj8yR7AxofNVRRQ3HeGZ6ze2jedGJWAZuv1kk83DDHhbM4etgZoX',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 1, 0],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 21,
-          Amount: '1100000',
-          IsUnspent: true,
-          OutputIndex: 0,
-          TransactionId: 2,
-          UtxoTransactionOutputId: 3
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
+            Digest: 1.249559827714551e-31,
+            Ordinal: 0,
+            BlockId: 2,
+            LastUpdateTime: 1568392656000,
+            Status: 1,
+            TransactionId: 2
+          },
+          UtxoTransactionOutput: {
+            AddressId: 21,
+            Amount: '1100000',
+            IsUnspent: true,
+            OutputIndex: 0,
+            TransactionId: 2,
+            UtxoTransactionOutputId: 3
+          }
         }
       },
       {
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
-          Digest: 1.249559827714551e-31,
-          Ordinal: 0,
-          BlockId: 2,
-          LastUpdateTime: 1568392656000,
-          Status: 1,
-          TransactionId: 2
+        address: '2cWKMJemoBajxKobGHH4FWX8MYipNcYd8QWU6GJNfam6H7HJ4CJFvv42jqiPayM6skcPs',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 0, 19],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 20,
-          Amount: '900000',
-          IsUnspent: true,
-          OutputIndex: 1,
-          TransactionId: 2,
-          UtxoTransactionOutputId: 4
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
+            Digest: 1.249559827714551e-31,
+            Ordinal: 0,
+            BlockId: 2,
+            LastUpdateTime: 1568392656000,
+            Status: 1,
+            TransactionId: 2
+          },
+          UtxoTransactionOutput: {
+            AddressId: 20,
+            Amount: '900000',
+            IsUnspent: true,
+            OutputIndex: 1,
+            TransactionId: 2,
+            UtxoTransactionOutputId: 4
+          }
         }
       },
       ]);

--- a/app/api/ada/lib/storage/bridge/tests/status.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/status.test.js
@@ -231,23 +231,30 @@ async function baseTest(
     {
       const response = await basePubDeriver.getAllUtxos();
       expect(response).toEqual([{
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
-          Digest: 1.249559827714551e-31,
-          Ordinal: 0,
-          BlockId: 1,
-          LastUpdateTime: 1568392636000,
-          Status: 1,
-          TransactionId: 2
+        address: '2cWKMJemoBam9FHms2YNoTSaKGn5xCbN5FRhAa3seKgkfrAYujWrX8PRiFF2jVVMuM455',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 0, 4],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 5,
-          Amount: '2100000',
-          IsUnspent: true,
-          OutputIndex: 0,
-          TransactionId: 2,
-          UtxoTransactionOutputId: 3
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
+            Digest: 1.249559827714551e-31,
+            Ordinal: 0,
+            BlockId: 1,
+            LastUpdateTime: 1568392636000,
+            Status: 1,
+            TransactionId: 2
+          },
+          UtxoTransactionOutput: {
+            AddressId: 5,
+            Amount: '2100000',
+            IsUnspent: true,
+            OutputIndex: 0,
+            TransactionId: 2,
+            UtxoTransactionOutputId: 3
+          }
         }
       }]);
     }
@@ -308,43 +315,57 @@ async function baseTest(
     {
       const response = await basePubDeriver.getAllUtxos();
       expect(response).toEqual([{
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
-          Digest: 8.191593645542673e-27,
-          Ordinal: 0,
-          BlockId: 2,
-          LastUpdateTime: 1568392656000,
-          Status: 1,
-          TransactionId: 1
+        address: '2cWKMJemoBam9FHms2YNoTSaKGn5xCbN5FRhAa3seKgkfrAYujWrX8PRiFF2jVVMuM455',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 0, 4],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 5,
-          Amount: '2100000',
-          IsUnspent: true,
-          OutputIndex: 0,
-          TransactionId: 1,
-          UtxoTransactionOutputId: 1,
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
+            Digest: 8.191593645542673e-27,
+            Ordinal: 0,
+            BlockId: 2,
+            LastUpdateTime: 1568392656000,
+            Status: 1,
+            TransactionId: 1
+          },
+          UtxoTransactionOutput: {
+            AddressId: 5,
+            Amount: '2100000',
+            IsUnspent: true,
+            OutputIndex: 0,
+            TransactionId: 1,
+            UtxoTransactionOutputId: 1,
+          }
         }
       },
       {
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
-          Digest: 1.249559827714551e-31,
-          Ordinal: 0,
-          BlockId: 1,
-          LastUpdateTime: 1568392636000,
-          Status: 1,
-          TransactionId: 2
+        address: '2cWKMJemoBam9FHms2YNoTSaKGn5xCbN5FRhAa3seKgkfrAYujWrX8PRiFF2jVVMuM455',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 0, 4],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 5,
-          Amount: '2100000',
-          IsUnspent: true,
-          OutputIndex: 0,
-          TransactionId: 2,
-          UtxoTransactionOutputId: 3
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
+            Digest: 1.249559827714551e-31,
+            Ordinal: 0,
+            BlockId: 1,
+            LastUpdateTime: 1568392636000,
+            Status: 1,
+            TransactionId: 2
+          },
+          UtxoTransactionOutput: {
+            AddressId: 5,
+            Amount: '2100000',
+            IsUnspent: true,
+            OutputIndex: 0,
+            TransactionId: 2,
+            UtxoTransactionOutputId: 3
+          }
         }
       }]);
     }
@@ -393,43 +414,57 @@ async function baseTest(
     {
       const response = await basePubDeriver.getAllUtxos();
       expect(response).toEqual([{
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
-          Digest: 8.191593645542673e-27,
-          Ordinal: 0,
-          BlockId: 2,
-          LastUpdateTime: 1568392656000,
-          Status: 1,
-          TransactionId: 1
+        address: '2cWKMJemoBam9FHms2YNoTSaKGn5xCbN5FRhAa3seKgkfrAYujWrX8PRiFF2jVVMuM455',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 0, 4],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 5,
-          Amount: '2100000',
-          IsUnspent: true,
-          OutputIndex: 0,
-          TransactionId: 1,
-          UtxoTransactionOutputId: 1,
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed545',
+            Digest: 8.191593645542673e-27,
+            Ordinal: 0,
+            BlockId: 2,
+            LastUpdateTime: 1568392656000,
+            Status: 1,
+            TransactionId: 1
+          },
+          UtxoTransactionOutput: {
+            AddressId: 5,
+            Amount: '2100000',
+            IsUnspent: true,
+            OutputIndex: 0,
+            TransactionId: 1,
+            UtxoTransactionOutputId: 1,
+          }
         }
       },
       {
-        Transaction: {
-          ErrorMessage: null,
-          Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
-          Digest: 1.249559827714551e-31,
-          Ordinal: 0,
-          BlockId: 1,
-          LastUpdateTime: 1568392636000,
-          Status: 1,
-          TransactionId: 2
+        address: '2cWKMJemoBam9FHms2YNoTSaKGn5xCbN5FRhAa3seKgkfrAYujWrX8PRiFF2jVVMuM455',
+        addressing: {
+          path: [2147483692, 2147485463, 2147483648, 0, 4],
+          startLevel: 1,
         },
-        UtxoTransactionOutput: {
-          AddressId: 5,
-          Amount: '2100000',
-          IsUnspent: true,
-          OutputIndex: 0,
-          TransactionId: 2,
-          UtxoTransactionOutputId: 3
+        output: {
+          Transaction: {
+            ErrorMessage: null,
+            Hash: '29f2fe214ec2c9b05773a689eca797e903adeaaf51dfe20782a4bf401e7ed546',
+            Digest: 1.249559827714551e-31,
+            Ordinal: 0,
+            BlockId: 1,
+            LastUpdateTime: 1568392636000,
+            Status: 1,
+            TransactionId: 2
+          },
+          UtxoTransactionOutput: {
+            AddressId: 5,
+            Amount: '2100000',
+            IsUnspent: true,
+            OutputIndex: 0,
+            TransactionId: 2,
+            UtxoTransactionOutputId: 3
+          }
         }
       }]);
     }

--- a/app/api/ada/lib/storage/bridge/tests/status.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/status.test.js
@@ -19,7 +19,7 @@ import {
 import { loadLovefieldDB } from '../../database/index';
 
 import {
-  asGetAllAddresses,
+  asGetAllUtxos,
   asGetUtxoBalance,
   asDisplayCutoff,
 } from '../../models/PublicDeriver/index';
@@ -168,11 +168,11 @@ async function baseTest(
 
   const withDisplayCutoff = asDisplayCutoff(publicDeriver);
   if (!withDisplayCutoff) throw new Error('missing display cutoff functionality');
+  const withUtxos = asGetAllUtxos(withDisplayCutoff);
+  if (!withUtxos) throw new Error('missing get all utxos functionality');
   const withUtxoBalance = asGetUtxoBalance(withDisplayCutoff);
   if (!withUtxoBalance) throw new Error('missing utxo balance functionality');
-  const withGetAllAddresses = asGetAllAddresses(withUtxoBalance);
-  if (!withGetAllAddresses) throw new Error('missing get all addresses functionality');
-  const basePubDeriver = withGetAllAddresses;
+  const basePubDeriver = withUtxoBalance;
 
   // single pending tx
   {
@@ -546,7 +546,7 @@ test('Pending dropped from backend without rollback', async (done) => {
   );
   const getBestBlock = genGetBestBlock(networkTransactions);
 
-  const basePubDeriver = asGetAllAddresses(publicDeriver);
+  const basePubDeriver = asGetAllUtxos(publicDeriver);
   expect(basePubDeriver != null).toEqual(true);
   if (basePubDeriver == null) {
     throw new Error('Syncing txs basePubDeriver != GetAllAddressesInstance');

--- a/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -49,7 +49,7 @@ import { TxStatusCodes, } from '../database/primitives/tables';
 import {
   ScanAddressesInstance,
 } from '../models/PublicDeriver';
-import type { IPublicDeriver, IGetAllAddresses, } from '../models/PublicDeriver/interfaces';
+import type { IPublicDeriver, IGetAllUtxos, } from '../models/PublicDeriver/interfaces';
 import {
   GetLastSyncForPublicDeriver,
   GetPublicDeriver,
@@ -79,7 +79,7 @@ export async function rawGetUtxoTransactions(
     GetBip44DerivationSpecific: Class<GetBip44DerivationSpecific>,
   |},
   request: {
-    addressFetch: IGetAllAddresses,
+    addressFetch: IGetAllUtxos,
     getTxAndBlock: (txIds: Array<number>) => Promise<$ReadOnlyArray<{
       Block: null | $ReadOnly<BlockRow>,
       Transaction: $ReadOnly<TransactionRow>
@@ -91,7 +91,7 @@ export async function rawGetUtxoTransactions(
   addressLookupMap: Map<number, string>,
   txs: Array<UtxoAnnotatedTransaction>,
 |}> {
-  const addresses = await request.addressFetch.rawGetAllAddresses(
+  const addresses = await request.addressFetch.rawGetAllUtxoAddresses(
     dbTx,
     {
       GetPathWithSpecific: deps.GetPathWithSpecific,
@@ -154,7 +154,7 @@ export async function rawGetUtxoTransactions(
 export async function getAllUtxoTransactions(
   db: lf$Database,
   request: {
-    addressFetch: IGetAllAddresses,
+    addressFetch: IGetAllUtxos,
     skip?: number,
     limit?: number,
   },
@@ -206,7 +206,7 @@ export async function getAllUtxoTransactions(
 export async function getPendingUtxoTransactions(
   db: lf$Database,
   request: {
-    addressFetch: IGetAllAddresses,
+    addressFetch: IGetAllUtxos,
   },
 ): Promise<{|
   addressLookupMap: Map<number, string>,
@@ -254,7 +254,7 @@ export async function getPendingUtxoTransactions(
 
 export async function updateTransactions(
   db: lf$Database,
-  publicDeriver: IPublicDeriver & IGetAllAddresses,
+  publicDeriver: IPublicDeriver & IGetAllUtxos,
   checkAddressesInUse: FilterFunc,
   getTransactionsHistoryForAddresses: HistoryFunc,
   getBestBlock: BestBlockFunc,
@@ -380,7 +380,7 @@ async function rollback(
     GetBip44DerivationSpecific: Class<GetBip44DerivationSpecific>,
   |},
   request: {
-    publicDeriver: IPublicDeriver & IGetAllAddresses,
+    publicDeriver: IPublicDeriver & IGetAllUtxos,
     lastSyncInfo: $ReadOnly<LastSyncInfoRow>,
   }
 ): Promise<void> {
@@ -393,7 +393,7 @@ async function rollback(
   }
 
   // 1) Get the best block we have in storage
-  const addresses = await request.publicDeriver.rawGetAllAddresses(
+  const addresses = await request.publicDeriver.rawGetAllUtxoAddresses(
     dbTx,
     {
       GetPathWithSpecific: deps.GetPathWithSpecific,
@@ -520,7 +520,7 @@ async function rawUpdateTransactions(
     GetTxAndBlock: Class<GetTxAndBlock>,
     GetBip44DerivationSpecific: Class<GetBip44DerivationSpecific>,
   |},
-  publicDeriver: IPublicDeriver & IGetAllAddresses,
+  publicDeriver: IPublicDeriver & IGetAllUtxos,
   lastSyncInfo: $ReadOnly<LastSyncInfoRow>,
   checkAddressesInUse: FilterFunc,
   getTransactionsHistoryForAddresses: HistoryFunc,
@@ -573,7 +573,7 @@ async function rawUpdateTransactions(
     // 3) get new txs from fetcher
 
     // important: we fetched addresses AFTER scanning for new addresses
-    const addresses = await publicDeriver.rawGetAllAddresses(
+    const addresses = await publicDeriver.rawGetAllUtxoAddresses(
       dbTx,
       {
         GetPathWithSpecific: deps.GetPathWithSpecific,

--- a/app/api/ada/lib/storage/database/utxoTransactions/api/read.js
+++ b/app/api/ada/lib/storage/database/utxoTransactions/api/read.js
@@ -99,10 +99,10 @@ export class GetUtxoOutputs {
   }
 }
 
-export type UtxoTxOutput = {
+export type UtxoTxOutput = {|
   Transaction: $ReadOnly<TransactionRow>,
   UtxoTransactionOutput: $ReadOnly<UtxoTransactionOutputRow>,
-};
+|};
 export class GetUtxoTxOutputsWithTx {
   static ownTables = Object.freeze({
     [TransactionSchema.name]: TransactionSchema,
@@ -150,10 +150,10 @@ export class GetUtxoTxOutputsWithTx {
       )
     );
 
-    const queryResult: $ReadOnlyArray<{
+    const queryResult: $ReadOnlyArray<{|
       Transaction: $ReadOnly<TransactionRow>,
       UtxoTransactionOutput: $ReadOnly<UtxoTransactionOutputRow>,
-    }> = await tx.attach(query);
+    |}> = await tx.attach(query);
 
     if (queryResult.length === 0) {
       return undefined;

--- a/app/api/ada/lib/storage/models/PublicDeriver/index.js
+++ b/app/api/ada/lib/storage/models/PublicDeriver/index.js
@@ -1269,7 +1269,7 @@ const GetUtxoBalanceMixin = (
       },
       undefined
     );
-    return getBalanceForUtxos(utxos);
+    return getBalanceForUtxos(utxos.map(utxo => utxo.output.UtxoTransactionOutput));
   }
   getBalance = async (
     _body: IGetUtxoBalanceRequest,

--- a/app/api/ada/lib/storage/models/PublicDeriver/interfaces.js
+++ b/app/api/ada/lib/storage/models/PublicDeriver/interfaces.js
@@ -20,7 +20,8 @@ import type {
 
 import {
   GetUtxoTxOutputsWithTx,
-} from  '../../database/utxoTransactions/api/read';
+} from '../../database/utxoTransactions/api/read';
+import type { UtxoTxOutput } from '../../database/utxoTransactions/api/read';
 
 import type {
   AddressRow,
@@ -31,7 +32,7 @@ import type { PublicDeriverRow, LastSyncInfoRow, } from '../../database/wallet/t
 
 import type {
   IChangePasswordRequestFunc, IChangePasswordRequest,
-  Addressing,
+  Address, Addressing,
 } from '../common/interfaces';
 import {
   GetPublicDeriver,
@@ -142,26 +143,17 @@ export interface IGetPublic {
   +changePubDeriverPassword: IChangePasswordRequestFunc,
 }
 
-export type IGetAllAddressesRequest = PathRequest;
-export type IGetAllAddressesResponse = Array<PathWithAddrAndRow>;
-export type IGetAllAddressesFunc = (
-  body: IGetAllAddressesRequest
-) => Promise<IGetAllAddressesResponse>;
-export interface IGetAllAddresses {
-  +rawGetAllAddresses: RawVariation<
-    IGetAllAddressesFunc,
-    {|
-      GetPathWithSpecific: Class<GetPathWithSpecific>,
-      GetAddress: Class<GetAddress>,
-      GetBip44DerivationSpecific: Class<GetBip44DerivationSpecific>,
-    |},
-    IGetAllAddressesRequest
-  >;
-  +getAllAddresses: IGetAllAddressesFunc
-}
-
+export type IGetAllUtxoAddressesRequest = PathRequest;
+export type IGetAllUtxoAddressesResponse = Array<PathWithAddrAndRow>;
+export type IGetAllUtxoAddressesFunc = (
+  body: IGetAllUtxoAddressesRequest
+) => Promise<IGetAllUtxoAddressesResponse>;
 export type IGetAllUtxosRequest = void;
-export type IGetAllUtxosResponse = PromisslessReturnType<typeof GetUtxoTxOutputsWithTx.getUtxo>;
+export type IGetAllUtxosResponse = Array<{|
+  output: $ReadOnly<UtxoTxOutput>;
+  ...Addressing,
+  ...Address,
+|}>;
 export type IGetAllUtxosFunc = (
   body: IGetAllUtxosRequest
 ) => Promise<IGetAllUtxosResponse>;
@@ -177,6 +169,17 @@ export interface IGetAllUtxos {
     IGetAllUtxosRequest
   >;
   +getAllUtxos: IGetAllUtxosFunc;
+
+  +rawGetAllUtxoAddresses: RawVariation<
+    IGetAllUtxoAddressesFunc,
+    {|
+      GetPathWithSpecific: Class<GetPathWithSpecific>,
+      GetAddress: Class<GetAddress>,
+      GetBip44DerivationSpecific: Class<GetBip44DerivationSpecific>,
+    |},
+    IGetAllUtxoAddressesRequest
+  >;
+  +getAllUtxoAddresses: IGetAllUtxoAddressesFunc
 }
 
 export type IDisplayCutoffPopRequest = void;

--- a/app/api/ada/lib/storage/models/utils.js
+++ b/app/api/ada/lib/storage/models/utils.js
@@ -17,7 +17,6 @@ import type {
   IPublicDeriver,
   PathWithAddrAndRow,
   IGetAllUtxos,
-  IGetAllUtxosResponse,
   IGetUtxoBalanceResponse,
   IHasChainsRequest,
   IGetNextUnusedForChainResponse,
@@ -49,6 +48,7 @@ import {
   GetBip44DerivationSpecific,
 } from '../database/bip44/api/read';
 import type { UtxoTxOutput } from '../database/utxoTransactions/api/read';
+import type { UtxoTransactionOutputRow } from '../database/utxoTransactions/tables';
 import { Bip44DerivationLevels } from '../database/bip44/api/utils';
 import type { GetPathWithSpecificByTreeRequest } from '../database/primitives/api/read';
 import type {
@@ -469,11 +469,7 @@ export async function getChainAddressesForDisplay(
   return await raii(
     request.publicDeriver.getDb(),
     depTables,
-    async tx => await rawGetChainAddressesForDisplay(
-      tx,
-      deps,
-      request,
-    )
+    async tx => await rawGetChainAddressesForDisplay(tx, deps, request)
   );
 }
 export async function rawGetAllAddressesForDisplay(
@@ -588,16 +584,17 @@ export function getUtxoBalanceForAddresses(
   );
   const mapping = mapValues(
     groupByAddress,
-    utxoList => getBalanceForUtxos(utxoList)
+    (utxoList: Array<$ReadOnly<UtxoTxOutput>>) => getBalanceForUtxos(
+      utxoList.map(utxo => utxo.UtxoTransactionOutput)
+    )
   );
   return mapping;
 }
 
-
 export function getBalanceForUtxos(
-  utxos: IGetAllUtxosResponse,
+  utxos: $ReadOnlyArray<$ReadOnly<UtxoTransactionOutputRow>>,
 ): IGetUtxoBalanceResponse {
-  const amounts = utxos.map(utxo => new BigNumber(utxo.output.UtxoTransactionOutput.Amount));
+  const amounts = utxos.map(utxo => new BigNumber(utxo.Amount));
   const total = amounts.reduce(
     (acc, amount) => acc.plus(amount),
     new BigNumber(0)

--- a/app/api/ada/lib/storage/models/utils.js
+++ b/app/api/ada/lib/storage/models/utils.js
@@ -227,7 +227,7 @@ export async function rawGetDerivationsByPath<
       row,
       addressing: {
         path,
-        startLevel: request.startingDerivation - request.commonPrefix.length,
+        startLevel: request.derivationLevel - request.commonPrefix.length + 1,
       },
     };
   });

--- a/app/api/ada/lib/storage/models/utils.js
+++ b/app/api/ada/lib/storage/models/utils.js
@@ -16,7 +16,7 @@ import {
 import type {
   IPublicDeriver,
   PathWithAddrAndRow,
-  IGetAllAddresses,
+  IGetAllUtxos,
   IGetAllUtxosResponse,
   IGetUtxoBalanceResponse,
   IHasChainsRequest,
@@ -48,6 +48,7 @@ import {
   GetAllBip44Wallets,
   GetBip44DerivationSpecific,
 } from '../database/bip44/api/read';
+import type { UtxoTxOutput } from '../database/utxoTransactions/api/read';
 import { Bip44DerivationLevels } from '../database/bip44/api/utils';
 import type { GetPathWithSpecificByTreeRequest } from '../database/primitives/api/read';
 import type {
@@ -484,10 +485,10 @@ export async function rawGetAllAddressesForDisplay(
     GetBip44DerivationSpecific: Class<GetBip44DerivationSpecific>,
   |},
   request: {
-    publicDeriver: IPublicDeriver & IGetAllAddresses,
+    publicDeriver: IPublicDeriver & IGetAllUtxos,
   },
 ): Promise<Array<{| ...Address, ...Value, ...Addressing, ...UsedStatus |}>> {
-  let addresses = await request.publicDeriver.rawGetAllAddresses(
+  let addresses = await request.publicDeriver.rawGetAllUtxoAddresses(
     tx,
     {
       GetAddress: deps.GetAddress,
@@ -519,7 +520,7 @@ export async function rawGetAllAddressesForDisplay(
 }
 export async function getAllAddressesForDisplay(
   request: {
-    publicDeriver: IPublicDeriver & IGetAllAddresses,
+    publicDeriver: IPublicDeriver & IGetAllUtxos,
   },
 ): Promise<Array<{| ...Address, ...Value, ...Addressing, ...UsedStatus |}>> {
   const deps = Object.freeze({
@@ -579,7 +580,7 @@ export async function rawGetNextUnusedIndex(
 }
 
 export function getUtxoBalanceForAddresses(
-  utxos: IGetAllUtxosResponse,
+  utxos: $ReadOnlyArray<$ReadOnly<UtxoTxOutput>>,
 ): { [key: number]: IGetUtxoBalanceResponse } {
   const groupByAddress = groupBy(
     utxos,
@@ -596,7 +597,7 @@ export function getUtxoBalanceForAddresses(
 export function getBalanceForUtxos(
   utxos: IGetAllUtxosResponse,
 ): IGetUtxoBalanceResponse {
-  const amounts = utxos.map(utxo => new BigNumber(utxo.UtxoTransactionOutput.Amount));
+  const amounts = utxos.map(utxo => new BigNumber(utxo.output.UtxoTransactionOutput.Amount));
   const total = amounts.reduce(
     (acc, amount) => acc.plus(amount),
     new BigNumber(0)

--- a/app/api/ada/lib/storage/tests/index.test.js
+++ b/app/api/ada/lib/storage/tests/index.test.js
@@ -3,7 +3,6 @@
 import {
   schema,
 } from 'lovefield';
-import stableStringify from 'json-stable-stringify';
 import '../../test-config';
 import { loadLovefieldDB } from '../database/index';
 import {

--- a/app/api/ada/lib/storage/tests/index.test.js
+++ b/app/api/ada/lib/storage/tests/index.test.js
@@ -31,7 +31,7 @@ import {
 import {
   PublicDeriver,
   asAddFromPublic,
-  asGetAllAddresses,
+  asGetAllUtxos,
   asGetPublicKey,
   asDisplayCutoff,
   asHasChains,
@@ -207,10 +207,10 @@ test('Can add and fetch address in wallet', async (done) => {
       });
     }
 
-    const asGetAllAddressesInstance = asGetAllAddresses(publicDeriver);
-    expect(asGetAllAddressesInstance != null).toEqual(true);
-    if (asGetAllAddressesInstance != null) {
-      const addresses = await asGetAllAddressesInstance.getAllAddresses();
+    const withUtxos = asGetAllUtxos(publicDeriver);
+    expect(withUtxos != null).toEqual(true);
+    if (withUtxos != null) {
+      const addresses = await withUtxos.getAllUtxoAddresses();
       expect(addresses.length).toEqual(40);
       expect(addresses[0].addr.Hash).toEqual(firstExternalAddressHash);
       expect(addresses[0].addressing.path).toEqual([

--- a/app/api/ada/lib/utils.js
+++ b/app/api/ada/lib/utils.js
@@ -202,7 +202,7 @@ export function signRequestFee(req: BaseSignRequest, shift: boolean): BigNumber 
     .map(utxo => new BigNumber(utxo.amount))
     .reduce((sum, val) => sum.plus(val), new BigNumber(0));
 
-  const tx: TransactionType = req.unsignedTx.to_json();
+  const tx = req.unsignedTx.to_json();
   const outputTotal = tx.outputs
     .map(val => new BigNumber(val.value))
     .reduce((sum, val) => sum.plus(val), new BigNumber(0));
@@ -231,7 +231,7 @@ export function signRequestTotalInput(req: BaseSignRequest, shift: boolean): Big
 }
 
 export function signRequestReceivers(req: BaseSignRequest, includeChange: boolean): Array<string> {
-  const tx: TransactionType = req.unsignedTx.to_json();
+  const tx = req.unsignedTx.to_json();
   let receivers = tx.outputs
     .map(val => val.address);
 

--- a/app/stores/ada/AdaTransactionsStore.js
+++ b/app/stores/ada/AdaTransactionsStore.js
@@ -19,7 +19,7 @@ import { assuranceLevels, } from '../../config/transactionAssuranceConfig';
 import type {
   GetTransactionRowsToExportFunc,
 } from '../../api/ada';
-import { asGetAllAddresses, } from '../../api/ada/lib/storage/models/PublicDeriver/index';
+import { asGetAllUtxos, } from '../../api/ada/lib/storage/models/PublicDeriver/index';
 
 import type {
   ExportTransactionsRequest,
@@ -105,11 +105,11 @@ export default class AdaTransactionsStore extends TransactionsStore {
 
       const publicDeriver = this.stores.substores.ada.wallets.selected;
       if (!publicDeriver) return;
-      const withGetAddresses = asGetAllAddresses(publicDeriver.self);
-      if (!withGetAddresses) return;
+      const withUtxos = asGetAllUtxos(publicDeriver.self);
+      if (!withUtxos) return;
 
       this.getTransactionRowsToExportRequest.execute({
-        publicDeriver: withGetAddresses,
+        publicDeriver: withUtxos,
         ...params,
       });
       if (!this.getTransactionRowsToExportRequest.promise) throw new Error('should never happen');

--- a/app/stores/ada/LedgerSendStore.js
+++ b/app/stores/ada/LedgerSendStore.js
@@ -119,7 +119,6 @@ export default class LedgerSendStore extends Store {
         const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
         this.createLedgerSignTxDataRequest.execute({
           ...params,
-          getUTXOsForAddresses: stateFetcher.getUTXOsForAddresses,
           getTxsBodiesForUTXOs: stateFetcher.getTxsBodiesForUTXOs,
         });
         if (!this.createLedgerSignTxDataRequest.promise) throw new Error('should never happen');

--- a/app/stores/ada/TrezorSendStore.js
+++ b/app/stores/ada/TrezorSendStore.js
@@ -74,7 +74,6 @@ export default class TrezorSendStore extends Store {
       const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
       this.createTrezorSignTxDataRequest.execute({
         ...params,
-        getUTXOsForAddresses: stateFetcher.getUTXOsForAddresses,
         getTxsBodiesForUTXOs: stateFetcher.getTxsBodiesForUTXOs,
       });
       if (!this.createTrezorSignTxDataRequest.promise) throw new Error('should never happen');

--- a/app/stores/base/AddressesStore.js
+++ b/app/stores/base/AddressesStore.js
@@ -10,7 +10,7 @@ import type {
 } from '../../api/ada';
 import environment from '../../environment';
 import {
-  PublicDeriver, asGetAllAddresses, asHasChains, asDisplayCutoff,
+  PublicDeriver, asGetAllUtxos, asHasChains, asDisplayCutoff,
 } from '../../api/ada/lib/storage/models/PublicDeriver/index';
 import type {
   IHasChainsRequest
@@ -197,13 +197,13 @@ export default class AddressesStore extends Store {
   _wrapForAllAddresses = (request: {
     publicDeriver: PublicDeriver
   }): Promise<Array<StandardAddress>> => {
-    const withGetAllAddresses = asGetAllAddresses(request.publicDeriver);
-    if (withGetAllAddresses == null) {
+    const withUtxos = asGetAllUtxos(request.publicDeriver);
+    if (withUtxos == null) {
       Logger.error(`_wrapForAllAddresses incorrect public deriver`);
       return Promise.resolve([]);
     }
     return this.api[environment.API].getAllAddressesForDisplay({
-      publicDeriver: withGetAllAddresses
+      publicDeriver: withUtxos
     });
   }
   _wrapForChainAddresses = (request: {

--- a/app/stores/base/TransactionsStore.js
+++ b/app/stores/base/TransactionsStore.js
@@ -11,7 +11,7 @@ import type { GetTransactionsFunc, GetBalanceFunc,
 import environment from '../../environment';
 import {
   PublicDeriver,
-  asGetAllAddresses,
+  asGetAllUtxos,
   asGetBalance,
 } from '../../api/ada/lib/storage/models/PublicDeriver/index';
 import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
@@ -127,7 +127,7 @@ export default class TransactionsStore extends Store {
     const walletsStore = this.stores.substores[environment.API].wallets;
     const walletsActions = this.actions[environment.API].wallets;
 
-    const publicDeriver = asGetAllAddresses(basePubDeriver.self);
+    const publicDeriver = asGetAllUtxos(basePubDeriver.self);
     if (publicDeriver == null) {
       return;
     }

--- a/flow/declarations/cardano-wasm.js
+++ b/flow/declarations/cardano-wasm.js
@@ -833,7 +833,7 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
     /**
      * @returns {any}
      */
-    to_json(): any;
+    to_json(): SignedTransactionType;
 
     /**
      * @param {any} value
@@ -871,7 +871,7 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
     /**
      * @returns {any}
      */
-    to_json(): any;
+    to_json(): TransactionType;
 
     /**
      * @param {any} value
@@ -928,7 +928,7 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
     apply_output_policy(
       fee_algorithm: LinearFeeAlgorithm,
       policy: OutputPolicy
-    ): any;
+    ): Array<TxOutType<string>>;
 
     /**
      * @returns {Coin}
@@ -1031,7 +1031,7 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
     /**
      * @returns {any}
      */
-    to_json(): any;
+    to_json(): TxInputType;
 
     /**
      * @param {any} value
@@ -1055,7 +1055,7 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
      * serialize into a JsValue object
      * @returns {any}
      */
-    to_json(): any;
+    to_json(): TxOutType<string>;
 
     /**
      * retrieve the object from a JsValue.
@@ -1080,7 +1080,7 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
      * serialize into a JsValue object
      * @returns {any}
      */
-    to_json(): any;
+    to_json(): TxoPointerType;
 
     /**
      * retrieve the object from a JsValue.
@@ -1141,17 +1141,30 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
 // WASM bindings don't expose the underlying type of some Rust structs
 // so we expose the mourselves
 
-declare type TransactionType = {
-  inputs: Array<TxoPointerType>;
-  outputs: Array<TxOutType>;
-};
+declare type TransactionType = {|
+  inputs: Array<TxoPointerType>,
+  outputs: Array<TxOutType<number>>,
+|};
 
-declare type TxoPointerType = {
+declare type WitnessType = {|
+  PkWitness: Array<string>,
+|};
+declare type SignedTransactionType = {|
+  tx: TransactionType,
+  witness: Array<WitnessType>,
+|};
+
+declare type TxoPointerType = {|
   id: string,
-  index: number
-};
+  index: number,
+|};
 
-declare type TxOutType = {
+declare type TxOutType<T> = {|
   address: string,
-  value: number,
-};
+  value: T,
+|};
+
+declare type TxInputType = {|
+  ptr: TxoPointerType,
+  value: TxOutType<string>,
+|};


### PR DESCRIPTION
This PR does a few things

1) Storage v2 stores all the UTXO locally. However, for creating transactions we still took the UTXO from the server. This PR now makes it take the UTXO locally (which enables features like creating a transaction offline)
2) I add some missing types to the v2 WASM bindings (to make it easier to upgrade to v3 later)
3) I remove the `IGetAllAddresses` and add its functionality to `IGetAllUtxos`. This is because now we know Chimeric wallets will be implemented using a chain derivation so it no longer makes sense to just ask for all addresses. You need to instead ask for all UTXO addresses and ask for all Account addresses separately. This means that our "balance tracker" feature would probably best be implemented as a new wallet type as opposed to a subset of Bip44 (which storage v2 still supports)