### PR TITLE
Add shelley explorer links

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -118,9 +118,6 @@ import {
 } from './lib/storage/models/utils';
 import { convertAdaTransactionsToExportRows } from './lib/utils';
 import { migrateToLatest } from './lib/storage/adaMigration';
-import {
-  makeCardanoBIP44Path,
-} from 'yoroi-extension-ledger-connect-handler';
 import { generateAdaPaperPdf } from './paperWallet/paperWalletPdf';
 import type { PdfGenStepType } from './paperWallet/paperWalletPdf';
 import type { TransactionExportRow } from '../export';

--- a/app/api/ada/lib/storage/adaLocalStorage.js
+++ b/app/api/ada/lib/storage/adaLocalStorage.js
@@ -3,7 +3,7 @@
 // Wrapper API to Save&Load localstorage using JSON
 
 import type { ExplorerType } from '../../../../domain/Explorer';
-import { Explorer } from '../../../../domain/Explorer';
+import { getDefaultExplorer } from '../../../../domain/Explorer';
 import { getLocalItem, setLocalItem } from '../../../localStorage/primitives';
 
 // Use constant keys to store/load localstorage
@@ -19,7 +19,7 @@ export async function saveSelectedExplorer(explorer: ExplorerType): Promise<void
 
 export async function getSelectedExplorer(): Promise<ExplorerType> {
   const explorer = await _getFromStorage<ExplorerType>(storageKeys.SELECTED_EXPLORER_KEY);
-  return explorer || Explorer.SEIZA;
+  return explorer || getDefaultExplorer();
 }
 
 /* Util functions */

--- a/app/api/ada/lib/storage/database/accountingTransactions/api/read.js
+++ b/app/api/ada/lib/storage/database/accountingTransactions/api/read.js
@@ -2,13 +2,7 @@
 
 import type {
   lf$Database,
-  lf$Predicate,
-  lf$schema$Table,
   lf$Transaction,
-  lf$query$Select,
-} from 'lovefield';
-import {
-  op,
 } from 'lovefield';
 import { groupBy, } from 'lodash';
 
@@ -18,9 +12,7 @@ import type {
   AccountingTransactionOutputRow,
   DbAccountingInputs, DbAccountingOutputs,
 } from '../tables';
-import { TxStatusCodes, TransactionSchema, } from '../../primitives/tables';
 import type {
-  TxStatusCodesType,
   TransactionRow,
 } from '../../primitives/tables';
 import { getRowIn, } from '../../utils';

