### PR TITLE
shin/ch2051/fix-password-input-component

### DIFF
--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -61,10 +61,6 @@
       & > div {
         width: 100%;
       }
-
-      & > div:last-child {
-        padding-bottom: 0;
-      }
     }
   }
 }

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -93,10 +93,6 @@
           margin-top: 0;
           width: 100%;
         }
-
-        & > div:last-child {
-          padding-bottom: 0;
-        }
       }
 
       .paperPassword {

--- a/app/components/wallet/send/WalletSendConfirmationDialog.scss
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.scss
@@ -102,7 +102,8 @@
   .error {
     @include error-message;
     text-align: center;
-    margin-top: 17px;
+    margin-top: 10px;
+    margin-bottom: 10px !important;
   }
 }
 
@@ -153,7 +154,6 @@
 
   .walletPassword {
     margin-top: 0;
-    padding-bottom: 0; // TBD
   }
 
   .amountFeesWrapper {

--- a/app/components/wallet/send/WalletSendConfirmationDialog.scss
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.scss
@@ -153,7 +153,7 @@
 
   .walletPassword {
     margin-top: 0;
-    padding-bottom: 0;
+    padding-bottom: 0; // TBD
   }
 
   .amountFeesWrapper {

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
@@ -31,12 +31,3 @@
 .isSubmitting {
   @include loading-spinner("../../../assets/images/spinner-light.svg");
 }
-
-
-:global(.YoroiModern) {
-  .walletPasswordFields {
-    & > div:last-child {
-      padding-bottom: 0;
-    }
-  }
-}

--- a/app/components/wallet/settings/paper-wallets/UserPasswordDialog.scss
+++ b/app/components/wallet/settings/paper-wallets/UserPasswordDialog.scss
@@ -22,14 +22,6 @@
   }
 }
 
-:global(.YoroiModern) {
-  .dialog {
-    .repeatedPassword {
-      padding-bottom: 0;
-    }
-  }
-}
-
 :global .UserPasswordDialog_dialog .HeaderBlock_headerBlock {
   margin-bottom: 24px;
 }

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -263,7 +263,7 @@ export default {
   '--theme-dialog-title-color': '#2b2c32',
   '--theme-dialog-title-margin': '0 0 38px 0',
   '--theme-dialog-input-margin': '10px 0 24px 0',
-  '--theme-dialog-input-actions-margin': '34px 0 0 0',
+  '--theme-dialog-input-actions-margin': '8px 0 0 0',
 
   '--theme-main-body-background-color': '#ffffff',
   '--theme-main-body-messages-color': '#353535',

--- a/app/themes/skins/FormFieldOwnSkin.js
+++ b/app/themes/skins/FormFieldOwnSkin.js
@@ -72,14 +72,14 @@ export const FormFieldOwnSkin = class extends React.Component<Props, State> {
 
           <div className={styles.iconsWrapper}>
             {this.props.done === true && <SvgInline svg={SuccessSvg} />}
-            {this.props.type === 'password' && !this.props.error ? (
+            {(this.props.error != null && this.props.error !== '') && <SvgInline svg={ErrorSvg} />}
+            {(this.props.type === 'password') ? (
               <button tabIndex="-1" type="button" onClick={this.showPassword}>
                 {isPasswordShown
                   ? <SvgInline svg={PasswordSvg} />
                   : <SvgInline svg={PasswordHiddenSvg} />}
               </button>
             ) : null}
-            {this.props.error && <SvgInline svg={ErrorSvg} />}
           </div>
           {this.props.render(omit(renderProps, ['themeId']))}
           {this.props.label && (


### PR DESCRIPTION
#### Story:
https://app.clubhouse.io/emurgo/story/2051/fix-password-input-component

#### Here two problems were there.
1. Password peek button was not showing when you type something.
![image](https://user-images.githubusercontent.com/19986226/67911836-4ff68680-fbcb-11e9-80ce-4482d0e7f2ea.png)

2. No error message was shown even if error exists.
![image (1)](https://user-images.githubusercontent.com/19986226/67911909-8df3aa80-fbcb-11e9-81d1-21c1f513506d.png)

#### Affected dialogs/components
- Create Normal wallet dialog [WalletCreateDialog]
- Create Paper wallet dialog [UserPasswordDialog]
- Restore Normal wallet dialog [WalletRestoreDialog]
- Restore Paper wallet dialog [WalletRestoreDialog]
- Send Confirmation dialog [WalletSendConfirmationDialog]
- Change Password dialog [ChangeWalletPasswordDialog ]