### PR TITLE
shin/ch2073/in-case-of-no-internet-connection-fix-error

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -1091,6 +1091,7 @@ export default class AdaApi {
         throw new WalletAlreadyRestoredError();
       }
 
+      // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1055
       if (error instanceof CheckAdressesInUseApiError) {
         // CheckAdressesInUseApiError throw it as it is.
         throw error;

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -81,7 +81,10 @@ import type {
 import type {
   SignTransactionResponse as LedgerSignTxResponse
 } from '@cardano-foundation/ledgerjs-hw-app-cardano';
-import { InvalidWitnessError, } from './errors';
+import {
+  InvalidWitnessError,
+  CheckAdressesInUseApiError,
+} from './errors';
 import { WrongPassphraseError } from './lib/cardanoCrypto/cryptoErrors';
 import {
   getAdaWallet,
@@ -1087,8 +1090,14 @@ export default class AdaApi {
       if (error.message.includes('Wallet with that mnemonics already exists')) {
         throw new WalletAlreadyRestoredError();
       }
-      // We don't know what the problem was -> throw generic error
-      throw new GenericApiError();
+
+      if (error instanceof CheckAdressesInUseApiError) {
+        // CheckAdressesInUseApiError throw it as it is.
+        throw error;
+      } else {
+        // We don't know what the problem was so throw a generic error
+        throw new GenericApiError();
+      }
     }
   }
 

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -118,6 +118,7 @@ export default class WalletRestoreDialogContainer
     const { verifyRestore, submitValues } = this.state;
     if (verifyRestore) {
       const { addresses, accountPlate } = verifyRestore;
+      // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1055
       let error;
       /**
        * CheckAdressesInUseApiError happens when yoroi could not fetch Used Address.

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -14,6 +14,7 @@ import {
 } from '../../../api/ada/lib/cardanoCrypto/cryptoWallet';
 import type { WalletAccountNumberPlate } from '../../../domain/Wallet';
 import globalMessages from '../../../i18n/global-messages';
+import { CheckAdressesInUseApiError } from '../../../api/ada/errors';
 
 type Props = InjectedDialogContainerProps & {
   mode: "regular" | "paper",
@@ -117,6 +118,18 @@ export default class WalletRestoreDialogContainer
     const { verifyRestore, submitValues } = this.state;
     if (verifyRestore) {
       const { addresses, accountPlate } = verifyRestore;
+      let error;
+      /**
+       * CheckAdressesInUseApiError happens when yoroi could not fetch Used Address.
+       * Mostly because internet not connected or yoroi backend is down.
+       * At this point wallet is already created in the storage.
+       * When internet connection is back, everything will be loaded correctly.
+       */
+      if (restoreRequest.error instanceof CheckAdressesInUseApiError === false) {
+        error = restoreRequest.error;
+      }
+      const isSubmitting = restoreRequest.isExecuting ||
+        (restoreRequest.error instanceof CheckAdressesInUseApiError);
       return (
         <WalletRestoreVerifyDialog
           addresses={addresses}
@@ -137,9 +150,9 @@ export default class WalletRestoreDialogContainer
           getNotification={uiNotifications.getTooltipActiveNotification(
             this.state.notificationElementId
           )}
-          isSubmitting={restoreRequest.isExecuting}
+          isSubmitting={isSubmitting}
           classicTheme={this.props.classicTheme}
-          error={restoreRequest.error}
+          error={error}
         />
       );
     }

--- a/app/stores/ada/LedgerConnectStore.js
+++ b/app/stores/ada/LedgerConnectStore.js
@@ -37,7 +37,6 @@ import {
   prepareLedgerConnect,
 } from '../../utils/hwConnectHandler';
 
-import globalMessages from '../../i18n/global-messages';
 import LocalizableError, { UnexpectedError } from '../../i18n/LocalizableError';
 import { CheckAdressesInUseApiError } from '../../api/ada/errors';
 
@@ -256,10 +255,16 @@ export default class LedgerConnectStore
       Logger.error(`LedgerConnectStore::_saveHW::error ${stringifyError(error)}`);
 
       if (error instanceof CheckAdressesInUseApiError) {
-        // redirecting CheckAdressesInUseApiError -> hwConnectDialogSaveError101
-        // because for user hwConnectDialogSaveError101 is more meaningful in this context
-        this.error = new LocalizableError(globalMessages.hwConnectDialogSaveError101);
-      } else if (error instanceof LocalizableError) {
+        /**
+         * This error happens when yoroi could not fetch Used Address.
+         * Mostly because internet not connected or yoroi backend is down.
+         * At this point wallet is already created in the storage.
+         * When internet connection is back, everything will be loaded correctly.
+         */
+        return;
+      }
+
+      if (error instanceof LocalizableError) {
         this.error = error;
       } else {
         // some unknow error

--- a/app/stores/ada/LedgerConnectStore.js
+++ b/app/stores/ada/LedgerConnectStore.js
@@ -254,6 +254,7 @@ export default class LedgerConnectStore
     } catch (error) {
       Logger.error(`LedgerConnectStore::_saveHW::error ${stringifyError(error)}`);
 
+      // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1055
       if (error instanceof CheckAdressesInUseApiError) {
         /**
          * This error happens when yoroi could not fetch Used Address.

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -364,6 +364,7 @@ export default class TrezorConnectStore
     } catch (error) {
       Logger.error(`TrezorConnectStore::_saveHW::error ${stringifyError(error)}`);
 
+      // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1055
       if (error instanceof CheckAdressesInUseApiError) {
         /**
          * This error happens when yoroi could not fetch Used Address.

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -365,10 +365,16 @@ export default class TrezorConnectStore
       Logger.error(`TrezorConnectStore::_saveHW::error ${stringifyError(error)}`);
 
       if (error instanceof CheckAdressesInUseApiError) {
-        // redirecting CheckAdressesInUseApiError -> hwConnectDialogSaveError101
-        // because for user hwConnectDialogSaveError101 is more meaningful in this context
-        this.error = new LocalizableError(globalMessages.hwConnectDialogSaveError101);
-      } else if (error instanceof LocalizableError) {
+        /**
+         * This error happens when yoroi could not fetch Used Address.
+         * Mostly because internet not connected or yoroi backend is down.
+         * At this point wallet is already created in the storage.
+         * When internet connection is back, everything will be loaded correctly.
+         */
+        return;
+      }
+
+      if (error instanceof LocalizableError) {
         this.error = error;
       } else {
         // some unknow error


### PR DESCRIPTION
Story:
https://app.clubhouse.io/emurgo/story/2073/in-case-of-no-internet-connection-fix-error-showing-on-various-restore-hw-connect-process

This PR just does not shows `CheckAdressesInUseApiError` because user might get confused because wallets been loaded and still showing error.

This PR just simulates flow as it was in **1.8.2**.
Solving the problem from bottom needs discussion and core level changes. 