### PR TITLE
Fix CI for Shelley branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
 
       # cancel builds from the same branch (since circle feature seems not working)
       - run: bash .circleci/stop_redundant_jobs.sh
-      - *restore_cache
+      # - *restore_cache
       - run: bash .circleci/rust_install.sh
 
       - run: npm rebuild node-sass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
       - *restore_cache
       - run: bash .circleci/rust_install.sh
 
+      - run: npm rebuild node-sass
       - run: npm ci
       - *save_cache
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,14 @@ aliases:
   - &restore_cache
       restore_cache:
         keys:
-          - generic-tools-cache-{{ checksum "package.json" }}
+          - generic-tools-cache-{{ checksum "package-lock.json" }}
   - &save_cache
       save_cache:
         paths:
          - ~/.npm
          - ~/.rustup
          - ~/.cargo
-        key: generic-tools-cache-{{ checksum "package.json" }}
+        key: generic-tools-cache-{{ checksum "package-lock.json" }}
   - &setenv
       run: bash .circleci/set_dynamic_env.sh
   - &global_environment


### PR DESCRIPTION
 I’ve noticed all Yoroi-Frontend CI builds fail since we’ve moved to node12. After some investigation, this is because of the `npm ci` step since it starts by doing
```
node-sass@4.11.0 install /home/circleci/.npm/tmp/git-clone-545af135/node_modules/node-sass
node scripts/install.js
```

`node-sass@4.11.0` is the wrong version — that’s for node11. We need >4.12
I’ve bumped the version Yoroi uses to 4.13 already so it’s not an issue in our package. I have no clue why CI insists on using 4.11 (`npm run ci` works just fine locally)