### PR TITLE
shin/ch2068/fix-bottom-margin-on-non-password-dialog

### DIFF
--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -63,4 +63,8 @@
       }
     }
   }
+
+  :global(.Dialog_actions) {
+    margin-top: 10px;
+  }
 }

--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -65,6 +65,6 @@
   }
 
   :global(.Dialog_actions) {
-    margin-top: 10px;
+    margin-top: var(--theme-dialog-password-input-actions-margin-top);
   }
 }

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -95,5 +95,9 @@
         }
       }
     }
+
+    :global(.Dialog_actions) {
+      margin-top: 10px;
+    }
   }
 }

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -97,7 +97,7 @@
     }
 
     :global(.Dialog_actions) {
-      margin-top: 10px;
+      margin-top: var(--theme-dialog-password-input-actions-margin-top);
     }
   }
 }

--- a/app/components/wallet/send/WalletSendConfirmationDialog.scss
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.scss
@@ -102,8 +102,6 @@
   .error {
     @include error-message;
     text-align: center;
-    margin-top: 10px;
-    margin-bottom: 10px !important;
   }
 }
 

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
@@ -31,7 +31,7 @@
 :global(.YoroiModern) {
   .dialog {
     :global(.Dialog_actions) {
-      margin-top: 10px;
+      margin-top: var(--theme-dialog-password-input-actions-margin-top);
     }
   }
 } 

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
@@ -28,6 +28,14 @@
   }
 }
 
+:global(.YoroiModern) {
+  .dialog {
+    :global(.Dialog_actions) {
+      margin-top: 10px;
+    }
+  }
+} 
+
 .isSubmitting {
   @include loading-spinner("../../../assets/images/spinner-light.svg");
 }

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
@@ -24,7 +24,7 @@
   .error {
     @include error-message;
     text-align: center;
-    margin-top: 27px;
+    margin-bottom: 24px !important;
   }
 }
 
@@ -34,7 +34,7 @@
       margin-top: var(--theme-dialog-password-input-actions-margin-top);
     }
   }
-} 
+}
 
 .isSubmitting {
   @include loading-spinner("../../../assets/images/spinner-light.svg");

--- a/app/components/wallet/settings/paper-wallets/UserPasswordDialog.scss
+++ b/app/components/wallet/settings/paper-wallets/UserPasswordDialog.scss
@@ -25,7 +25,7 @@
 :global(.YoroiModern) {
   .dialog {
     :global(.Dialog_actions) {
-      margin-top: 10px;
+      margin-top: var(--theme-dialog-password-input-actions-margin-top);
     }
   }
 }

--- a/app/components/wallet/settings/paper-wallets/UserPasswordDialog.scss
+++ b/app/components/wallet/settings/paper-wallets/UserPasswordDialog.scss
@@ -22,6 +22,14 @@
   }
 }
 
+:global(.YoroiModern) {
+  .dialog {
+    :global(.Dialog_actions) {
+      margin-top: 10px;
+    }
+  }
+}
+
 :global .UserPasswordDialog_dialog .HeaderBlock_headerBlock {
   margin-bottom: 24px;
 }

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -263,7 +263,7 @@ export default {
   '--theme-dialog-title-color': '#2b2c32',
   '--theme-dialog-title-margin': '0 0 38px 0',
   '--theme-dialog-input-margin': '10px 0 24px 0',
-  '--theme-dialog-input-actions-margin': '8px 0 0 0',
+  '--theme-dialog-input-actions-margin': '34px 0 0 0',
 
   '--theme-main-body-background-color': '#ffffff',
   '--theme-main-body-messages-color': '#353535',

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -264,6 +264,7 @@ export default {
   '--theme-dialog-title-margin': '0 0 38px 0',
   '--theme-dialog-input-margin': '10px 0 24px 0',
   '--theme-dialog-input-actions-margin': '34px 0 0 0',
+  '--theme-dialog-password-input-actions-margin-top': '10px',
 
   '--theme-main-body-background-color': '#ffffff',
   '--theme-main-body-messages-color': '#353535',


### PR DESCRIPTION
#### Story
https://app.clubhouse.io/emurgo/story/2068/fix-bottom-margin-on-non-password-dialog

#### Problem:
Problem happened while fixing problem no 2 in: https://github.com/Emurgo/yoroi-frontend/pull/1011
The common variable `--theme-dialog-input-actions-margin` was changed.
For dialog's with password was ok but dialog's with no-password input, bottom margin became on lesser side.

#### This PR
This PR fixed that problem be resetting `--theme-dialog-input-actions-margin` to original and setting custom margin where password is used.
