### PR TITLE
disable URI code for Shelley

### DIFF
--- a/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -966,7 +966,7 @@ export async function networkTxToDbTx(
               const wasmAddr = RustModule.WalletV3.Address.from_string(output.address);
               txType = wasmAddr.get_discrimination();
             } catch (_e2) {
-              throw new Error('networkTxToDbTx Unknown output type');
+              throw new Error('networkTxToDbTx Unknown output type ' + output.address);
             }
           }
           // consider a group address as a UTXO output

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -18,6 +18,7 @@ import RawHash from '../widgets/hashWrappers/RawHash';
 import ExplorableHashContainer from '../../containers/widgets/ExplorableHashContainer';
 import type { ExplorerType } from '../../domain/Explorer';
 import type { StandardAddress } from '../../stores/base/AddressesStore';
+import environment from '../../environment';
 
 const messages = defineMessages({
   walletAddressLabel: {
@@ -224,26 +225,28 @@ export default class WalletReceive extends Component<Props, State> {
                 {/* Address Action block start */}
                 <div className={styles.addressActions}>
                   {/* Generate payment URL for Address action */}
-                  <div className={classnames([
-                    styles.addressActionItemBlock,
-                    styles.generateURLActionBlock])}
-                  >
-                    <button
-                      type="button"
-                      onClick={onGeneratePaymentURI.bind(this, address.address)}
-                      className={styles.btnGenerateURI}
+                  {!environment.isShelley() && // disable URI for Shelley testnet
+                    <div className={classnames([
+                      styles.addressActionItemBlock,
+                      styles.generateURLActionBlock])}
                     >
-                      <div className={styles.generateURLActionBlock}>
-                        <SvgInline
-                          svg={generateURIIcon}
-                          className={styles.generateURIIcon}
-                        />
-                        <span className={styles.actionIconText}>
-                          {intl.formatMessage(messages.generatePaymentURLLabel)}
-                        </span>
-                      </div>
-                    </button>
-                  </div>
+                      <button
+                        type="button"
+                        onClick={onGeneratePaymentURI.bind(this, address.address)}
+                        className={styles.btnGenerateURI}
+                      >
+                        <div className={styles.generateURLActionBlock}>
+                          <SvgInline
+                            svg={generateURIIcon}
+                            className={styles.generateURIIcon}
+                          />
+                          <span className={styles.actionIconText}>
+                            {intl.formatMessage(messages.generatePaymentURLLabel)}
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  }
                   {/* Verify Address action */}
                   <div className={classnames([
                     styles.addressActionItemBlock,

--- a/app/containers/settings/categories/GeneralSettingsPage.js
+++ b/app/containers/settings/categories/GeneralSettingsPage.js
@@ -57,6 +57,7 @@ export default class GeneralSettingsPage extends Component<InjectedProps> {
       }));
     const { currentTheme } = this.props.stores.profile;
 
+    // disable for Shelley to avoid overriding mainnet Yoroi URI
     const uriSettings = environment.userAgentInfo.canRegisterProtocol() && !environment.isShelley()
       ? (
         <UriSettingsBlock

--- a/app/containers/settings/categories/GeneralSettingsPage.js
+++ b/app/containers/settings/categories/GeneralSettingsPage.js
@@ -57,7 +57,7 @@ export default class GeneralSettingsPage extends Component<InjectedProps> {
       }));
     const { currentTheme } = this.props.stores.profile;
 
-    const uriSettings = environment.userAgentInfo.canRegisterProtocol()
+    const uriSettings = environment.userAgentInfo.canRegisterProtocol() && !environment.isShelley()
       ? (
         <UriSettingsBlock
           registerUriScheme={() => registerProtocols()}

--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -66,7 +66,7 @@ export default class ProfileStore extends Store {
     },
     {
       isDone: () => (
-        environment.isShelley() || // disable for Shelley to overriding mainnet Yoroi URI
+        environment.isShelley() || // disable for Shelley to avoid overriding mainnet Yoroi URI
         !environment.userAgentInfo.canRegisterProtocol() ||
         this.isUriSchemeAccepted
       ),

--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -65,7 +65,11 @@ export default class ProfileStore extends Store {
       },
     },
     {
-      isDone: () => !environment.userAgentInfo.canRegisterProtocol() || this.isUriSchemeAccepted,
+      isDone: () => (
+        environment.isShelley() || // disable for Shelley to overriding mainnet Yoroi URI
+        !environment.userAgentInfo.canRegisterProtocol() ||
+        this.isUriSchemeAccepted
+      ),
       action: () => {
         const route = ROUTES.PROFILE.URI_PROMPT;
         if (this.stores.app.currentRoute === route) {


### PR DESCRIPTION
I'm disabling the `web+yoroi` payment URLs for Shelley since this would override a user's mainnet config.