### PR TITLE
Stricter type requirements on API folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   parser: '@przemyslawzalewski/babel-eslint',
   parserOptions: {
     ecmaVersion: 6,
@@ -99,7 +100,7 @@ module.exports = {
     'import/no-cycle': 0, // doesn't work with Flow unfortunately
     'max-classes-per-file': 0,
     'no-floating-promise/no-floating-promise': 2,
-    "flowtype/no-primitive-constructor-types": 2
+    "flowtype/no-primitive-constructor-types": 2,
   },
   plugins: [
     'import',

--- a/app/api/.eslintrc.js
+++ b/app/api/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  rules: {
+    'flowtype/require-return-type': [
+      2,
+      'always',
+      {
+        excludeArrowFunctions: true,
+        annotateUndefined: 'ignore',
+        excludeMatching: ['constructor'],
+      }
+    ],
+    "flowtype/require-parameter-type": [
+      2,
+      {
+        "excludeArrowFunctions": true
+      }
+    ],
+  },
+}

--- a/app/api/ada/lib/cardanoCrypto/rustLoader.js
+++ b/app/api/ada/lib/cardanoCrypto/rustLoader.js
@@ -7,7 +7,7 @@ class Module {
   _wasmv2: WasmV2;
   _wasmv3: WasmV3;
 
-  async load() {
+  async load(): Promise<void> {
     this._wasmv2 = await import('cardano-wallet-browser');
     this._wasmv3 = await import('js-chain-libs');
   }

--- a/app/api/ada/lib/state-fetch/batchedFetcher.js
+++ b/app/api/ada/lib/state-fetch/batchedFetcher.js
@@ -93,7 +93,7 @@ export class BatchedFetcher implements IFetcher {
 function batchUTXOsForAddresses(
   getUTXOsForAddresses: AddressUtxoFunc,
 ): AddressUtxoFunc {
-  return async function (body) {
+  return async function (body: AddressUtxoRequest): Promise<AddressUtxoResponse> {
     try {
       // split up all addresses into chunks of equal size
       const groupsOfAddresses: Array<Array<string>>
@@ -122,7 +122,7 @@ function batchUTXOsForAddresses(
 function batchTxsBodiesForInputs(
   getTxsBodiesForUTXOs: TxBodiesFunc,
 ): TxBodiesFunc {
-  return async function (body) {
+  return async function (body: TxBodiesRequest): Promise<TxBodiesResponse> {
     try {
       // split up all txs into chunks of equal size
       const groupsOfTxsHashes = chunk(body.txsHashes, CONFIG.app.txsBodiesRequestSize);
@@ -152,7 +152,7 @@ function batchTxsBodiesForInputs(
 export function batchGetUTXOsSumsForAddresses(
   getUTXOsSumsForAddresses: UtxoSumFunc,
 ): UtxoSumFunc {
-  return async function (body) {
+  return async function (body: UtxoSumRequest): Promise<UtxoSumResponse> {
     try {
       // batch all addresses into chunks for API
       const groupsOfAddresses = chunk(body.addresses, addressesLimit);
@@ -187,7 +187,7 @@ export function batchGetUTXOsSumsForAddresses(
 export function batchGetTransactionsHistoryForAddresses(
   getTransactionsHistoryForAddresses: HistoryFunc,
 ): HistoryFunc {
-  return async function (body: HistoryRequest) {
+  return async function (body: HistoryRequest): Promise<HistoryResponse> {
     try {
       // we need two levels of batching: addresses and then transactions
       const transactions = await _batchHistoryByAddresses(
@@ -273,7 +273,7 @@ async function _batchHistoryByTransaction(
 export function batchCheckAddressesInUse(
   checkAddressesInUse: FilterFunc,
 ): FilterFunc {
-  return async function (body) {
+  return async function (body: FilterUsedRequest): Promise<FilterUsedResponse> {
     try {
       const groupsOfAddresses = chunk(body.addresses, addressesLimit);
       const groupedAddrPromises = groupsOfAddresses.map(

--- a/app/api/ada/lib/storage/bridge/hashMapper.js
+++ b/app/api/ada/lib/storage/bridge/hashMapper.js
@@ -31,7 +31,7 @@ export type AddByHashRequest = {|
 export type AddByHashFunc = AddByHashRequest => Promise<void>;
 export function rawGenAddByHash(
   ownAddressIds: Set<number>,
-) {
+): AddByHashFunc {
   return async (
     request: AddByHashRequest
   ): Promise<void> => {

--- a/app/api/ada/lib/storage/bridge/tests/common.js
+++ b/app/api/ada/lib/storage/bridge/tests/common.js
@@ -66,7 +66,7 @@ export async function setup(
   return publicDeriver;
 }
 
-export function mockDate() {
+export function mockDate(): void {
   const time = [0];
   // $FlowFixMe flow doesn't like that we override built-in functions.
   Date.now = jest.spyOn(Date, 'now').mockImplementation(() => time[0]++);
@@ -75,7 +75,7 @@ export function mockDate() {
 export function filterDbSnapshot(
   dump: any,
   keys: Array<string>
-) {
+): void {
   // 1) test all keys we care about are present
   keys.sort();
 

--- a/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
@@ -571,7 +571,7 @@ test('Utxo created and used in same sync', async (done) => {
  * However, the diff is too big to reasonably compare with your eyes
  * Therefore, we test each table separately
  */
-function compareObject(obj1: { tables: any }, obj2: { tables: any }) {
+function compareObject(obj1: { tables: any }, obj2: { tables: any }): void {
   for (const prop of Object.keys(obj1)) {
     if (obj1[prop] !== undefined && obj2[prop] === undefined) {
       expect(stableStringify(obj1)).toEqual(stableStringify(obj2));

--- a/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -294,7 +294,7 @@ export async function updateTransactions(
   checkAddressesInUse: FilterFunc,
   getTransactionsHistoryForAddresses: HistoryFunc,
   getBestBlock: BestBlockFunc,
-) {
+): Promise<void> {
   const derivationTables = publicDeriver.getConceptualWallet().getDerivationTables();
   let lastSyncInfo = undefined;
   try {

--- a/app/api/ada/lib/storage/database/__mocks__/initialSeed.js
+++ b/app/api/ada/lib/storage/database/__mocks__/initialSeed.js
@@ -1,6 +1,10 @@
 // @flow
 
-export function getInitialSeeds() {
+export function getInitialSeeds(): {|
+  AddressSeed: number,
+  TransactionSeed: number,
+  BlockSeed: number,
+  |} {
   return {
     AddressSeed: 1690513609,
     TransactionSeed: 769388545,

--- a/app/api/ada/lib/storage/database/initialSeed.js
+++ b/app/api/ada/lib/storage/database/initialSeed.js
@@ -2,7 +2,11 @@
 
 import crypto from 'crypto';
 
-export function getInitialSeeds() {
+export function getInitialSeeds(): {|
+  AddressSeed: number,
+  TransactionSeed: number,
+  BlockSeed: number,
+  |} {
   return {
     AddressSeed: crypto.randomBytes(4).readUInt32BE(0),
     TransactionSeed: crypto.randomBytes(4).readUInt32BE(0),

--- a/app/api/ada/lib/storage/database/transactionModels/utxo/api/read.js
+++ b/app/api/ada/lib/storage/database/transactionModels/utxo/api/read.js
@@ -118,7 +118,7 @@ export class GetUtxoTxOutputsWithTx {
   static baseQuery(
     db: lf$Database,
     predicate: (txTable: lf$schema$Table, outputTable: lf$schema$Table) => lf$Predicate,
-  ) {
+  ): lf$query$Select {
     const txTable = db.getSchema().table(
       GetUtxoTxOutputsWithTx.ownTables[TransactionSchema.name].name
     );

--- a/app/api/ada/paperWallet/paperWalletPdf.js
+++ b/app/api/ada/paperWallet/paperWalletPdf.js
@@ -126,7 +126,7 @@ export const generateAdaPaperPdf = async (
 
 function printPasswordMessage(
   doc: Pdf,
-) {
+): void {
   doc.setFontSize(11);
   const text = 'password or a hint';
   textCenter(doc, 56, text, null, 180, true);
@@ -139,7 +139,7 @@ function printTestnetLabel(
   y: number,
   r?: number,
   xShift?: number
-) {
+): void {
   doc.setFontSize(50);
   doc.setFontType('bold');
   doc.setTextColor(255, 180, 164);
@@ -205,7 +205,7 @@ function printAddresses(
   return true;
 }
 
-function printMnemonics(doc: Pdf, words: Array<string>) {
+function printMnemonics(doc: Pdf, words: Array<string>): void {
   doc.setFont('courier');
   doc.setFontSize(7);
   const [pA, pB] = [{ x: 56, y: 82 }, { x: 153, y: 105 }];
@@ -232,11 +232,11 @@ function textCenter(
   doc: Pdf,
   y: number,
   text: string,
-  m,
-  r,
+  m: null,
+  r: ?number,
   isReverseCentering?: boolean,
   xShift?: number
-) {
+): void {
   const unit = doc.getStringUnitWidth(text);
   const fontSize = doc.internal.getFontSize();
   const scaleFactor = doc.internal.scaleFactor;
@@ -252,7 +252,7 @@ async function addImage(doc: Pdf, url: string, params?: AddImageParams): Promise
   return addImageBase64(doc, await loadImage(url), params);
 }
 
-function addImageBase64(doc: Pdf, img: string, params?: AddImageParams) {
+function addImageBase64(doc: Pdf, img: string, params?: AddImageParams): void {
   const { x, y, w, h, r } = params || {};
   doc.addImage(img, 'png', x || 0, y || 0, w, h, '', 'FAST', r);
 }

--- a/app/api/ada/restoration/byron/scan.js
+++ b/app/api/ada/restoration/byron/scan.js
@@ -52,7 +52,9 @@ export async function addByronAddress(
   addByHash: AddByHashFunc,
   insertRequest: InsertRequest,
   address: string,
-) {
+): Promise<{|
+  KeyDerivationId: number,
+|}> {
   await addByHash({
     ...insertRequest,
     address: {

--- a/app/api/ada/restoration/shelley/scan.js
+++ b/app/api/ada/restoration/shelley/scan.js
@@ -53,7 +53,9 @@ export async function addShelleyAddress(
   addByHash: AddByHashFunc,
   insertRequest: InsertRequest,
   address: string,
-) {
+): Promise<{|
+  KeyDerivationId: number,
+|}> {
   await addByHash({
     ...insertRequest,
     address: {

--- a/app/api/ada/transactions/utils.test.js
+++ b/app/api/ada/transactions/utils.test.js
@@ -207,6 +207,6 @@ const _expRow = (
   date: string
 ): TransactionExportRow => ({ type, amount, fee, date: new Date(date) });
 
-function _expectEqual(a, b) {
+function _expectEqual(a: any, b: any): void {
   expect(a).toEqual(b);
 }

--- a/app/api/export/index.test.js
+++ b/app/api/export/index.test.js
@@ -46,7 +46,7 @@ test('convert random nonsense to CSV file body', async () => {
   expect(fileType).toEqual('csv');
 });
 
-async function extractStringFromBlob(b): Promise<string> {
+async function extractStringFromBlob(b: Blob): Promise<string> {
   return new Promise(resolve => {
     const reader = new FileReader();
     reader.addEventListener('loadend', () => {

--- a/app/api/localStorage/index.js
+++ b/app/api/localStorage/index.js
@@ -155,7 +155,7 @@ export default class LocalStorageApi {
 
   unsetHideBalance = (): Promise<void> => removeLocalItem(storageKeys.HIDE_BALANCE);
 
-  async reset() {
+  async reset(): Promise<void> {
     await this.unsetUserLocale();
     await this.unsetTermsOfUseAcceptance();
     await this.unsetUserTheme();

--- a/app/utils/routing.js
+++ b/app/utils/routing.js
@@ -19,7 +19,7 @@ export const matchRoute = (
  */
 type ParamsT = ?{ [key: string]: Array<number|string>|number|string };
 export const buildRoute = (pattern: string, params: ParamsT) => {
-  function toArray(val) {
+  function toArray(val): Array<number | string> {
     return Array.isArray(val) ? val : [val];
   }
   const reRepeatingSlashes = /\/+/g; // '/some//path'


### PR DESCRIPTION
This makes that any JS function in the API folder has to specify function argument types and return types.