### PR TITLE
Add flow to all files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,7 +91,7 @@ module.exports = {
     'react/jsx-indent': 1,
     'flowtype/define-flow-type': 1,
     'flowtype/use-flow-type': 1,
-    'flowtype/require-valid-file-annotation': 2,
+    'flowtype/require-valid-file-annotation': [2, 'always'],
     'global-require': 'off',
     'no-await-in-loop': 0,
     'no-unused-expressions': 0,

--- a/app/api/localStorage/primitives.js
+++ b/app/api/localStorage/primitives.js
@@ -8,7 +8,9 @@ import environment from '../../environment';
  * so the WebPage will use the `localStorage`.
  */
 
+/*::
 declare var chrome;
+*/
 
 // =====
 //  get

--- a/app/utils/tabManager.js
+++ b/app/utils/tabManager.js
@@ -5,8 +5,9 @@ import {
   addListener,
 } from '../api/localStorage/primitives';
 
-declare var chrome; // TODO: no type for chrome
-
+/*::
+declare var chrome;
+*/
 /**
  * We may run into bugs if the user has two copies of Yoroi running on the same localstorage
  * Since Yoroi data process is not transactional.

--- a/chrome/content-scripts/3rd-party-trezor/trezor-usb-permissions.js
+++ b/chrome/content-scripts/3rd-party-trezor/trezor-usb-permissions.js
@@ -3,7 +3,9 @@
 Handling messages from usb permissions iframe
 */
 
-declare var chrome; // TODO: no type for chrome
+/*::
+declare var chrome;
+*/
 
 const switchToPopupTab = (event) => {
     window.removeEventListener('beforeunload', switchToPopupTab);

--- a/chrome/extension/background.js
+++ b/chrome/extension/background.js
@@ -1,4 +1,9 @@
+// @flow
 import debounce from 'lodash/debounce';
+
+/*::
+declare var chrome;
+*/
 
 const onYoroiIconClicked = () => {
   chrome.tabs.create({ url: 'main_window.html' });

--- a/chrome/manifest.development.js
+++ b/chrome/manifest.development.js
@@ -1,3 +1,5 @@
+// @flow
+
 import buildManifest from './manifest.template';
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 

--- a/chrome/manifest.mainnet.js
+++ b/chrome/manifest.mainnet.js
@@ -1,3 +1,5 @@
+// @flow
+
 import buildManifest from './manifest.template';
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 

--- a/chrome/manifest.shelley-dev.js
+++ b/chrome/manifest.shelley-dev.js
@@ -1,3 +1,5 @@
+// @flow
+
 import buildManifest from './manifest.template';
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 

--- a/chrome/manifest.staging.js
+++ b/chrome/manifest.staging.js
@@ -1,3 +1,5 @@
+// @flow
+
 import buildManifest from './manifest.template';
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 

--- a/chrome/manifest.template.js
+++ b/chrome/manifest.template.js
@@ -1,58 +1,83 @@
+// @flow
+
 export default ({
   description,
   defaultTitle,
   contentSecurityPolicy,
   versionName,
   extensionKey
-}) => ({
-  version: '1.10.0',
-  name: 'yoroi',
-  manifest_version: 2,
-  ...(versionName ? { version_name: versionName } : {}),
-  description,
-  browser_action: {
-    default_title: defaultTitle,
-    default_icon: {
-      16: 'img/icon-16.png',
-      48: 'img/icon-48.png',
-      128: 'img/icon-128.png',
+} /*: {
+  description: string,
+  defaultTitle: string,
+  contentSecurityPolicy: string,
+  versionName?: string,
+  extensionKey?: string,
+} */
+) => { // eslint-disable-line function-paren-newline
+  const base = {
+    version: '1.10.0',
+    name: 'yoroi',
+    manifest_version: 2,
+    description,
+    browser_action: {
+      default_title: defaultTitle,
+      default_icon: {
+        /* eslint-disable quote-props */
+        '16': 'img/icon-16.png',
+        '48': 'img/icon-48.png',
+        '128': 'img/icon-128.png',
+        /* eslint-enable quote-props */
+      },
     },
-  },
-  browser_specific_settings: {
-    gecko: {
-      id: '{530f7c6c-6077-4703-8f71-cb368c663e35}',
+    browser_specific_settings: {
+      gecko: {
+        id: '{530f7c6c-6077-4703-8f71-cb368c663e35}',
+      },
     },
-  },
-  icons: {
-    16: 'img/icon-16.png',
-    48: 'img/icon-48.png',
-    128: 'img/icon-128.png',
-  },
-  background: {
-    page: 'background.html',
-  },
-  permissions: [
-    'storage',
-    '*://connect.trezor.io/*',
-    'https://emurgo.github.io/yoroi-extension-ledger-connect/*'
-  ],
-  content_scripts: [
-    {
-      matches: ['*://connect.trezor.io/*/popup.html'],
-      js: ['js/trezor-content-script.js'],
+    icons: {
+      /* eslint-disable quote-props */
+      '16': 'img/icon-16.png',
+      '48': 'img/icon-48.png',
+      '128': 'img/icon-128.png',
+      /* eslint-enable quote-props */
     },
-    {
-      matches: ['https://emurgo.github.io/yoroi-extension-ledger-connect/*'],
-      js: ['js/ledger-content-script.js']
-    }
-  ],
-  content_security_policy: contentSecurityPolicy,
-  ...(extensionKey ? { key: extensionKey } : {}),
-  protocol_handlers: [
-    {
-      protocol: 'web+cardano',
-      name: 'Yoroi',
-      uriTemplate: 'main_window.html#/send-from-uri?q=%s',
+    background: {
+      page: 'background.html',
     },
-  ],
-});
+    permissions: [
+      'storage',
+      '*://connect.trezor.io/*',
+      'https://emurgo.github.io/yoroi-extension-ledger-connect/*'
+    ],
+    content_scripts: [
+      {
+        matches: ['*://connect.trezor.io/*/popup.html'],
+        js: ['js/trezor-content-script.js'],
+      },
+      {
+        matches: ['https://emurgo.github.io/yoroi-extension-ledger-connect/*'],
+        js: ['js/ledger-content-script.js']
+      }
+    ],
+    content_security_policy: contentSecurityPolicy,
+    protocol_handlers: [
+      {
+        protocol: 'web+cardano',
+        name: 'Yoroi',
+        uriTemplate: 'main_window.html#/send-from-uri?q=%s',
+      },
+    ],
+  };
+
+  const verName /*: {| version_name?: string |} */ = versionName != null
+    ? { version_name: versionName }
+    : Object.freeze({});
+  const extKey /*: {| key?: string |} */ = extensionKey != null
+    ? { key: extensionKey }
+    : Object.freeze({});
+  return {
+    ...verName,
+    ...base,
+    ...extKey,
+  };
+};

--- a/chrome/manifest.test.js
+++ b/chrome/manifest.test.js
@@ -1,3 +1,5 @@
+// @flow
+
 import buildManifest from './manifest.template';
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 

--- a/chrome/manifest.testnet.js
+++ b/chrome/manifest.testnet.js
@@ -1,3 +1,5 @@
+// @flow
+
 import buildManifest from './manifest.template';
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 

--- a/features/step_definitions/migration-steps.js
+++ b/features/step_definitions/migration-steps.js
@@ -1,13 +1,12 @@
 // @flow
 
 import { Then } from 'cucumber';
-
-const latestVersion = require('../../chrome/manifest.test').version;
+import manifest from '../../chrome/manifest.test';
 
 Then(/^Last launch version is updated$/, async function () {
   await this.driver.wait(async () => {
     const lastLaunchVersion = await getLastLaunchVersion(this.driver);
-    return lastLaunchVersion === latestVersion;
+    return lastLaunchVersion === manifest.version;
   });
 });
 

--- a/webpack/commonConfig.js
+++ b/webpack/commonConfig.js
@@ -1,3 +1,5 @@
+// @flow
+
 const path = require('path');
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
@@ -7,7 +9,7 @@ const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin');
 const shell = require('shelljs');
 const manifestEnvs = require('../chrome/manifestEnvs');
 
-const plugins = (folder) => ([
+const plugins = (folder /*: string */) => ([
   /** We remove non-English languages from BIP39 to avoid triggering bad word filtering */
   new webpack.IgnorePlugin(/^\.\/(?!english)/, /bip39\/src\/wordlists$/),
   /**
@@ -148,7 +150,7 @@ const resolve = {
   extensions: ['*', '.js', '.wasm']
 };
 
-const definePlugin = (networkName, isProd) => ({
+const definePlugin = (networkName /*: string */, isProd /*: boolean */) => ({
   'process.env': {
     NODE_ENV: JSON.stringify(isProd ? 'production' : 'development'),
     COMMIT: JSON.stringify(shell.exec('git rev-parse HEAD', { silent: true }).trim()),

--- a/webpack/customPublicPath.js
+++ b/webpack/customPublicPath.js
@@ -1,6 +1,15 @@
+// @flow
+
 /* global __webpack_public_path__ __HOST__ __PORT__ */
 /* eslint no-global-assign: 0 camelcase: 0 */
 /* eslint no-unused-vars: 0 */
+
+/*::
+declare var chrome;
+declare var __webpack_public_path__: string;
+declare var __HOST__: string;
+declare var __PORT__: number;
+*/
 
 if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'shelley-dev') {
   __webpack_public_path__ = chrome.extension.getURL('/js/');

--- a/webpack/devConfig.js
+++ b/webpack/devConfig.js
@@ -1,3 +1,5 @@
+// @flow
+
 const commonConfig = require('./commonConfig');
 
 const path = require('path');
@@ -9,7 +11,7 @@ const customPath = path.join(__dirname, './customPublicPath');
 const hotScript =
   'webpack-hot-middleware/client?path=__webpack_hmr&dynamicPublicPath=true';
 
-const baseDevConfig = (networkName) => ({
+const baseDevConfig = (networkName /*: string */) => ({
   mode: 'development',
   optimization: commonConfig.optimization,
   node: commonConfig.node,

--- a/webpack/prodConfig.js
+++ b/webpack/prodConfig.js
@@ -1,3 +1,5 @@
+// @flow
+
 const commonConfig = require('./commonConfig');
 
 const path = require('path');
@@ -5,7 +7,7 @@ const webpack = require('webpack');
 
 const customPath = path.join(__dirname, './customPublicPath');
 
-const baseProdConfig = (networkName) => ({
+const baseProdConfig = (networkName /*: string */) => ({
   mode: 'production',
   optimization: commonConfig.optimization,
   node: commonConfig.node,


### PR DESCRIPTION
I noticed out linting rule to make sure all files start with `// @flow` wasn't working so I fixed it.

All the files that were missing Flow annotation were build files where we can't use Flow directly (would break tooling) so I use Flow's [comment type](https://flow.org/en/docs/types/comments/) to make it all work.