### PR TITLE
Use bip39 for mnemonic to entropy

### DIFF
--- a/app/api/ada/adaWallet.test.js
+++ b/app/api/ada/adaWallet.test.js
@@ -50,6 +50,7 @@ test('Is valid Daedalus paper mnemonic', async () => {
 test('Unscramble Daedalus paper produces 12 valid words', async () => {
   const [words, count] = unscramblePaperMnemonic(VALID_DD_PAPER.words, 27);
   expect(count).toEqual(12);
+  if (words == null) throw new Error('failed to unscramble in test');
   expect(validateMnemonic(words)).toEqual(true);
 });
 

--- a/flow-typed/npm/bip39_v3.0.x.js
+++ b/flow-typed/npm/bip39_v3.0.x.js
@@ -1,0 +1,37 @@
+// @flow
+declare module 'bip39' {
+  declare export function mnemonicToSeedSync(
+    mnemonic: string,
+    password?: string
+  ): Buffer;
+  declare export function mnemonicToSeed(
+    mnemonic: string,
+    password?: string
+  ): Promise<Buffer>;
+  declare export function mnemonicToEntropy(
+    mnemonic: string,
+    wordlist?: string[]
+  ): string;
+  declare export function entropyToMnemonic(
+    entropy: Buffer | string,
+    wordlist?: string[]
+  ): string;
+  declare export function generateMnemonic(
+    strength?: number,
+    rng?: (size: number) => Buffer,
+    wordlist?: string[]
+  ): string;
+  declare export function validateMnemonic(
+    mnemonic: string, wordlist?: string[]
+  ): boolean;
+  declare export function setDefaultWordlist(
+    language: string
+  ): void;
+  declare export function getDefaultWordlist(): string;
+
+  declare export var wordlists: {
+    [index: string]: string[];
+  };
+  declare export var _default: string[] | void;
+
+}


### PR DESCRIPTION
The Rust team removed the ability to convert from a mnemonic to a private key in the Shelley WASM bindings (no more `from_english_mnemonics`). The idea was to use the BIP39 library instead but it turns out we can't do the migration beacuse

A) No way to turn an `Buffer` to a private key in WASM (only accepts `Entropy` type)
B) No way to generate paper wallets with a `Buffer` (only accepts `Entropy` type)

This PR at least makes it easier to make this change in the future if/when we can