### PR TITLE
shin/ch2071/fix-check-dialog-style-in-both-modern-and

### DIFF
--- a/app/components/wallet/hwConnect/ledger/CheckDialog.js
+++ b/app/components/wallet/hwConnect/ledger/CheckDialog.js
@@ -23,7 +23,7 @@ import aboutLedgerSVG from '../../../../assets/images/hardware-wallet/ledger/che
 
 import { ProgressInfo } from '../../../../types/HWConnectStoreTypes';
 
-import styles from '../common/CheckDialog.scss';
+import styles from './CheckDialog.scss';
 
 const messages = defineMessages({
   aboutPrerequisite1Part1: {
@@ -142,7 +142,7 @@ export default class CheckDialog extends Component<Props> {
 
     return (
       <Dialog
-        className={classnames([styles.component, 'CheckDialog'])}
+        className={classnames([styles.component, 'CheckDialog', styles.ledger])}
         title={intl.formatMessage(globalMessages.ledgerConnectAllDialogTitle)}
         actions={dailogActions}
         closeOnOverlayClick={false}

--- a/app/components/wallet/hwConnect/ledger/CheckDialog.scss
+++ b/app/components/wallet/hwConnect/ledger/CheckDialog.scss
@@ -1,0 +1,20 @@
+@import '../common/CheckDialog.scss';
+
+:global(.YoroiClassic) {
+  .component.ledger {
+    .prerequisiteBlock {
+      width: 550px;
+    }
+    .hwImageBlock {
+      width: 150px;
+    }    
+  }
+}
+
+:global(.YoroiModern) {
+  .component.ledger {
+    .prerequisiteBlock {
+      width: 500px
+    }
+  }
+}


### PR DESCRIPTION
Left: Before, Right: After
Modern Theme:
![image](https://user-images.githubusercontent.com/19986226/68097963-505d8d00-fefd-11e9-9d3d-69480de9fd5b.png)

Classic Theme:
![image](https://user-images.githubusercontent.com/19986226/68097972-5c494f00-fefd-11e9-99f4-d4a48ffa59f7.png)


