### PR TITLE
 shin/ch2052/fix-select-component-label

### DIFF
--- a/app/themes/overrides/FormFieldOverrides.scss
+++ b/app/themes/overrides/FormFieldOverrides.scss
@@ -19,7 +19,7 @@
 
 .label {
   background: white;
-  top: -4px;
+  top: 2px;
   left: 10px;
   font-family: var(--rp-theme-font-regular);
   font-size: 12px;


### PR DESCRIPTION
#### Story:
https://app.clubhouse.io/emurgo/story/2052/fix-select-component-label

#### Affected components:
**1. Language selection**

Before:
![image](https://user-images.githubusercontent.com/19986226/67912976-014aeb80-fbcf-11e9-8bdd-4a71f7501b8b.png)

After:
![image](https://user-images.githubusercontent.com/19986226/67913021-1c1d6000-fbcf-11e9-985f-f305beddbe0a.png)

**2. Explorer selection**

Before:
![image](https://user-images.githubusercontent.com/19986226/67913075-38b99800-fbcf-11e9-8856-7b927dd73701.png)

After:
![image](https://user-images.githubusercontent.com/19986226/67913096-44a55a00-fbcf-11e9-92b6-aacc643d9a64.png)

**3. Paper wallet. No. of address selection** 

Before:
![image](https://user-images.githubusercontent.com/19986226/67913590-ee391b00-fbd0-11e9-918c-fbe80fec201b.png)

After:
![image](https://user-images.githubusercontent.com/19986226/67913608-fd1fcd80-fbd0-11e9-9774-c7d19084053f.png)
