### PR TITLE
 shin/ch2070/fix-verify-restored-wallet-copy-tool-tip 

### DIFF
--- a/app/components/wallet/WalletRestoreVerifyDialog.scss
+++ b/app/components/wallet/WalletRestoreVerifyDialog.scss
@@ -56,6 +56,7 @@
 }
 
 :global(.YoroiModern) .dialog {
+  // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1052
   min-width: 680px;
   max-width: 680px; 
 }

--- a/app/components/wallet/WalletRestoreVerifyDialog.scss
+++ b/app/components/wallet/WalletRestoreVerifyDialog.scss
@@ -56,6 +56,6 @@
 }
 
 :global(.YoroiModern) .dialog {
-  min-width: var(--theme-modal-min-max-width-lg);
-  max-width: var(--theme-modal-min-max-width-lg); 
+  min-width: 680px;
+  max-width: 680px; 
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/19986226/68081500-3adf5900-fe52-11e9-816e-ed93de421510.png)

After:
![image](https://user-images.githubusercontent.com/19986226/68081502-40d53a00-fe52-11e9-89f4-8d18fb056f8a.png)

This PR increases width of **Verify Restored Wallet** dialog which is not the best solution.
Other solutions could be:
1. Making tool-tip overflows over the dialog: tried but seems not working in the first attempt
2. Multi-line tool-tip: needs many changes including translation. 
3. Something else