### PR TITLE
Fix member variable type in stores

### DIFF
--- a/app/actions/profile-actions.js
+++ b/app/actions/profile-actions.js
@@ -7,10 +7,10 @@ import type { ExplorerType } from '../domain/Explorer';
 export default class ProfileActions {
   acceptTermsOfUse: Action<void> = new Action();
   acceptUriScheme: Action<void> = new Action();
-  updateTentativeLocale: Action<{ locale: string }> = new Action();
-  updateLocale: Action<{ locale: string }> = new Action();
-  updateSelectedExplorer: Action<{ explorer: ExplorerType }> = new Action();
-  updateTheme: Action<{ theme: string }> = new Action();
+  updateTentativeLocale: Action<{| locale: string |}> = new Action();
+  updateLocale: Action<{| locale: string |}> = new Action();
+  updateSelectedExplorer: Action<{| explorer: ExplorerType |}> = new Action();
+  updateTheme: Action<{| theme: string |}> = new Action();
   exportTheme: Action<void> = new Action();
   commitLocaleToStorage: Action<{ locale: string }> = new Action();
   updateHideBalance: Action<void> = new Action();

--- a/app/containers/profile/LanguageSelectionPage.js
+++ b/app/containers/profile/LanguageSelectionPage.js
@@ -43,7 +43,7 @@ export default class LanguageSelectionPage extends Component<InjectedProps> {
     await this.props.stores.profile.getProfileLocaleRequest.execute();
   }
 
-  onSelectLanguage = (values: { locale: string }) => {
+  onSelectLanguage = (values: {| locale: string |}) => {
     this.props.actions.profile.updateTentativeLocale.trigger(values);
   };
 

--- a/app/containers/settings/categories/GeneralSettingsPage.js
+++ b/app/containers/settings/categories/GeneralSettingsPage.js
@@ -16,15 +16,15 @@ import { getExplorers } from '../../../domain/Explorer';
 @observer
 export default class GeneralSettingsPage extends Component<InjectedProps> {
 
-  onSelectLanguage = (values: { locale: string }) => {
+  onSelectLanguage = (values: {| locale: string |}) => {
     this.props.actions.profile.updateLocale.trigger(values);
   };
 
-  onSelecExplorer = (values: { explorer: ExplorerType }) => {
+  onSelecExplorer = (values: {| explorer: ExplorerType |}) => {
     this.props.actions.profile.updateSelectedExplorer.trigger(values);
   };
 
-  selectTheme = (values: { theme: string }) => {
+  selectTheme = (values: {| theme: string |}) => {
     this.props.actions.profile.updateTheme.trigger(values);
   };
 
@@ -32,7 +32,7 @@ export default class GeneralSettingsPage extends Component<InjectedProps> {
     this.props.actions.profile.exportTheme.trigger();
   };
 
-  getThemeVars = (theme: { theme: string }) => (
+  getThemeVars = (theme: {| theme: string |}) => (
     this.props.stores.profile.getThemeVars(theme)
   )
 

--- a/app/containers/wallet/WalletAddPage.js
+++ b/app/containers/wallet/WalletAddPage.js
@@ -85,7 +85,7 @@ export default class WalletAddPage extends Component<Props> {
         />
       );
     } else if (uiDialogs.isOpen(WalletRestoreDialog)) {
-      const mode = uiDialogs.getParam('restoreType') || 'regular';
+      const mode = uiDialogs.getParam<string>('restoreType') || 'regular';
       if ((mode !== 'regular') && (mode !== 'paper')) {
         throw new Error('Invalid restore type');
       }

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -127,8 +127,8 @@ export default class WalletReceivePage extends Component<Props, State> {
 
         {uiDialogs.isOpen(URIGenerateDialog) ? (
           <URIGenerateDialog
-            walletAddress={uiDialogs.getParam('address')}
-            amount={uiDialogs.getParam('amount')}
+            walletAddress={uiDialogs.getParam<string>('address')}
+            amount={uiDialogs.getParam<number>('amount')}
             onClose={() => actions.dialogs.closeActiveDialog.trigger()}
             onGenerate={(address, amount) => { this.generateURI(address, amount); }}
             classicTheme={profile.isClassicTheme}
@@ -140,12 +140,12 @@ export default class WalletReceivePage extends Component<Props, State> {
 
         {uiDialogs.isOpen(URIDisplayDialog) ? (
           <URIDisplayDialog
-            address={uiDialogs.getParam('address')}
-            amount={uiDialogs.getParam('amount')}
+            address={uiDialogs.getParam<string>('address')}
+            amount={uiDialogs.getParam<number>('amount')}
             onClose={() => actions.dialogs.closeActiveDialog.trigger()}
             onBack={() => this.openURIGenerateDialog(
-              uiDialogs.getParam('address'),
-              uiDialogs.getParam('amount'),
+              uiDialogs.getParam<string>('address'),
+              uiDialogs.getParam<number>('amount'),
             )}
             onCopyAddressTooltip={(elementId) => {
               if (!uiNotifications.isOpen(elementId)) {

--- a/app/stores/.eslintrc.js
+++ b/app/stores/.eslintrc.js
@@ -1,0 +1,26 @@
+module.exports = {
+  rules: {
+    'flowtype/require-return-type': [
+      2,
+      'always',
+      {
+        excludeArrowFunctions: true,
+        annotateUndefined: 'ignore',
+        excludeMatching: ['constructor'],
+      }
+    ],
+    "flowtype/require-parameter-type": [
+      2,
+      {
+        "excludeArrowFunctions": true
+      }
+    ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "ClassProperty:not([typeAnnotation])[key.name!=/_.*/]",
+        "message": "Missing type annotation of class property. This has unexpected cross-module behavior."
+      },
+    ],
+  },
+}

--- a/app/stores/ada/AdaTransactionsStore.js
+++ b/app/stores/ada/AdaTransactionsStore.js
@@ -90,7 +90,9 @@ export default class AdaTransactionsStore extends TransactionsStore {
   }
 
   /** Wrap utility function to expose to components/containers */
-  validateAmount = (amountInLovelaces: string): Promise<boolean> => (
+  validateAmount: string => Promise<boolean> = (
+    amountInLovelaces: string
+  ): Promise<boolean> => (
     Promise.resolve(isValidAmountInLovelaces(amountInLovelaces))
   );
 

--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -89,7 +89,9 @@ export default class AdaWalletsStore extends WalletStore {
 
   // =================== VALIDITY CHECK ==================== //
 
-  isValidAddress = (address: string): Promise<boolean> => this.api.ada.isValidAddress({ address });
+  isValidAddress: string => Promise<boolean> = (
+    address: string
+  ): Promise<boolean> => this.api.ada.isValidAddress({ address });
 
   isValidMnemonic: {|
     mnemonic: string,
@@ -108,11 +110,11 @@ export default class AdaWalletsStore extends WalletStore {
     walletName: string,
     walletPassword: string,
   |}) => {
-    await this._restore(params);
+    await this.restore(params);
   };
 
   // =================== NOTIFICATION ==================== //
-  showLedgerNanoWalletIntegratedNotification = (): void => {
+  showLedgerNanoWalletIntegratedNotification: void => void = (): void => {
     const notification: Notification = {
       id: globalMessages.ledgerNanoSWalletIntegratedNotificationMessage.id,
       message: globalMessages.ledgerNanoSWalletIntegratedNotificationMessage,
@@ -121,7 +123,7 @@ export default class AdaWalletsStore extends WalletStore {
     this.actions.notifications.open.trigger(notification);
   }
 
-  showTrezorTWalletIntegratedNotification = (): void => {
+  showTrezorTWalletIntegratedNotification: void => void = (): void => {
     const notification: Notification = {
       id: globalMessages.trezorTWalletIntegratedNotificationMessage.id,
       message: globalMessages.trezorTWalletIntegratedNotificationMessage,
@@ -130,7 +132,7 @@ export default class AdaWalletsStore extends WalletStore {
     this.actions.notifications.open.trigger(notification);
   }
 
-  showWalletCreatedNotification = (): void => {
+  showWalletCreatedNotification: void => void = (): void => {
     const notification: Notification = {
       id: globalMessages.walletCreatedNotificationMessage.id,
       message: globalMessages.walletCreatedNotificationMessage,
@@ -139,7 +141,7 @@ export default class AdaWalletsStore extends WalletStore {
     this.actions.notifications.open.trigger(notification);
   }
 
-  showWalletRestoredNotification = (): void => {
+  showWalletRestoredNotification: void => void = (): void => {
     const notification: Notification = {
       id: globalMessages.walletRestoredNotificationMessage.id,
       message: globalMessages.walletRestoredNotificationMessage,

--- a/app/stores/ada/HWVerifyAddressStore.js
+++ b/app/stores/ada/HWVerifyAddressStore.js
@@ -79,7 +79,7 @@ export default class AddressesStore extends Store {
     this._setActionProcessing(false);
   }
 
-  trezorVerifyAddress = async (
+  trezorVerifyAddress: (BIP32Path, string) => Promise<void> = async (
     path: BIP32Path,
     address: string
   ): Promise<void> => {
@@ -96,7 +96,7 @@ export default class AddressesStore extends Store {
     }
   }
 
-  ledgerVerifyAddress = async (
+  ledgerVerifyAddress: (BIP32Path, string) => Promise<void> = async (
     path: BIP32Path,
     address: string,
   ): Promise<void> => {

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -284,7 +284,7 @@ export default class TrezorConnectStore
     return true;
   };
 
-  _handleConnectError = (error): void => {
+  _handleConnectError = (error: Error): void => {
     Logger.error(`TrezorConnectStore::_handleConnectError ${stringifyError(error)}`);
 
     this.hwDeviceInfo = undefined;

--- a/app/stores/base/AddressesStore.js
+++ b/app/stores/base/AddressesStore.js
@@ -81,7 +81,7 @@ export class AddressTypeStore<T> {
   }
 
   /** Refresh addresses for all wallets */
-  @action refreshAddresses = () => {
+  @action refreshAddresses: void => void = () => {
     const publicDeriver = this.stores.substores[environment.API].wallets.selected;
     if (publicDeriver == null) return;
     const allRequest = this._getRequest(publicDeriver.self);
@@ -103,7 +103,7 @@ export class AddressTypeStore<T> {
     return new CachedRequest<SubRequestType<T>>(this.request);
   };
 
-  @action addObservedWallet = (
+  @action addObservedWallet: PublicDeriver => void = (
     publicDeriver: PublicDeriver
   ): void => {
     this.addressesRequests.push({
@@ -177,7 +177,9 @@ export default class AddressesStore extends Store {
     this.error = null;
   };
 
-  addObservedWallet = (publicDeriver: PublicDeriverWithCachedMeta): void => {
+  addObservedWallet: PublicDeriverWithCachedMeta => void = (
+    publicDeriver: PublicDeriverWithCachedMeta
+  ): void => {
     const withHasChains = asHasChains(publicDeriver.self);
     if (withHasChains == null) {
       this.allAddressesForDisplay.addObservedWallet(publicDeriver.self);
@@ -188,7 +190,9 @@ export default class AddressesStore extends Store {
     this.refreshAddresses(publicDeriver);
   }
 
-  refreshAddresses = (publicDeriver: PublicDeriverWithCachedMeta): void => {
+  refreshAddresses: PublicDeriverWithCachedMeta => void = (
+    publicDeriver: PublicDeriverWithCachedMeta
+  ): void => {
     const withHasChains = asHasChains(publicDeriver.self);
     if (withHasChains == null) {
       this.allAddressesForDisplay.refreshAddresses();

--- a/app/stores/base/TransactionsStore.js
+++ b/app/stores/base/TransactionsStore.js
@@ -133,7 +133,7 @@ export default class TransactionsStore extends Store {
   }
 
   /** Refresh transaction data for all wallets and update wallet balance */
-  @action refreshTransactionData = (
+  @action refreshTransactionData: PublicDeriverWithCachedMeta => void = (
     basePubDeriver: PublicDeriverWithCachedMeta,
   ): void => {
     const walletsStore = this.stores.substores[environment.API].wallets;
@@ -206,7 +206,7 @@ export default class TransactionsStore extends Store {
       .catch(() => {}); // Do nothing. It's logged in the api call
   };
 
-  @action refreshLocal = (
+  @action refreshLocal: (PublicDeriver & IGetAllUtxos & IGetLastSyncInfo) => void = (
     publicDeriver: PublicDeriver & IGetAllUtxos & IGetLastSyncInfo,
   ): void => {
     const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
@@ -233,7 +233,7 @@ export default class TransactionsStore extends Store {
   }
 
   /** Add a new public deriver to track and refresh the data */
-  @action addObservedWallet = (
+  @action addObservedWallet: PublicDeriverWithCachedMeta => void = (
     publicDeriver: PublicDeriverWithCachedMeta
   ): void => {
     this.transactionsRequests.push({

--- a/app/stores/base/WalletSettingsStore.js
+++ b/app/stores/base/WalletSettingsStore.js
@@ -4,8 +4,8 @@ import Store from './Store';
 
 export default class WalletSettingsStore extends Store {
 
-  @observable walletFieldBeingEdited = null;
-  @observable lastUpdatedWalletField = null;
+  @observable walletFieldBeingEdited: string | null = null;
+  @observable lastUpdatedWalletField: string | null = null;
 
   @action _startEditingWalletField = ({ field }: { field: string }) => {
     this.walletFieldBeingEdited = field;

--- a/app/stores/base/WalletStore.js
+++ b/app/stores/base/WalletStore.js
@@ -136,11 +136,11 @@ export default class WalletsStore extends Store {
   };
 
   /** Restore wallet and move to wallet summary screen */
-  _restore = async (params: {|
+  restore: {|
     recoveryPhrase: string,
     walletName: string,
     walletPassword: string,
-  |}) => {
+  |} => Promise<void> = async (params) => {
     this.restoreRequest.reset();
 
     const persistentDb = this.stores.loading.loadPersitentDbRequest.result;
@@ -202,11 +202,16 @@ export default class WalletsStore extends Store {
     return matchRoute(ROUTES.WALLETS.ROOT + '(/*rest)', currentRoute) !== false;
   }
 
-  getWalletRoute = (
+  getWalletRoute: (PublicDeriver, ?string) => string = (
     publicDeriver: PublicDeriver,
-    page: string = 'transactions'
+    page: ?string
   ): string => (
-    buildRoute(ROUTES.WALLETS.PAGE, { id: publicDeriver.getPublicDeriverId(), page })
+    buildRoute(ROUTES.WALLETS.PAGE, {
+      id: publicDeriver.getPublicDeriverId(),
+      page: page == null
+        ? 'transactions'
+        : page
+    })
   );
 
   goToWalletRoute(publicDeriver: PublicDeriver) {
@@ -222,7 +227,7 @@ export default class WalletsStore extends Store {
   }
 
   @action
-  addHwWallet = async (
+  addHwWallet: PublicDeriver => Promise<void> = async (
     publicDeriver: PublicDeriver,
   ): Promise<void> => {
     const withCache = await PublicDeriverWithCachedMeta.fromPublicDeriver(publicDeriver);
@@ -248,7 +253,7 @@ export default class WalletsStore extends Store {
   }
 
   /** Make all API calls required to setup/update wallet */
-  @action restoreWalletsFromStorage = async (): Promise<void> => {
+  @action restoreWalletsFromStorage: void => Promise<void> = async (): Promise<void> => {
     const persistentDb = this.stores.loading.loadPersitentDbRequest.result;
     if (persistentDb == null) {
       throw new Error('restoreWalletsFromStorage db not loaded. Should never happen');
@@ -277,15 +282,15 @@ export default class WalletsStore extends Store {
     }
   };
 
-  @action registerObserversForNewWallet = async (
+  @action registerObserversForNewWallet: PublicDeriverWithCachedMeta => Promise<void> = async (
     publicDeriver: PublicDeriverWithCachedMeta
-  ) => {
+  ): Promise<void> => {
     this.stores.substores[environment.API].addresses.addObservedWallet(publicDeriver);
     this.stores.substores[environment.API].transactions.addObservedWallet(publicDeriver);
   };
 
   /** Make all API calls required to setup imported wallet */
-  @action refreshImportedWalletData = async () => {
+  @action refreshImportedWalletData: void => Promise<void> = async (): Promise<void> => {
     if (this.hasAnyPublicDeriver) this._setActiveWallet({ wallet: this.publicDerivers[0] });
     return await this.restoreWalletsFromStorage();
   };

--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -93,7 +93,7 @@ export default class LoadingStore extends Store {
   }
 
   @action
-  validateUriPath = async (): Promise<void> => {
+  validateUriPath: void => Promise<void> = async (): Promise<void> => {
     if (this.fromUriScheme) {
       const uriParams = await getURIParameters(
         decodeURIComponent(this._originRoute.location),
@@ -109,7 +109,7 @@ export default class LoadingStore extends Store {
    * Need to clear any data inijected by the URI after we've applied it
    */
   @action
-  resetUriParams = (): void => {
+  resetUriParams: void => void = (): void => {
     this._uriParams = null;
     this._originRoute = { route: '', location: '' };
   }

--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -104,7 +104,14 @@ export default class ProfileStore extends Store {
     },
   ];
 
-  @observable bigNumberDecimalFormat = {
+  @observable bigNumberDecimalFormat: {|
+    decimalSeparator: string,
+    groupSeparator: string,
+    groupSize: number,
+    secondaryGroupSize: number,
+    fractionGroupSeparator: string,
+    fractionGroupSize: number,
+  |} = {
     decimalSeparator: '.',
     groupSeparator: ',',
     groupSize: 3,
@@ -309,7 +316,7 @@ export default class ProfileStore extends Store {
   }
 
   /* @Returns Merged Pre-Built Theme and Custom Theme */
-  @computed get currentThemeVars() {
+  @computed get currentThemeVars(): { [key: string]: string } {
     const { result } = this.getCustomThemeRequest.execute();
     const currentThemeVars = this.getThemeVars({ theme: this.currentTheme });
     let customThemeVars = {};
@@ -355,12 +362,14 @@ export default class ProfileStore extends Store {
     }
   };
 
-  getThemeVars = ({ theme }: { theme: string }) => {
+  getThemeVars: {| theme: string |} => { [key: string]: string } = (
+    { theme }
+  ): { [key: string]: string } => {
     if (theme) return require(`../../themes/prebuilt/${theme}.js`).default;
     return require(`../../themes/prebuilt/${ProfileStore.getDefaultTheme()}.js`); // default
   };
 
-  hasCustomTheme = (): boolean => {
+  hasCustomTheme: void => boolean = (): boolean => {
     const { result } = this.getCustomThemeRequest.execute();
     return result !== undefined;
   };
@@ -431,7 +440,9 @@ export default class ProfileStore extends Store {
     return result != null ? result : '0.0.0';
   }
 
-  setLastLaunchVersion = async (version: string) => {
+  setLastLaunchVersion: string => Promise<void> = async (
+    version: string
+  ): Promise<void> => {
     await this.setLastLaunchVersionRequest.execute(version);
     await this.getLastLaunchVersionRequest.execute(); // eagerly cache
   };
@@ -450,7 +461,9 @@ export default class ProfileStore extends Store {
     return result || 'seiza';
   }
 
-  setSelectedExplorer = async ({ explorer }: { explorer: ExplorerType }) => {
+  setSelectedExplorer: {| explorer: ExplorerType |} => Promise<void> = async (
+    { explorer }
+  ): Promise<void> => {
     await this.setSelectedExplorerRequest.execute({ explorer });
     await this.getSelectedExplorerRequest.execute(); // eagerly cache
   };

--- a/app/stores/toplevel/TopbarStore.js
+++ b/app/stores/toplevel/TopbarStore.js
@@ -51,7 +51,9 @@ export default class TopbarStore extends Store {
 
   // @computed decorator for methods with parameters are not supported in this
   // version of mobx. Instead, making a regular function that calls `computed`
-  isActiveCategory = category => computed(
+  isActiveCategory: Category => boolean = (
+    category: Category
+  ): boolean => computed(
     () => this.activeTopbarCategory && this.activeTopbarCategory === category.route
   ).get();
 

--- a/app/stores/toplevel/UiDialogsStore.js
+++ b/app/stores/toplevel/UiDialogsStore.js
@@ -23,13 +23,19 @@ export default class UiDialogsStore extends Store {
     this.actions.dialogs.updateDataForActiveDialog.listen(this._onUpdateDataForActiveDialog);
   }
 
-  isOpen = (dialog: Function): boolean => (this.activeDialog
+  isOpen: Function => boolean = (
+    dialog: Function
+  ): boolean => (this.activeDialog
     ? this.activeDialog.name === dialog.name
     : false);
 
-  getParam = (key: string): string => this.paramsForActiveDialog[key];
+  getParam: <T>(number | string) => T = <T>(
+    key: (number | string)
+  ): T => this.paramsForActiveDialog[key];
 
-  countdownSinceDialogOpened = (countDownTo: number) => (
+  countdownSinceDialogOpened: number => number = (
+    countDownTo: number
+  ): number => (
     Math.max(countDownTo - this.secondsSinceActiveDialogIsOpen, 0)
   );
 

--- a/app/stores/toplevel/UiNotificationsStore.js
+++ b/app/stores/toplevel/UiNotificationsStore.js
@@ -19,9 +19,13 @@ export default class UiNotificationsStore extends Store {
     this.actions.notifications.closeActiveNotification.listen(this._onClose);
   }
 
-  isOpen = (id: string): boolean => !!this._findNotificationById(id);
+  isOpen: string => boolean = (
+    id: string
+  ): boolean => !!this._findNotificationById(id);
 
-  getTooltipActiveNotification = (tooltipNotificationId : string): ?Notification => {
+  getTooltipActiveNotification: string => ?Notification = (
+    tooltipNotificationId : string
+  ): ?Notification => {
     let notification = null;
     const activeNotificationId = this.mostRecentActiveNotification ?
       this.mostRecentActiveNotification.id :


### PR DESCRIPTION
In the Yoroi codebase, we have many places with code that looks like
```
isValidMnemonic = (
    mnemonic: string,
    numberOfWords: number
  ): boolean => this.api.ada.isValidMnemonic({ mnemonic, numberOfWords });
```

Although this code LOOKS LIKE it has correct Flow types, *actually flow will resolve this function to “any”*.

This is because Flow uses type inference so `isValidMnemonic` has no type but since we’re assigning it `(string, number) => boolean` it INFERS the type is `(string, number) => boolean`

*HOWEVER* Flow type inference is not cross-module! That means if you call `isValidMnemonic` from any other file it will just be `any`

To fix this, you have to instead do

```
isValidMnemonic: (string, number) => boolean = (
    mnemonic: string,
    numberOfWords: number
  ): boolean => this.api.ada.isValidMnemonic({ mnemonic, numberOfWords });
```

This is the cause of a huge amount of `any` types in the Yoroi-Frontend codebase because nobody noticed this tricky behavior of Flow until now