### PR TITLE
Add accounting-style transactions

### DIFF
--- a/app/api/ada/adaTypes.js
+++ b/app/api/ada/adaTypes.js
@@ -63,12 +63,12 @@ export type BaseSignRequest = {|
   unsignedTx: RustModule.WalletV2.Transaction,
 |};
 
-export type V3UnsignedTxFromUtxoResponse = {|
+export type V3UnsignedTxUtxoResponse = {|
   senderUtxos: Array<RemoteUnspentOutput>,
   unsignedTx: RustModule.WalletV3.Transaction,
   changeAddr: Array<{| ...Address, ...Value, ...Addressing |}>,
 |};
-export type V3UnsignedTxResponse = {|
+export type V3UnsignedTxAddressedUtxoResponse = {|
   senderUtxos: Array<AddressedUtxo>,
   unsignedTx: RustModule.WalletV3.Transaction,
   changeAddr: Array<{| ...Address, ...Value, ...Addressing |}>,

--- a/app/api/ada/daedalusTransfer.js
+++ b/app/api/ada/daedalusTransfer.js
@@ -118,10 +118,10 @@ export async function buildTransferTx(
       );
 
     // first build a transaction to see what the fee will be
-    const txBuilder = await sendAllUnsignedTxFromUtxo(
+    const txBuilder = sendAllUnsignedTxFromUtxo(
       outputAddr,
       senderUtxos
-    ).then(resp => resp.txBuilder);
+    ).txBuilder;
     const fee = coinToBigNumber(txBuilder.get_balance_without_fees().value());
 
     // sign inputs

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -707,7 +707,7 @@ export default class AdaApi {
         ...signingKey,
         password,
       });
-      const signedTx = await signTransaction(
+      const signedTx = signTransaction(
         signRequest,
         request.publicDeriver.getBip44Parent().getPublicDeriverLevel(),
         RustModule.WalletV2.PrivateKey.from_hex(normalizedKey.prvKeyHex)
@@ -853,7 +853,7 @@ export default class AdaApi {
 
       let unsignedTxResponse;
       if (shouldSendAll) {
-        unsignedTxResponse = await sendAllUnsignedTx(
+        unsignedTxResponse = sendAllUnsignedTx(
           receiver,
           addressedUtxo
         );
@@ -863,7 +863,7 @@ export default class AdaApi {
           throw new Error('createUnsignedTx no internal addresses left. Should never happen');
         }
         const changeAddr = nextUnusedInternal.addressInfo;
-        unsignedTxResponse = await newAdaUnsignedTx(
+        unsignedTxResponse = newAdaUnsignedTx(
           receiver,
           amount,
           [{

--- a/app/api/ada/transactions/accountingTransaction.test.js
+++ b/app/api/ada/transactions/accountingTransaction.test.js
@@ -1,0 +1,79 @@
+// @flow
+import '../lib/test-config';
+
+import {
+  getTxInputTotal,
+  getTxOutputTotal,
+} from './utils';
+import {
+  NotEnoughMoneyToSendError,
+} from '../errors';
+import {
+  buildTransaction,
+  signTransaction,
+} from './accountingTransactions';
+import { RustModule } from '../lib/cardanoCrypto/rustLoader';
+import BigNumber from 'bignumber.js';
+
+beforeAll(async () => {
+  await RustModule.load();
+});
+
+describe('Create unsigned TX for account', () => {
+  it('Should create a valid transaction', async () => {
+    const senderKey = RustModule.WalletV3.PrivateKey.from_bech32(
+      'ed25519_sk1ahfetf02qwwg4dkq7mgp4a25lx5vh9920cr5wnxmpzz9906qvm8qwvlts0'
+    );
+
+    const unsignedTxResponse = buildTransaction(
+      senderKey.to_public(),
+      'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+      new BigNumber(2000000),
+      new BigNumber(5000000),
+    );
+    const inputSum = getTxInputTotal(unsignedTxResponse);
+    const outputSum = getTxOutputTotal(unsignedTxResponse);
+    expect(inputSum.toString()).toEqual('2155383');
+    expect(outputSum.toString()).toEqual('2000000');
+    expect(inputSum.minus(outputSum).toString()).toEqual('155383');
+
+    const signedTx = signTransaction(
+      unsignedTxResponse,
+      0,
+      senderKey,
+    );
+
+    const witnesses = signedTx.witnesses();
+
+    expect(witnesses.size()).toEqual(1);
+    expect(witnesses.get(0).to_bech32()).toEqual(
+      'witness1qfmmw476z0hd33wfx32p0qkn3xc7j42h0gr37z3vgq9aanzn3v6vm93j7wzpdea3qg440a4vwtdta0vf7mv5vd2d96s2xjw8urj73dc93jsax4'
+    );
+  });
+
+  it('Should fail due to insufficient funds (not enough to cover fees)', () => {
+    const senderKey = RustModule.WalletV3.PrivateKey.from_bech32(
+      'ed25519_sk1ahfetf02qwwg4dkq7mgp4a25lx5vh9920cr5wnxmpzz9906qvm8qwvlts0'
+    );
+
+    expect(() => buildTransaction(
+      senderKey.to_public(),
+      'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+      new BigNumber(2000000),
+      new BigNumber(2000000),
+    )).toThrow(NotEnoughMoneyToSendError);
+  });
+
+  it('Should fail due to insufficient funds (not enough to cover amount)', () => {
+    const senderKey = RustModule.WalletV3.PrivateKey.from_bech32(
+      'ed25519_sk1ahfetf02qwwg4dkq7mgp4a25lx5vh9920cr5wnxmpzz9906qvm8qwvlts0'
+    );
+
+    expect(() => buildTransaction(
+      senderKey.to_public(),
+      'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+      new BigNumber(2000000),
+      new BigNumber(1000000),
+    )).toThrow(NotEnoughMoneyToSendError);
+  });
+});

--- a/app/api/ada/transactions/accountingTransactions.js
+++ b/app/api/ada/transactions/accountingTransactions.js
@@ -1,0 +1,93 @@
+// @flow
+
+import {
+  NotEnoughMoneyToSendError,
+} from '../errors';
+import type { ConfigType } from '../../../../config/config-types';
+import { RustModule } from '../lib/cardanoCrypto/rustLoader';
+import BigNumber from 'bignumber.js';
+
+declare var CONFIG: ConfigType;
+
+export function buildTransaction(
+  sender: RustModule.WalletV3.PublicKey,
+  receiver: string,
+  amount: BigNumber,
+  accountBalance: BigNumber,
+): RustModule.WalletV3.Transaction {
+  if (amount.gt(accountBalance)) {
+    throw new NotEnoughMoneyToSendError();
+  }
+  const sourceAccount = RustModule.WalletV3.Account.from_public_key(sender);
+
+  const feeAlgorithm = RustModule.WalletV3.Fee.linear_fee(
+    RustModule.WalletV3.Value.from_str(CONFIG.app.linearFee.constant),
+    RustModule.WalletV3.Value.from_str(CONFIG.app.linearFee.coefficient),
+    RustModule.WalletV3.Value.from_str(CONFIG.app.linearFee.certificate),
+  );
+
+  let fee;
+  {
+    const fakeTxBuilder = RustModule.WalletV3.TransactionBuilder.new_no_payload();
+    fakeTxBuilder.add_input(
+      RustModule.WalletV3.Input.from_account(
+        sourceAccount,
+        // the value we put in here is irrelevant. Just need some value to be able to calculate fee
+        RustModule.WalletV3.Value.from_str('1000000'),
+      ),
+    );
+    fakeTxBuilder.add_output(
+      RustModule.WalletV3.Address.from_string(receiver),
+      // the value we put in here is irrelevant. Just need some value to be able to calculate fee
+      RustModule.WalletV3.Value.from_str('1')
+    );
+
+    const tx = fakeTxBuilder.seal_with_output_policy(
+      feeAlgorithm,
+      RustModule.WalletV3.OutputPolicy.forget()
+    );
+    const calculatedFee = feeAlgorithm.calculate(tx);
+    if (calculatedFee == null) {
+      throw new NotEnoughMoneyToSendError();
+    }
+    fee = new BigNumber(calculatedFee.to_str());
+  }
+  const newAmount = amount.plus(fee);
+  if (newAmount.gt(accountBalance)) {
+    throw new NotEnoughMoneyToSendError();
+  }
+
+  const txBuilder = RustModule.WalletV3.TransactionBuilder.new_no_payload();
+  txBuilder.add_input(
+    RustModule.WalletV3.Input.from_account(
+      sourceAccount,
+      RustModule.WalletV3.Value.from_str(newAmount.toString()),
+    ),
+  );
+  txBuilder.add_output(
+    RustModule.WalletV3.Address.from_string(receiver),
+    RustModule.WalletV3.Value.from_str(amount.toString())
+  );
+
+  const tx = txBuilder.seal_with_output_policy(
+    feeAlgorithm,
+    RustModule.WalletV3.OutputPolicy.forget()
+  );
+  return tx;
+}
+
+export function signTransaction(
+  unsignedTx: RustModule.WalletV3.Transaction,
+  accountCounter: number,
+  accountPrivateKey: RustModule.WalletV3.PrivateKey
+): RustModule.WalletV3.AuthenticatedTransaction {
+  const txFinalizer = new RustModule.WalletV3.TransactionFinalizer(unsignedTx);
+  const witness = RustModule.WalletV3.Witness.for_account(
+    RustModule.WalletV3.Hash.from_hex(CONFIG.app.genesisHash),
+    txFinalizer.get_tx_sign_data_hash(),
+    accountPrivateKey,
+    RustModule.WalletV3.SpendingCounter.from_u32(accountCounter)
+  );
+  txFinalizer.set_witness(0, witness);
+  return txFinalizer.finalize();
+}

--- a/app/api/ada/transactions/legacy/transactionV2.test.js
+++ b/app/api/ada/transactions/legacy/transactionV2.test.js
@@ -98,9 +98,9 @@ beforeAll(async () => {
 });
 
 describe('Create unsigned TX from UTXO', () => {
-  it('Should create a valid transaction withhout selection', async () => {
+  it('Should create a valid transaction withhout selection', () => {
     const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[1]];
-    const unsignedTxResponse = await newAdaUnsignedTxFromUtxo(
+    const unsignedTxResponse = newAdaUnsignedTxFromUtxo(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       '5001', // smaller than input
       [],
@@ -116,38 +116,38 @@ describe('Create unsigned TX from UTXO', () => {
     expect(unsignedTxResponse.txBuilder.get_balance_without_fees().value().to_str()).toEqual('0.995000');
   });
 
-  it('Should fail due to insufficient funds (bigger than all inputs)', async () => {
+  it('Should fail due to insufficient funds (bigger than all inputs)', () => {
     const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[1]];
-    expect(newAdaUnsignedTxFromUtxo(
+    expect(() => newAdaUnsignedTxFromUtxo(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       '1900001', // bigger than input including fees
       [],
       utxos
-    )).rejects.toThrow(NotEnoughMoneyToSendError);
+    )).toThrow(NotEnoughMoneyToSendError);
   });
 
-  it('Should fail due to insufficient funds (no inputs)', async () => {
-    expect(newAdaUnsignedTxFromUtxo(
+  it('Should fail due to insufficient funds (no inputs)', () => {
+    expect(() => newAdaUnsignedTxFromUtxo(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       '1', // bigger than input including fees
       [],
       [],
-    )).rejects.toThrow(NotEnoughMoneyToSendError);
+    )).toThrow(NotEnoughMoneyToSendError);
   });
 
-  it('Should fail due to insufficient funds (not enough to cover fees)', async () => {
+  it('Should fail due to insufficient funds (not enough to cover fees)', () => {
     const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[0]];
-    expect(newAdaUnsignedTxFromUtxo(
+    expect(() => newAdaUnsignedTxFromUtxo(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       '1', // bigger than input including fees
       [],
       utxos,
-    )).rejects.toThrow(NotEnoughMoneyToSendError);
+    )).toThrow(NotEnoughMoneyToSendError);
   });
 
-  it('Should pick inputs when using input selection', async () => {
+  it('Should pick inputs when using input selection', () => {
     const utxos: Array<RemoteUnspentOutput> = sampleUtxos;
-    const unsignedTxResponse = await newAdaUnsignedTxFromUtxo(
+    const unsignedTxResponse = newAdaUnsignedTxFromUtxo(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       '1001', // smaller than input
       [sampleAdaAddresses[0]],
@@ -166,8 +166,8 @@ describe('Create unsigned TX from UTXO', () => {
 
 
 describe('Create unsigned TX from addresses', () => {
-  it('Should create a valid transaction withhout selection', async () => {
-    const unsignedTxResponse = await newAdaUnsignedTx(
+  it('Should create a valid transaction withhout selection', () => {
+    const unsignedTxResponse = newAdaUnsignedTx(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       '5001', // smaller than input
       [],
@@ -185,8 +185,8 @@ describe('Create unsigned TX from addresses', () => {
 });
 
 describe('Create signed transactions', () => {
-  it('Witness should match on valid private key', async () => {
-    const unsignedTxResponse = await newAdaUnsignedTx(
+  it('Witness should match on valid private key', () => {
+    const unsignedTxResponse = newAdaUnsignedTx(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       '5001', // smaller than input
       [],
@@ -224,7 +224,7 @@ describe('Create signed transactions', () => {
     ]);
   });
 
-  it('Witness should with addressing from root', async () => {
+  it('Witness should with addressing from root', () => {
     const accountPrivateKey = RustModule.WalletV2.Bip44AccountPrivate.new(
       RustModule.WalletV2.PrivateKey.from_hex(
         '70afd5ff1f7f551c481b7e3f3541f7c63f5f6bcb293af92565af3deea0bcd6481a6e7b8acbe38f3906c63ccbe8b2d9b876572651ac5d2afc0aca284d9412bb1b4839bf02e1d990056d0f06af22ce4bcca52ac00f1074324aab96bbaaaccf290d'
@@ -301,9 +301,9 @@ describe('Create signed transactions', () => {
 
 describe('Create sendAll unsigned TX from UTXO', () => {
   describe('Create send-all TX from UTXO', () => {
-    it('Create a transaction involving all input with no change', async () => {
+    it('Create a transaction involving all input with no change', () => {
       const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[1], sampleUtxos[2]];
-      const sendAllResponse = await sendAllUnsignedTxFromUtxo(
+      const sendAllResponse = sendAllUnsignedTxFromUtxo(
         'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
         utxos,
       );
@@ -319,19 +319,19 @@ describe('Create sendAll unsigned TX from UTXO', () => {
     });
   });
 
-  it('Should fail due to insufficient funds (no inputs)', async () => {
-    expect(sendAllUnsignedTxFromUtxo(
+  it('Should fail due to insufficient funds (no inputs)', () => {
+    expect(() => sendAllUnsignedTxFromUtxo(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       [],
-    )).rejects.toThrow(NotEnoughMoneyToSendError);
+    )).toThrow(NotEnoughMoneyToSendError);
   });
 
-  it('Should fail due to insufficient funds (not enough to cover fees)', async () => {
+  it('Should fail due to insufficient funds (not enough to cover fees)', () => {
     const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[0]];
-    expect(sendAllUnsignedTxFromUtxo(
+    expect(() => sendAllUnsignedTxFromUtxo(
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
       utxos,
-    )).rejects.toThrow(NotEnoughMoneyToSendError);
+    )).toThrow(NotEnoughMoneyToSendError);
   });
 
 });

--- a/app/api/ada/transactions/legacy/transactionsV2.js
+++ b/app/api/ada/transactions/legacy/transactionsV2.js
@@ -29,10 +29,10 @@ import type { IGetAllUtxosResponse } from '../../lib/storage/models/PublicDerive
 declare var CONFIG: ConfigType;
 const protocolMagic = CONFIG.network.protocolMagic;
 
-export async function sendAllUnsignedTx(
+export function sendAllUnsignedTx(
   receiver: string,
   allUtxos: Array<AddressedUtxo>,
-): Promise<UnsignedTxResponse> {
+): UnsignedTxResponse {
   const addressingMap = new Map<RemoteUnspentOutput, AddressedUtxo>();
   for (const utxo of allUtxos) {
     addressingMap.set({
@@ -43,7 +43,7 @@ export async function sendAllUnsignedTx(
       utxo_id: utxo.utxo_id
     }, utxo);
   }
-  const unsignedTxResponse = await sendAllUnsignedTxFromUtxo(
+  const unsignedTxResponse = sendAllUnsignedTxFromUtxo(
     receiver,
     Array.from(addressingMap.keys())
   );
@@ -65,10 +65,10 @@ export async function sendAllUnsignedTx(
   };
 }
 
-export async function sendAllUnsignedTxFromUtxo(
+export function sendAllUnsignedTxFromUtxo(
   receiver: string,
   allUtxos: Array<RemoteUnspentOutput>,
-): Promise<UnsignedTxFromUtxoResponse> {
+): UnsignedTxFromUtxoResponse {
   const totalBalance = allUtxos
     .map(utxo => new BigNumber(utxo.amount))
     .reduce(
@@ -96,7 +96,7 @@ export async function sendAllUnsignedTxFromUtxo(
     throw new NotEnoughMoneyToSendError();
   }
   const newAmount = totalBalance.minus(fee).toString();
-  const unsignedTxResponse = await newAdaUnsignedTxFromUtxo(receiver, newAmount, [], allUtxos);
+  const unsignedTxResponse = newAdaUnsignedTxFromUtxo(receiver, newAmount, [], allUtxos);
 
   // sanity check
   const balance = unsignedTxResponse.txBuilder.get_balance(feeAlgorithm);
@@ -118,12 +118,12 @@ export async function sendAllUnsignedTxFromUtxo(
  * This maximizes privacy.
  * The address will not be part of the input if it has no UTXO in it
  */
-export async function newAdaUnsignedTx(
+export function newAdaUnsignedTx(
   receiver: string,
   amount: string,
   changeAdaAddr: Array<{| ...Address, ...Addressing |}>,
   allUtxos: Array<AddressedUtxo>,
-): Promise<UnsignedTxResponse> {
+): UnsignedTxResponse {
   const addressingMap = new Map<RemoteUnspentOutput, AddressedUtxo>();
   for (const utxo of allUtxos) {
     addressingMap.set({
@@ -134,7 +134,7 @@ export async function newAdaUnsignedTx(
       utxo_id: utxo.utxo_id
     }, utxo);
   }
-  const unsignedTxResponse = await newAdaUnsignedTxFromUtxo(
+  const unsignedTxResponse = newAdaUnsignedTxFromUtxo(
     receiver,
     amount,
     changeAdaAddr,
@@ -164,12 +164,12 @@ export async function newAdaUnsignedTx(
  * A) Addressing
  * B) Having the key provided externally
  */
-export async function newAdaUnsignedTxFromUtxo(
+export function newAdaUnsignedTxFromUtxo(
   receiver: string,
   amount: string,
   changeAdaAddr: Array<{| ...Address, ...Addressing |}>,
   allUtxos: Array<RemoteUnspentOutput>,
-): Promise<UnsignedTxFromUtxoResponse> {
+): UnsignedTxFromUtxoResponse {
   const feeAlgorithm = RustModule.WalletV2.LinearFeeAlgorithm.default();
 
   const txInputs = utxoToTxInput(allUtxos);
@@ -202,7 +202,7 @@ export async function newAdaUnsignedTxFromUtxo(
   }
 
   const txBuilder = new RustModule.WalletV2.TransactionBuilder();
-  const changeAddrTxOut = await addTxIO(
+  const changeAddrTxOut = addTxIO(
     txBuilder, senderInputs, outputPolicy, feeAlgorithm, receiver, amount
   );
   const change = filterToUsedChange(changeAdaAddr, changeAddrTxOut);

--- a/app/api/ada/transactions/utxoTransactions.test.js
+++ b/app/api/ada/transactions/utxoTransactions.test.js
@@ -119,18 +119,9 @@ beforeAll(async () => {
 });
 
 describe('Create unsigned TX from UTXO', () => {
-  it('Should create a valid transaction withhout selection', async () => {
-    // const pubKey = v2PkKeyToV3Key(
-    //   RustModule.WalletV2.PublicKey.from_hex(keys[2].pubKey)
-    // );
-    // const address = RustModule.WalletV3.Address.single_from_public_key(
-    //   pubKey,
-    //   RustModule.WalletV3.AddressDiscrimination.Production,
-    // );
-    // console.log(address.to_string('ca'));
-
+  it('Should create a valid transaction withhout selection', () => {
     const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[1]];
-    const unsignedTxResponse = await newAdaUnsignedTxFromUtxo(
+    const unsignedTxResponse = newAdaUnsignedTxFromUtxo(
       keys[0].bechAddress,
       '5001', // smaller than input
       [],
@@ -144,38 +135,38 @@ describe('Create unsigned TX from UTXO', () => {
     expect(inputSum.minus(outputSum).toString()).toEqual('995000');
   });
 
-  it('Should fail due to insufficient funds (bigger than all inputs)', async () => {
+  it('Should fail due to insufficient funds (bigger than all inputs)', () => {
     const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[1]];
-    expect(newAdaUnsignedTxFromUtxo(
+    expect(() => newAdaUnsignedTxFromUtxo(
       keys[0].bechAddress,
       '1900001', // bigger than input including fees
       [],
       utxos
-    )).rejects.toThrow(NotEnoughMoneyToSendError);
+    )).toThrow(NotEnoughMoneyToSendError);
   });
 
-  it('Should fail due to insufficient funds (no inputs)', async () => {
-    expect(newAdaUnsignedTxFromUtxo(
+  it('Should fail due to insufficient funds (no inputs)', () => {
+    expect(() => newAdaUnsignedTxFromUtxo(
       keys[0].bechAddress,
       '1', // bigger than input including fees
       [],
       [],
-    )).rejects.toThrow(NotEnoughMoneyToSendError);
+    )).toThrow(NotEnoughMoneyToSendError);
   });
 
-  it('Should fail due to insufficient funds (not enough to cover fees)', async () => {
+  it('Should fail due to insufficient funds (not enough to cover fees)', () => {
     const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[0]];
-    expect(newAdaUnsignedTxFromUtxo(
+    expect(() => newAdaUnsignedTxFromUtxo(
       keys[0].bechAddress,
       '1', // bigger than input including fees
       [],
       utxos,
-    )).rejects.toThrow(NotEnoughMoneyToSendError);
+    )).toThrow(NotEnoughMoneyToSendError);
   });
 
-  it('Should pick inputs when using input selection', async () => {
+  it('Should pick inputs when using input selection', () => {
     const utxos: Array<RemoteUnspentOutput> = sampleUtxos;
-    const unsignedTxResponse = await newAdaUnsignedTxFromUtxo(
+    const unsignedTxResponse = newAdaUnsignedTxFromUtxo(
       keys[0].bechAddress,
       '1001', // smaller than input
       [sampleAdaAddresses[0]],
@@ -193,8 +184,8 @@ describe('Create unsigned TX from UTXO', () => {
 
 
   describe('Create unsigned TX from addresses', () => {
-    it('Should create a valid transaction withhout selection', async () => {
-      const unsignedTxResponse = await newAdaUnsignedTx(
+    it('Should create a valid transaction withhout selection', () => {
+      const unsignedTxResponse = newAdaUnsignedTx(
         keys[0].bechAddress,
         '5001', // smaller than input
         [],
@@ -210,8 +201,8 @@ describe('Create unsigned TX from UTXO', () => {
   });
 
   describe('Create signed transactions', () => {
-    it('Witness should match on valid private key', async () => {
-      const unsignedTxResponse = await newAdaUnsignedTx(
+    it('Witness should match on valid private key', () => {
+      const unsignedTxResponse = newAdaUnsignedTx(
         keys[0].bechAddress,
         '5001', // smaller than input
         [],
@@ -240,8 +231,8 @@ describe('Create unsigned TX from UTXO', () => {
       );
     });
 
-    it('Witness should with addressing from root', async () => {
-      const unsignedTxResponse = await newAdaUnsignedTx(
+    it('Witness should with addressing from root', () => {
+      const unsignedTxResponse = newAdaUnsignedTx(
         keys[0].bechAddress,
         '5001', // smaller than input
         [],
@@ -296,9 +287,9 @@ describe('Create unsigned TX from UTXO', () => {
 
   describe('Create sendAll unsigned TX from UTXO', () => {
     describe('Create send-all TX from UTXO', () => {
-      it('Create a transaction involving all input with no change', async () => {
+      it('Create a transaction involving all input with no change', () => {
         const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[1], sampleUtxos[2]];
-        const sendAllResponse = await sendAllUnsignedTxFromUtxo(
+        const sendAllResponse = sendAllUnsignedTxFromUtxo(
           keys[0].bechAddress,
           utxos,
         );
@@ -312,19 +303,19 @@ describe('Create unsigned TX from UTXO', () => {
       });
     });
 
-    it('Should fail due to insufficient funds (no inputs)', async () => {
-      expect(sendAllUnsignedTxFromUtxo(
+    it('Should fail due to insufficient funds (no inputs)', () => {
+      expect(() => sendAllUnsignedTxFromUtxo(
         keys[0].bechAddress,
         [],
-      )).rejects.toThrow(NotEnoughMoneyToSendError);
+      )).toThrow(NotEnoughMoneyToSendError);
     });
 
-    it('Should fail due to insufficient funds (not enough to cover fees)', async () => {
+    it('Should fail due to insufficient funds (not enough to cover fees)', () => {
       const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[0]];
-      expect(sendAllUnsignedTxFromUtxo(
+      expect(() => sendAllUnsignedTxFromUtxo(
         keys[0].bechAddress,
         utxos,
-      )).rejects.toThrow(NotEnoughMoneyToSendError);
+      )).toThrow(NotEnoughMoneyToSendError);
     });
   });
 });


### PR DESCRIPTION
In the same PR I noticed that the UTXO transaction functions had a bunch of pointless `async` functions in them (they are no longer async but used to be when we made network calls to fetch the UTXO). I removed all of this.