### PR TITLE
Fix it-2 and it-77

### DIFF
--- a/features/step_definitions/common-steps.js
+++ b/features/step_definitions/common-steps.js
@@ -160,6 +160,8 @@ Given(/^I have completed the basic setup$/, async function () {
 
   // uri prompt page
   await acceptUriPrompt(this);
+
+  await this.waitForElement('.WalletAdd_component');
 });
 
 Then(/^I accept uri registration$/, async function () {


### PR DESCRIPTION
Recently `it-2` and `it-77` e2e tests have been failing. It looks like this was caused by a call to `await navigateTo.call(this, '/settings');` being done before the settings button was Wallet Add page was done loading. I fixed this by adding `await this.waitForElement('.WalletAdd_component');` to make sure the wallet add page is fully loaded.