### PR TITLE
Only load local tx on "load more" button

### DIFF
--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -68,7 +68,7 @@ export default class WalletSummaryPage extends Component<Props> {
           <WalletTransactionsList
             transactions={recent}
             selectedExplorer={this.props.stores.profile.selectedExplorer}
-            isLoadingTransactions={!recentTransactionsRequest.wasExecuted}
+            isLoadingTransactions={!recentTransactionsRequest.wasExecuted || recentTransactionsRequest.isExecuting}
             hasMoreToLoad={totalAvailable > limit}
             onLoadMore={() => actions.ada.transactions.loadMoreTransactions.trigger()}
             assuranceMode={wallet.assuranceMode}


### PR DESCRIPTION
Recall: Yoroi used to send 2 requests to our server -- one for the latest N transactions and one for all transactions. PR #753 fixed this by making that the "latest N transactions" query is done only from storage. This introduces a bug PR #939 which fixed (spinner was only triggering for network queries, not storage queries)

However, this fix did not go all the way. It turns out when you press the "load more transactions" button on Yoroi, this still sent a query to our backend (instead of just fetching it locally). This PR changes this so that the "load more transactions" button fetches transactions only from storage.