### PR TITLE
 shin/ch2063/fix-fast-times-on-create-wallet-recover-phrase

### DIFF
--- a/app/stores/toplevel/WalletBackupStore.js
+++ b/app/stores/toplevel/WalletBackupStore.js
@@ -69,7 +69,7 @@ class WalletBackupStore extends Store {
     this.isTermDeviceAccepted = false;
     this.isTermRecoveryAccepted = false;
     this.countdownRemaining = !environment.isMainnet() ? 0 : 10;
-    if (this.countdownTimerInterval) clearInterval(this.countdownTimerInterval);
+    clearInterval(this.countdownTimerInterval);
     this.countdownTimerInterval = setInterval(() => {
       if (this.countdownRemaining > 0) {
         action(() => this.countdownRemaining--)();
@@ -164,8 +164,9 @@ class WalletBackupStore extends Store {
     this.isEntering = false;
     this.isTermDeviceAccepted = false;
     this.isTermRecoveryAccepted = false;
-    this.countdownRemaining = 0;
 
+    this.countdownRemaining = 0;
+    clearInterval(this.countdownTimerInterval);
     this.countdownTimerInterval = null;
   };
 


### PR DESCRIPTION
#### Steps to reproduce:
The timer runs twice as fast if you close the overlay before the countdown ends (Creation of new wallet).
Steps:
1. Close overlay (on the screenshot) before countdown ends
2. Initiate creation of new wallet again and check the timer speed
---
Actual result - the timer runs at double speed
![image](https://user-images.githubusercontent.com/19986226/68008743-481a0d80-fcc3-11e9-8535-f6b15ae4b637.png)

#### Cause:
Timer was not getting clear on dialog close
