### PR TITLE
shin/ch2061/fix-verify-paper-wallet-password-error

### DIFF
--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -94,12 +94,6 @@
           width: 100%;
         }
       }
-
-      .paperPassword {
-        div:first-of-type {
-          padding-bottom: 0!important;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
This PR is continuation of: https://github.com/Emurgo/yoroi-frontend/pull/1011

This PR fixes: Verify paper wallet dialog [WalletRestoreDialog]

#### Problem:
![image (2)](https://user-images.githubusercontent.com/19986226/67930069-4ccabd00-fc02-11e9-9611-42f070e1fec1.png)

Also need to merge with `develop` branch for `1.9.0` release.