### PR TITLE
 shin/ch2050/fix-autocomplete-problems 

### DIFF
--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -258,7 +258,8 @@ export default class WalletRestoreDialog extends Component<Props> {
   componentDidMount() {
     setTimeout(() => {
       if (this.props.isVerificationMode === true) {
-        this.recoveryPhraseInput.focus();
+        // Refer:
+        // this.recoveryPhraseInput.focus();
       } else {
         this.walletNameInput.focus();
       }
@@ -266,7 +267,8 @@ export default class WalletRestoreDialog extends Component<Props> {
   }
 
   walletNameInput: Input;
-  recoveryPhraseInput: Autocomplete;
+  // Refer:
+  // recoveryPhraseInput: Autocomplete;
 
   render() {
     const { intl } = this.context;
@@ -393,7 +395,8 @@ export default class WalletRestoreDialog extends Component<Props> {
         <Autocomplete
           options={validWords}
           maxSelections={this.props.numberOfMnemonics}
-          inputRef={(input) => { this.recoveryPhraseInput = input; }}
+          // Refer:
+          // inputRef={(input) => { this.recoveryPhraseInput = input; }}
           {...recoveryPhraseField.bind()}
           done={mnemonicValidator(join(recoveryPhrase, ' '))}
           error={recoveryPhraseField.error}

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -258,7 +258,7 @@ export default class WalletRestoreDialog extends Component<Props> {
   componentDidMount() {
     setTimeout(() => {
       if (this.props.isVerificationMode === true) {
-        // Refer:
+        // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1009
         // this.recoveryPhraseInput.focus();
       } else {
         this.walletNameInput.focus();
@@ -267,7 +267,7 @@ export default class WalletRestoreDialog extends Component<Props> {
   }
 
   walletNameInput: Input;
-  // Refer:
+  // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1009
   // recoveryPhraseInput: Autocomplete;
 
   render() {
@@ -395,7 +395,7 @@ export default class WalletRestoreDialog extends Component<Props> {
         <Autocomplete
           options={validWords}
           maxSelections={this.props.numberOfMnemonics}
-          // Refer:
+          // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1009
           // inputRef={(input) => { this.recoveryPhraseInput = input; }}
           {...recoveryPhraseField.bind()}
           done={mnemonicValidator(join(recoveryPhrase, ' '))}


### PR DESCRIPTION
- Story:
https://app.clubhouse.io/emurgo/story/2050/fix-autocomplete-problems

- Note:
This is kind of temporary solution.
Not able to find why this problem started appearing.
As a drawback on Verify Paper Wallet, recovery phrase block will not be auto focused on load. 

- Affected fields:
  - Restore Wallet
![Restore Wallet](https://user-images.githubusercontent.com/41470567/67851620-e4091500-fb1b-11e9-995d-1d922d0b8464.png)<br/>
  - Restore Paper Wallet
![Restore Paper Wallet](https://user-images.githubusercontent.com/41470567/67851627-e79c9c00-fb1b-11e9-8b28-0543da8d3f4a.png)<br/>
  - Verify Paper Wallet
![Verify Paper Wallet](https://user-images.githubusercontent.com/41470567/67851631-e8cdc900-fb1b-11e9-8a2a-54ad9695a1f3.png)