--- a/app/components/settings/categories/general-setting/ExplorerSettings.js
+++ b/app/components/settings/categories/general-setting/ExplorerSettings.js
@@ -13,7 +13,7 @@ import type { ExplorerType } from '../../../../domain/Explorer';
 
 
 type Props = {|
-  explorers: Array<{ value: ExplorerType, label: string }>,
+  explorers: Array<{| value: ExplorerType, label: string |}>,
   selectedExplorer: ExplorerType,
   onSelectExplorer: Function,
   isSubmitting: boolean,

--- a/app/containers/settings/categories/GeneralSettingsPage.js
+++ b/app/containers/settings/categories/GeneralSettingsPage.js
@@ -11,7 +11,7 @@ import registerProtocols from '../../../uri-protocols';
 import environment from '../../../environment';
 import AboutYoroiSettingsBlock from '../../../components/settings/categories/general-setting/AboutYoroiSettingsBlock';
 import type { ExplorerType } from '../../../domain/Explorer';
-import { Explorer, explorerInfo } from '../../../domain/Explorer';
+import { getExplorers } from '../../../domain/Explorer';
 
 @observer
 export default class GeneralSettingsPage extends Component<InjectedProps> {
@@ -50,11 +50,7 @@ export default class GeneralSettingsPage extends Component<InjectedProps> {
     } = this.props.stores.profile;
     const isSubmittingLocale = setProfileLocaleRequest.isExecuting;
     const isSubmittingExplorer = setSelectedExplorerRequest.isExecuting;
-    const explorerOptions = Object.keys(Explorer)
-      .map(key => ({
-        value: Explorer[key],
-        label: explorerInfo[Explorer[key]].name,
-      }));
+    const explorerOptions = getExplorers();
     const { currentTheme } = this.props.stores.profile;
 
     // disable for Shelley to avoid overriding mainnet Yoroi URI

--- a/app/domain/Explorer.js
+++ b/app/domain/Explorer.js
@@ -1,12 +1,40 @@
 // @flow
 
-export const Explorer = Object.freeze({
+import environment from '../environment';
+
+const ShelleyExplorers = Object.freeze({
+  SEIZA: 'seiza',
+  JORMUNGANDR: 'jormungandr',
+});
+const ByronExplorers = Object.freeze({
   SEIZA: 'seiza',
   CLIO: 'clio',
   ADA_SCAN: 'adascan',
   CARDANO_EXPLORER: 'cardano_explorer',
 });
-export type ExplorerType = $Values<typeof Explorer>;
+export function getDefaultExplorer(): ExplorerType {
+  return environment.isShelley()
+    ? 'jormungandr'
+    : 'seiza';
+}
+export function getExplorers(): Array<{| value: ExplorerType, label: string |}> {
+  if (environment.isShelley()) {
+    return Object.keys(ShelleyExplorers)
+      .map(key => ({
+        value: ShelleyExplorers[key],
+        label: explorerInfo[ShelleyExplorers[key]].name,
+      }));
+  }
+  return Object.keys(ByronExplorers)
+    .map(key => ({
+      value: ByronExplorers[key],
+      label: explorerInfo[ByronExplorers[key]].name,
+    }));
+}
+export const Explorer = environment.isShelley()
+  ? ShelleyExplorers
+  : ByronExplorers;
+export type ExplorerType = $Values<typeof ShelleyExplorers> | $Values<typeof ByronExplorers>;
 
 export const Link = Object.freeze({
   address: 'address',
@@ -18,11 +46,18 @@ export type ExplorerInfo = {
   ...Inexact<typeof Link>,
   name: string,
 }
-const seiza = {
-  name: 'Seiza',
-  address: 'https://seiza.com/blockchain/address/',
-  transaction: 'https://seiza.com/blockchain/transaction/',
-};
+const seiza = environment.isShelley()
+  ? {
+    name: 'Seiza',
+    // TODO: proper URL for Shelley
+    address: 'https://seiza.com/blockchain/address/',
+    transaction: 'https://seiza.com/blockchain/transaction/',
+  }
+  : {
+    name: 'Seiza',
+    address: 'https://seiza.com/blockchain/address/',
+    transaction: 'https://seiza.com/blockchain/transaction/',
+  };
 
 export const explorerInfo: {
   [key: ExplorerType]: ExplorerInfo,
@@ -33,18 +68,29 @@ export const explorerInfo: {
   }
 } = Object.freeze({
   seiza,
-  clio: {
-    name: 'Clio.1',
-    address: 'https://clio.one/tracker/address/',
-  },
-  adascan: {
-    name: 'AdaScan',
-    address: 'https://adascan.net/address/',
-    transaction: 'https://adascan.net/transaction/',
-  },
-  cardano_explorer: {
-    name: 'CardanoExplorer',
-    address: 'https://cardanoexplorer.com/address/',
-    transaction: 'https://cardanoexplorer.com/tx/',
-  }
+  ...(!environment.isShelley()
+    ? {
+      clio: {
+        name: 'Clio.1',
+        address: 'https://clio.one/tracker/address/',
+      },
+      adascan: {
+        name: 'AdaScan',
+        address: 'https://adascan.net/address/',
+        transaction: 'https://adascan.net/transaction/',
+      },
+      cardano_explorer: {
+        name: 'CardanoExplorer',
+        address: 'https://cardanoexplorer.com/address/',
+        transaction: 'https://cardanoexplorer.com/tx/',
+      }
+    }
+    : {
+      jormungandr: {
+        name: 'Jormungandr Explorer',
+        address: 'https://explorer.jormungandr-testnet.iohkdev.io/address/',
+        transaction: 'https://explorer.jormungandr-testnet.iohkdev.io/tx/',
+      },
+    }
+  )
 });

--- a/app/domain/Explorer.js
+++ b/app/domain/Explorer.js
@@ -13,6 +13,7 @@ const ByronExplorers = Object.freeze({
   CARDANO_EXPLORER: 'cardano_explorer',
 });
 export function getDefaultExplorer(): ExplorerType {
+  // TODO: change default back to Seiza once we have a public URL
   return environment.isShelley()
     ? 'jormungandr'
     : 'seiza';

--- a/flow-typed/npm/js-chain-libs_v0.1.2.js
+++ b/flow-typed/npm/js-chain-libs_v0.1.2.js
@@ -97,7 +97,7 @@ declare module 'js-chain-libs' { // need to wrap flowgen output into module
     /**
      * @returns {Uint8Array}
      */
-    to_bytes(): Uint8Array;
+    as_bytes(): Uint8Array;
 
     /**
      * @returns {string}
@@ -502,7 +502,7 @@ declare module 'js-chain-libs' { // need to wrap flowgen output into module
     /**
      * @returns {Uint8Array}
      */
-    to_bytes(): Uint8Array;
+    as_bytes(): Uint8Array;
 
     /**
      * @returns {string}
@@ -1377,7 +1377,7 @@ declare module 'js-chain-libs' { // need to wrap flowgen output into module
     /**
      * @returns {Uint8Array}
      */
-    to_bytes(): Uint8Array;
+    as_bytes(): Uint8Array;
 
     /**
      * @returns {string}


### PR DESCRIPTION
This PR changes which explorers we show for Shelley builds.

Notably, since we don't have a public URL for the Shelley version of Seiza yet, it defaults to IOHK's Shelley explorer. @nicarq @rcmorano  you can change this when we have a public URL