### PR TITLE
Replace deprecated react-svg-inline library

### DIFF
--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -1,14 +1,13 @@
 // @flow
 import React, { Component } from 'react';
 import type { Node } from 'react';
-import SvgInline from 'react-svg-inline';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import LoadingSpinner from '../widgets/LoadingSpinner';
-import adaLogo from '../../assets/images/ada-logo.inline.svg';
-import cardanoLogo from '../../assets/images/cardano-logo.inline.svg';
-import yoroiLogo from '../../assets/images/yoroi-logo-shape-white.inline.svg';
+import AdaLogo from '../../assets/images/ada-logo.inline.svg';
+import CardanoLogo from '../../assets/images/cardano-logo.inline.svg';
+import YoroiLogo from '../../assets/images/yoroi-logo-shape-white.inline.svg';
 import styles from './Loading.scss';
 import LocalizableError from '../../i18n/LocalizableError';
 import globalMessages from '../../i18n/global-messages';
@@ -65,16 +64,12 @@ export default class Loading extends Component<Props> {
       styles[`${api}-apiLogo`],
     ]);
 
-    const yoroiLoadingLogo = yoroiLogo;
-    const currencyLoadingLogo = adaLogo;
-    const apiLoadingLogo = cardanoLogo;
-
     return (
       <div className={componentStyles}>
         <div className={styles.logos}>
-          <SvgInline svg={currencyLoadingLogo} className={currencyLogoStyles} />
-          <SvgInline svg={yoroiLoadingLogo} className={yoroiLogoStyles} />
-          <SvgInline svg={apiLoadingLogo} className={apiLogoStyles} />
+          <span className={currencyLogoStyles}><AdaLogo /></span>
+          <span className={yoroiLogoStyles}><YoroiLogo /></span>
+          <span className={apiLogoStyles}><CardanoLogo /></span>
         </div>
         {hasLoadedCurrentLocale && (
           <div>

--- a/app/components/profile/language-selection/IntroBanner.js
+++ b/app/components/profile/language-selection/IntroBanner.js
@@ -2,9 +2,8 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import styles from './IntroBanner.scss';
-import SvgInline from 'react-svg-inline';
 import { defineMessages, intlShape, } from 'react-intl';
-import testnetLogo from '../../../assets/images/yoroi-logotestnet-gradient.inline.svg';
+import TestnetLogo from '../../../assets/images/yoroi-logotestnet-gradient.inline.svg';
 
 type Props = {||};
 
@@ -34,7 +33,7 @@ export default class IntroBanner extends Component<Props> {
     const { intl } = this.context;
     return (
       <div className={styles.component}>
-        <SvgInline svg={testnetLogo} className={styles.banner} />
+        <span className={styles.banner}><TestnetLogo /></span>
         <div className={styles.mainTitle}>
           {intl.formatMessage(messages.title)}
         </div>

--- a/app/components/profile/uri-prompt/UriAccept.js
+++ b/app/components/profile/uri-prompt/UriAccept.js
@@ -1,13 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 import { observer } from 'mobx-react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
 import styles from './UriAccept.scss';
-import uriPrompt from '../../../assets/images/uri/uri-prompt.inline.svg';
+import UriPrompt from '../../../assets/images/uri/uri-prompt.inline.svg';
 import globalMessages from '../../../i18n/global-messages';
 
 const messages = defineMessages({
@@ -45,7 +44,7 @@ export default class UriAccept extends Component<Props> {
       <div className={styles.component}>
         <div className={styles.centeredBox}>
 
-          <SvgInline svg={uriPrompt} className={styles.aboutSvg} />
+          <span className={styles.aboutSvg}><UriPrompt /></span>
 
           <div className={styles.explanation}>
             <FormattedHTMLMessage {...messages.seePrompt} />

--- a/app/components/profile/uri-prompt/UriPromptForm.js
+++ b/app/components/profile/uri-prompt/UriPromptForm.js
@@ -1,14 +1,13 @@
 // @flow
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 import { observer } from 'mobx-react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import { defineMessages, intlShape } from 'react-intl';
 import styles from './UriPromptForm.scss';
-import aboutUri from '../../../assets/images/uri/about-url.inline.svg';
-import aboutUriClassic from '../../../assets/images/uri/about-url-classic.inline.svg';
+import AboutUri from '../../../assets/images/uri/about-url.inline.svg';
+import AboutUriClassic from '../../../assets/images/uri/about-url-classic.inline.svg';
 import globalMessages from '../../../i18n/global-messages';
 
 const messages = defineMessages({
@@ -50,13 +49,12 @@ export default class UriPromptForm extends Component<Props> {
       <div className={styles.component}>
         <div className={styles.centeredBox}>
 
-          <SvgInline
-            svg={this.props.classicTheme
-              ? aboutUriClassic
-              : aboutUri
+          <span className={styles.aboutSvg}>
+            {this.props.classicTheme
+              ? <AboutUriClassic />
+              : <AboutUri />
             }
-            className={styles.aboutSvg}
-          />
+          </span>
 
           <div className={styles.explanation}>
             {intl.formatMessage(messages.explanationLine1)}&nbsp;

--- a/app/components/profile/uri-prompt/UriSkip.js
+++ b/app/components/profile/uri-prompt/UriSkip.js
@@ -1,15 +1,14 @@
 // @flow
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 import { observer } from 'mobx-react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import { defineMessages, intlShape } from 'react-intl';
 import styles from './UriSkip.scss';
 import globalMessages from '../../../i18n/global-messages';
-import noTransactionClassicSvg from '../../../assets/images/transaction/no-transactions-yet.classic.inline.svg';
-import noTransactionModernSvg from '../../../assets/images/transaction/no-transactions-yet.modern.inline.svg';
+import NoTransactionClassicSvg from '../../../assets/images/transaction/no-transactions-yet.classic.inline.svg';
+import NoTransactionModernSvg from '../../../assets/images/transaction/no-transactions-yet.modern.inline.svg';
 
 
 const messages = defineMessages({
@@ -48,14 +47,16 @@ export default class UriSkip extends Component<Props> {
     ]);
 
     const noTransactionSvg = this.props.classicTheme
-      ? noTransactionClassicSvg
-      : noTransactionModernSvg;
+      ? <NoTransactionClassicSvg />
+      : <NoTransactionModernSvg />;
 
     return (
       <div className={styles.component}>
         <div className={styles.centeredBox}>
 
-          <SvgInline svg={noTransactionSvg} className={styles.aboutSvg} />
+          <span className={styles.aboutSvg}>
+            {noTransactionSvg}
+          </span>
 
           <div className={styles.explanation}>
             {intl.formatMessage(messages.descriptionLine1)}&nbsp;

--- a/app/components/topbar/TopBarCategory.js
+++ b/app/components/topbar/TopBarCategory.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import type { MessageDescriptor } from 'react-intl';
 import { intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import { observer } from 'mobx-react';
 import classNames from 'classnames';
 import styles from './TopBarCategory.scss';
@@ -38,9 +37,10 @@ export default class TopBarCategory extends Component<Props> {
       iconStyle != null ? iconStyle : null,
       styles.icon
     ]);
+    const SvgElem = icon;
     return (
       <button type="button" className={componentStyles} onClick={onClick}>
-        <SvgInline svg={icon} className={iconStyles} />
+        <span className={iconStyles}><SvgElem /></span>
         {inlineTextMD
           && <span className={styles.iconInlineText}>{intl.formatMessage(inlineTextMD)}</span>}
       </button>

--- a/app/components/topbar/WalletTopbarTitle.js
+++ b/app/components/topbar/WalletTopbarTitle.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import BigNumber from 'bignumber.js';
 import { observer } from 'mobx-react';
-import SvgInline from 'react-svg-inline';
 import classNames from 'classnames';
 import styles from './WalletTopbarTitle.scss';
 import { matchRoute } from '../../utils/routing';
@@ -10,8 +9,8 @@ import { ROUTES } from '../../routes-config';
 import WalletAccountIcon from './WalletAccountIcon';
 
 import { defineMessages, intlShape } from 'react-intl';
-import hideBalanceIcon from '../../assets/images/top-bar/password.hide.inline.svg';
-import showBalanceIcon from '../../assets/images/top-bar/password.show.inline.svg';
+import HideBalanceIcon from '../../assets/images/top-bar/password.hide.inline.svg';
+import ShowBalanceIcon from '../../assets/images/top-bar/password.show.inline.svg';
 import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 import { WalletTypeOption } from '../../api/ada/lib/storage/models/ConceptualWallet/interfaces';
 import type { WalletAccountNumberPlate } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
@@ -110,10 +109,12 @@ export default class WalletTopbarTitle extends Component<Props> {
                 onClick={onUpdateHideBalance}
                 className={classNames([styles.hideBalanceButton, 'hideBalanceButton'])}
               >
-                <SvgInline
-                  svg={shouldHideBalance ? showBalanceIcon : hideBalanceIcon}
-                  className={styles.showHideBalanceIcon}
-                />
+                <span className={styles.showHideBalanceIcon}>
+                  {shouldHideBalance
+                    ? <ShowBalanceIcon />
+                    : <HideBalanceIcon />
+                  }
+                </span>
               </button>
             </div>
           </div>

--- a/app/components/topbar/banners/ServerErrorBanner.js
+++ b/app/components/topbar/banners/ServerErrorBanner.js
@@ -2,9 +2,8 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { intlShape, defineMessages, FormattedHTMLMessage } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import styles from './ServerErrorBanner.scss';
-import warningSvg from '../../../assets/images/warning.inline.svg';
+import WarningSvg from '../../../assets/images/warning.inline.svg';
 import type { ServerStatusErrorType } from '../../../types/serverStatusErrorType';
 
 const messages = defineMessages({
@@ -50,7 +49,7 @@ export default class ServerErrorBanner extends Component<Props> {
       <div>
         {displayMessage === null ? null : (
           <div className={styles.serverError}>
-            <SvgInline key="0" svg={warningSvg} className={styles.warningIcon} />
+            <span key="0" className={styles.warningIcon}><WarningSvg /></span>
             <FormattedHTMLMessage {...displayMessage} key="1" />
 
           </div>)

--- a/app/components/topbar/banners/TestnetWarningBanner.js
+++ b/app/components/topbar/banners/TestnetWarningBanner.js
@@ -2,13 +2,12 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { intlShape, defineMessages, FormattedMessage } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import globalMessages from '../../../i18n/global-messages';
 import { handleExternalLinkClick } from '../../../utils/routing';
 import styles from './TestnetWarningBanner.scss';
 import environment from '../../../environment';
-import warningSvg from '../../../assets/images/warning.inline.svg';
-import shelleyTestnetWarningSvg from '../../../assets/images/shelley-testnet-warning.inline.svg';
+import WarningSvg from '../../../assets/images/warning.inline.svg';
+import ShelleyTestnetWarningSvg from '../../../assets/images/shelley-testnet-warning.inline.svg';
 
 const messages = defineMessages({
   testnetLabel: {
@@ -52,7 +51,7 @@ export default class TestnetWarningBanner extends Component<Props> {
     if (environment.isShelley()) {
       children = (
         <div className={styles.shelleyTestnetWarning}>
-          <SvgInline key="0" svg={shelleyTestnetWarningSvg} className={styles.shelleyTestnetWarningIcon} />
+          <span key="0" className={styles.shelleyTestnetWarningIcon}><ShelleyTestnetWarningSvg /></span>
           <div className={styles.text}>
             <FormattedMessage
               {...messages.shelleyTestnetLabel}
@@ -65,7 +64,7 @@ export default class TestnetWarningBanner extends Component<Props> {
     } else {
       children = (
         <div className={styles.testnetWarning}>
-          <SvgInline key="0" svg={warningSvg} className={styles.warningIcon} />
+          <span key="0" className={styles.warningIcon}><WarningSvg /></span>
           <FormattedMessage
             {...messages.testnetLabel}
             values={{ faqLink, network: environment.NETWORK }}

--- a/app/components/transfer/SuccessPage.js
+++ b/app/components/transfer/SuccessPage.js
@@ -2,9 +2,8 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import styles from './SuccessPage.scss';
-import successIcon from '../../assets/images/transfer-success.inline.svg';
+import SuccessIcon from '../../assets/images/transfer-success.inline.svg';
 
 type Props = {|
   +title: string,
@@ -25,7 +24,7 @@ export default class SuccessPage extends Component<Props> {
     return (
       <div className={styles.component}>
         <div>
-          <SvgInline svg={successIcon}  />
+          <SuccessIcon />
           <div className={styles.title}>
             {title}
           </div>

--- a/app/components/uri/URIInvalidDialog.js
+++ b/app/components/uri/URIInvalidDialog.js
@@ -3,12 +3,11 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 
 import Dialog from '../widgets/Dialog';
 import DialogCloseButton from '../widgets/DialogCloseButton';
 import globalMessages from '../../i18n/global-messages';
-import invalidURIImg from '../../assets/images/uri/invalid-uri.inline.svg';
+import InvalidURIImg from '../../assets/images/uri/invalid-uri.inline.svg';
 
 import styles from './URIInvalidDialog.scss';
 
@@ -70,7 +69,7 @@ export default class URIInvalidDialog extends Component<Props> {
       >
         <div>
           <center>
-            <SvgInline svg={invalidURIImg} className={styles.invalidURIImg} />
+            <span className={styles.invalidURIImg}><InvalidURIImg /></span>
           </center>
           <div className={styles.warningText}>
             {intl.formatMessage(messages.uriInvalidDialogWarningText1)}

--- a/app/components/uri/URILandingDialog.js
+++ b/app/components/uri/URILandingDialog.js
@@ -5,11 +5,10 @@ import { observer } from 'mobx-react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import { defineMessages, intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 
 import Dialog from '../widgets/Dialog';
 import DialogCloseButton from '../widgets/DialogCloseButton';
-import performTxImg from '../../assets/images/uri/perform-tx-uri.inline.svg';
+import PerformTxImg from '../../assets/images/uri/perform-tx-uri.inline.svg';
 
 import styles from './URILandingDialog.scss';
 
@@ -72,7 +71,7 @@ export default class URILandingDialog extends Component<Props> {
         onClose={onClose}
       >
         <div>
-          {!classicTheme && <SvgInline svg={performTxImg} className={styles.urlImage} />}
+          {!classicTheme && <span className={styles.urlImage}><PerformTxImg /></span>}
           <div className={styles.warningText}>
             {intl.formatMessage(messages.uriLandingDialogWarningLine1)}
             <ul>

--- a/app/components/wallet/WalletAdd.js
+++ b/app/components/wallet/WalletAdd.js
@@ -3,13 +3,12 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 
 import CustomTooltip from '../widgets/CustomTooltip';
-import logoYoroiIcon from '../../assets/images/yoroi-logo-white.inline.svg';
-import logoYoroiShelleyTestnetIcon from '../../assets/images/yoroi-logo-shelley-testnet-white.inline.svg';
-import settingsIcon from '../../assets/images/top-bar/setting-active.inline.svg';
-import daedalusIcon from '../../assets/images/top-bar/daedalus-migration.inline.svg';
+import LogoYoroiIcon from '../../assets/images/yoroi-logo-white.inline.svg';
+import LogoYoroiShelleyTestnetIcon from '../../assets/images/yoroi-logo-shelley-testnet-white.inline.svg';
+import SettingsIcon from '../../assets/images/top-bar/setting-active.inline.svg';
+import DaedalusIcon from '../../assets/images/top-bar/daedalus-migration.inline.svg';
 
 import styles from './WalletAdd.scss';
 
@@ -88,7 +87,7 @@ export default class WalletAdd extends Component<Props> {
       environmnent.isShelley() ? styles.shelleyTestnet : null
     ]);
 
-    const logoIcon = environmnent.isShelley() ? logoYoroiShelleyTestnetIcon : logoYoroiIcon;
+    const LogoIcon = environmnent.isShelley() ? LogoYoroiShelleyTestnetIcon : LogoYoroiIcon;
 
     return (
       <div className={componentStyle}>
@@ -96,14 +95,14 @@ export default class WalletAdd extends Component<Props> {
         <div className={styles.hero}>
           <div className={styles.settingsBar}>
             <button type="button" onClick={onSettings} className={styles.settingsBarLink}>
-              <SvgInline svg={settingsIcon} width="30" height="30" />
+              <SettingsIcon width="30" height="30" />
             </button>
           </div>
 
           <div className={styles.heroInner}>
             {/* Left block  */}
             <div className={styles.heroLeft}>
-              <SvgInline svg={logoIcon} className={styles.heroLogo} width="156" height="50" />
+              <span className={styles.heroLogo}><LogoIcon width="156" height="50" /></span>
               <h2 className={styles.heroTitle}>
                 <FormattedHTMLMessage {...(messages.title)} />
               </h2>
@@ -165,12 +164,9 @@ export default class WalletAdd extends Component<Props> {
                 onClick={onDaedalusTransfer}
                 className={classnames([styles.heroCardsItem, styles.heroCardsItemLink])}
               >
-                <SvgInline
-                  svg={daedalusIcon}
-                  width="45"
-                  height="40"
-                  className={styles.heroCardsItemLinkIcon}
-                />
+                <span className={styles.heroCardsItemLinkIcon}>
+                  <DaedalusIcon width="45" height="40" />
+                </span>
                 <div className={styles.heroCardsItemTitle}>
                   {intl.formatMessage(messages.transferFundsTitle)}
                   <CustomTooltip toolTip={messages.transferFundsTooltip} />

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -2,14 +2,13 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import classnames from 'classnames';
 import QRCode from 'qrcode.react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import BorderedBox from '../widgets/BorderedBox';
-import verifyIcon from '../../assets/images/verify-icon.inline.svg';
-import generateURIIcon from '../../assets/images/generate-uri.inline.svg';
+import VerifyIcon from '../../assets/images/verify-icon.inline.svg';
+import GenerateURIIcon from '../../assets/images/generate-uri.inline.svg';
 import LocalizableError from '../../i18n/LocalizableError';
 import LoadingSpinner from '../widgets/LoadingSpinner';
 import styles from './WalletReceive.scss';
@@ -235,10 +234,9 @@ export default class WalletReceive extends Component<Props, State> {
                         className={styles.btnGenerateURI}
                       >
                         <div className={styles.generateURLActionBlock}>
-                          <SvgInline
-                            svg={generateURIIcon}
-                            className={styles.generateURIIcon}
-                          />
+                          <span className={styles.generateURIIcon}>
+                            <GenerateURIIcon />
+                          </span>
                           <span className={styles.actionIconText}>
                             {intl.formatMessage(messages.generatePaymentURLLabel)}
                           </span>
@@ -261,10 +259,9 @@ export default class WalletReceive extends Component<Props, State> {
                       }
                     >
                       <div>
-                        <SvgInline
-                          svg={verifyIcon}
-                          className={styles.verifyIcon}
-                        />
+                        <span className={styles.verifyIcon}>
+                          <VerifyIcon />
+                        </span>
                         <span>{intl.formatMessage(messages.verifyAddressLabel)}</span>
                       </div>
                     </button>

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -159,7 +159,7 @@
             & > svg {
               height: 20px;
               width: 20px;
-              path {
+              path:nth-of-type(2) {
                 fill: var(--theme-icon-copy-address-color);
               }
             }

--- a/app/components/wallet/add/option-dialog/OptionBlock.js
+++ b/app/components/wallet/add/option-dialog/OptionBlock.js
@@ -3,10 +3,9 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { intlShape } from 'react-intl';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 
 import globalMessages from '../../../../i18n/global-messages';
-import arrowDownSVG from '../../../../assets/images/expand-arrow-grey.inline.svg';
+import ArrowDownSVG from '../../../../assets/images/expand-arrow-grey.inline.svg';
 import styles from './OptionBlock.scss';
 
 type Props = {|
@@ -86,12 +85,9 @@ export default class OptionBlock extends Component<Props, State> {
                   onClick={this.toggleLearnMore.bind(this)}
                 >
                   {intl.formatMessage(globalMessages.learnMore)}
-                  <SvgInline
-                    svg={arrowDownSVG}
-                    width="20px"
-                    height="20px"
-                    className={styles.learnMoreButtonIcon}
-                  />
+                  <span className={styles.learnMoreButtonIcon}>
+                    <ArrowDownSVG width="20px" height="20px" />
+                  </span>
                 </button>
               </div>)
             : null

--- a/app/components/wallet/backup-recovery/WalletBackupPrivacyWarningDialog.js
+++ b/app/components/wallet/backup-recovery/WalletBackupPrivacyWarningDialog.js
@@ -5,13 +5,12 @@ import classnames from 'classnames';
 import { Checkbox } from 'react-polymorph/lib/components/Checkbox';
 import { CheckboxSkin } from 'react-polymorph/lib/skins/simple/CheckboxSkin';
 import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import Dialog from '../../widgets/Dialog';
 import DialogCloseButton from '../../widgets/DialogCloseButton';
 import WalletRecoveryInstructions from './WalletRecoveryInstructions';
 import globalMessages from '../../../i18n/global-messages';
 import styles from './WalletBackupPrivacyWarningDialog.scss';
-import recoveryWatchingSvg from '../../../assets/images/recovery-watching.inline.svg';
+import RecoveryWatchingSvg from '../../../assets/images/recovery-watching.inline.svg';
 
 const messages = defineMessages({
   recoveryPhraseInstructions: {
@@ -79,7 +78,7 @@ export default class WalletBackupPrivacyWarningDialog extends Component<Props> {
         closeButton={<DialogCloseButton onClose={onCancelBackup} />}
         classicTheme={classicTheme}
       >
-        {!classicTheme && <SvgInline className={styles.recoveryImage} svg={recoveryWatchingSvg} />}
+        {!classicTheme && <span className={styles.recoveryImage}><RecoveryWatchingSvg /></span>}
         <WalletRecoveryInstructions
           instructionsText={<FormattedHTMLMessage {...messages.recoveryPhraseInstructions} />}
           classicTheme={classicTheme}

--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseDisplayDialog.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseDisplayDialog.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import WalletRecoveryPhraseMnemonic from './WalletRecoveryPhraseMnemonic';
 import DialogCloseButton from '../../widgets/DialogCloseButton';
 import DialogBackButton from '../../widgets/DialogBackButton';
@@ -10,7 +9,7 @@ import Dialog from '../../widgets/Dialog';
 import WalletRecoveryInstructions from './WalletRecoveryInstructions';
 import globalMessages from '../../../i18n/global-messages';
 import styles from './WalletRecoveryPhraseDisplayDialog.scss';
-import recoveryPhraseSvg from '../../../assets/images/recovery-phrase.inline.svg';
+import RecoveryPhraseSvg from '../../../assets/images/recovery-phrase.inline.svg';
 
 const messages = defineMessages({
   backupInstructions: {
@@ -68,7 +67,7 @@ export default class WalletRecoveryPhraseDisplayDialog extends Component<Props> 
         backButton={<DialogBackButton onBack={onBack} />}
         classicTheme={classicTheme}
       >
-        {!classicTheme && <SvgInline className={styles.recoveryImage} svg={recoveryPhraseSvg} />}
+        {!classicTheme && <span className={styles.recoveryImage}><RecoveryPhraseSvg /></span>}
 
         <WalletRecoveryInstructions
           instructionsText={<FormattedHTMLMessage {...messages.backupInstructions} />}

--- a/app/components/wallet/hwConnect/ledger/CheckDialog.js
+++ b/app/components/wallet/hwConnect/ledger/CheckDialog.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import { defineMessages, intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 
 import globalMessages from '../../../../i18n/global-messages';
 import LocalizableError from '../../../../i18n/LocalizableError';
@@ -16,10 +15,10 @@ import ProgressStepBlock from '../common/ProgressStepBlock';
 import HelpLinkBlock from './HelpLinkBlock';
 import HWErrorBlock from '../common/HWErrorBlock';
 
-import externalLinkSVG from '../../../../assets/images/link-external.inline.svg';
-import aboutPrerequisiteIconSVG from '../../../../assets/images/hardware-wallet/check-prerequisite-header-icon.inline.svg';
-import aboutPrerequisiteTrezorSVG from '../../../../assets/images/hardware-wallet/ledger/check.inline.svg';
-import aboutLedgerSVG from '../../../../assets/images/hardware-wallet/ledger/check-modern.inline.svg';
+import ExternalLinkSVG from '../../../../assets/images/link-external.inline.svg';
+import AboutPrerequisiteIconSVG from '../../../../assets/images/hardware-wallet/check-prerequisite-header-icon.inline.svg';
+import AboutPrerequisiteTrezorSVG from '../../../../assets/images/hardware-wallet/ledger/check.inline.svg';
+import AboutLedgerSVG from '../../../../assets/images/hardware-wallet/ledger/check-modern.inline.svg';
 
 import { ProgressInfo } from '../../../../types/HWConnectStoreTypes';
 
@@ -92,11 +91,11 @@ export default class CheckDialog extends Component<Props> {
 
     const middleBlock = (
       <div className={classnames([styles.middleBlock, styles.component])}>
-        {!classicTheme && <SvgInline svg={aboutLedgerSVG} />}
+        {!classicTheme && <AboutLedgerSVG />}
 
         <div className={styles.prerequisiteBlock}>
           <div>
-            <SvgInline svg={aboutPrerequisiteIconSVG} />
+            <AboutPrerequisiteIconSVG />
             <span className={styles.prerequisiteHeaderText}>
               {intl.formatMessage(globalMessages.hwConnectDialogAboutPrerequisiteHeader)}
             </span>
@@ -108,7 +107,7 @@ export default class CheckDialog extends Component<Props> {
                 onClick={event => onExternalLinkClick(event)}
               >
                 {intl.formatMessage(messages.aboutPrerequisite1Part1) + ' '}
-                <SvgInline svg={externalLinkSVG} />
+                <ExternalLinkSVG />
               </a>
               {intl.formatMessage(messages.aboutPrerequisite1Part2)}
               <a
@@ -116,7 +115,7 @@ export default class CheckDialog extends Component<Props> {
                 onClick={event => onExternalLinkClick(event)}
               >
                 {intl.formatMessage(messages.aboutPrerequisite1Part3) + ' '}
-                <SvgInline svg={externalLinkSVG} />
+                <ExternalLinkSVG />
               </a>
             </li>
             <li key="2">{intl.formatMessage(messages.aboutPrerequisite2)}</li>
@@ -127,7 +126,7 @@ export default class CheckDialog extends Component<Props> {
         </div>
         {classicTheme && (
           <div className={styles.hwImageBlock}>
-            <SvgInline svg={aboutPrerequisiteTrezorSVG} />
+            <AboutPrerequisiteTrezorSVG />
           </div>
         )}
       </div>);

--- a/app/components/wallet/hwConnect/ledger/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/ledger/ConnectDialog.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 
 import globalMessages from '../../../../i18n/global-messages';
 import LocalizableError from '../../../../i18n/LocalizableError';
@@ -17,9 +16,9 @@ import HelpLinkBlock from './HelpLinkBlock';
 import HWErrorBlock from '../common/HWErrorBlock';
 
 import connectLoadGIF from '../../../../assets/images/hardware-wallet/ledger/connect-load.gif';
-import connectErrorSVG from '../../../../assets/images/hardware-wallet/ledger/connect-error.inline.svg';
+import ConnectErrorSVG from '../../../../assets/images/hardware-wallet/ledger/connect-error.inline.svg';
 
-import connectErrorLedgerSVG from '../../../../assets/images/hardware-wallet/ledger/connect-error-modern.inline.svg';
+import ConnectErrorLedgerSVG from '../../../../assets/images/hardware-wallet/ledger/connect-error-modern.inline.svg';
 import connectLoadLedgerGIF from '../../../../assets/images/hardware-wallet/ledger/connect-load-modern.inline.gif';
 
 import { ProgressInfo } from '../../../../types/HWConnectStoreTypes';
@@ -115,7 +114,10 @@ export default class ConnectDialog extends Component<Props> {
         backButton = (<DialogBackButton onBack={goBack} />);
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleConnectErrorBlock])}>
-            <SvgInline svg={classicTheme ? connectErrorSVG : connectErrorLedgerSVG} />
+            {classicTheme
+              ? <ConnectErrorSVG />
+              : <ConnectErrorLedgerSVG />
+            }
           </div>);
         break;
       default:

--- a/app/components/wallet/hwConnect/ledger/HelpLinkBlock.js
+++ b/app/components/wallet/hwConnect/ledger/HelpLinkBlock.js
@@ -2,9 +2,8 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 
-import externalLinkSVG from '../../../../assets/images/link-external.inline.svg';
+import ExternalLinkSVG from '../../../../assets/images/link-external.inline.svg';
 import styles from '../common/HelpLinkBlock.scss';
 
 const messages = defineMessages({
@@ -40,7 +39,7 @@ export default class HelpLinkBlock extends Component<Props> {
           onClick={event => onExternalLinkClick(event)}
         >
           {intl.formatMessage(messages.helpLinkYoroiWithLedgerText)}
-          <SvgInline svg={externalLinkSVG} />
+          <ExternalLinkSVG />
         </a>
       </div>);
   }

--- a/app/components/wallet/hwConnect/ledger/SaveDialog.js
+++ b/app/components/wallet/hwConnect/ledger/SaveDialog.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 import { Input } from 'react-polymorph/lib/components/Input';
 import { InputOwnSkin } from '../../../../themes/skins/InputOwnSkin';
 
@@ -17,13 +16,13 @@ import ProgressStepBlock from '../common/ProgressStepBlock';
 import HelpLinkBlock from './HelpLinkBlock';
 import HWErrorBlock from '../common/HWErrorBlock';
 
-import infoIconSVG from '../../../../assets/images/info-icon.inline.svg';
+import InfoIconSVG from '../../../../assets/images/info-icon.inline.svg';
 
-import saveLoadImage from '../../../../assets/images/hardware-wallet/ledger/save-load-modern.inline.svg';
-import saveErrorImage from '../../../../assets/images/hardware-wallet/ledger/save-error-modern.inline.svg';
+import SaveLoadImage from '../../../../assets/images/hardware-wallet/ledger/save-load-modern.inline.svg';
+import SaveErrorImage from '../../../../assets/images/hardware-wallet/ledger/save-error-modern.inline.svg';
 
-import saveLoadSVG from '../../../../assets/images/hardware-wallet/ledger/save-load.inline.svg';
-import saveErrorSVG from '../../../../assets/images/hardware-wallet/ledger/save-error.inline.svg';
+import SaveLoadSVG from '../../../../assets/images/hardware-wallet/ledger/save-load.inline.svg';
+import SaveErrorSVG from '../../../../assets/images/hardware-wallet/ledger/save-error.inline.svg';
 
 import ReactToolboxMobxForm from '../../../../utils/ReactToolboxMobxForm';
 import vjf from 'mobx-react-form/lib/validators/VJF';
@@ -38,7 +37,7 @@ import styles from '../common/SaveDialog.scss';
 import headerMixin from '../../../mixins/HeaderBlock.scss';
 import config from '../../../../config';
 
-const saveStartSVG = saveLoadSVG;
+const SaveStartSVG = SaveLoadSVG;
 
 const messages = defineMessages({
   saveWalletNameInputBottomInfo: {
@@ -122,7 +121,7 @@ export default class SaveDialog extends Component<Props> {
       <div className={classnames([headerMixin.headerBlock, styles.headerSaveBlock])}>
         <div className={styles.walletNameInfoWrapper}>
           <div className={styles.walletNameInfoIcon}>
-            <SvgInline svg={infoIconSVG} width="20" height="20" />
+            <InfoIconSVG width="20" height="20" />
           </div>
           <div className={styles.walletNameInfo}>
             {intl.formatMessage(messages.saveWalletNameInputBottomInfo)}
@@ -143,19 +142,28 @@ export default class SaveDialog extends Component<Props> {
       case StepState.LOAD:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveLoadBlock])}>
-            <SvgInline svg={classicTheme ? saveLoadSVG : saveLoadImage} />
+            {classicTheme
+              ? <SaveLoadSVG />
+              : <SaveLoadImage />
+            }
           </div>);
         break;
       case StepState.PROCESS:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveStartProcessBlock])}>
-            <SvgInline svg={classicTheme ? saveStartSVG : saveLoadImage} />
+            {classicTheme
+              ? <SaveStartSVG />
+              : <SaveLoadImage />
+            }
           </div>);
         break;
       case StepState.ERROR:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveErrorBlock])}>
-            <SvgInline svg={classicTheme ? saveErrorSVG : saveErrorImage} />
+            {classicTheme
+              ? <SaveErrorSVG />
+              : <SaveErrorImage />
+            }
           </div>);
         break;
       default:

--- a/app/components/wallet/hwConnect/trezor/CheckDialog.js
+++ b/app/components/wallet/hwConnect/trezor/CheckDialog.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import { defineMessages, intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 
 import globalMessages from '../../../../i18n/global-messages';
 import LocalizableError from '../../../../i18n/LocalizableError';
@@ -16,10 +15,10 @@ import ProgressStepBlock from '../common/ProgressStepBlock';
 import HelpLinkBlock from './HelpLinkBlock';
 import HWErrorBlock from '../common/HWErrorBlock';
 
-import externalLinkSVG from '../../../../assets/images/link-external.inline.svg';
-import aboutPrerequisiteIconSVG from '../../../../assets/images/hardware-wallet/check-prerequisite-header-icon.inline.svg';
-import aboutPrerequisiteTrezorSVG from '../../../../assets/images/hardware-wallet/trezor/check.inline.svg';
-import aboutTrezorSvg from '../../../../assets/images/hardware-wallet/trezor/check-modern.inline.svg';
+import ExternalLinkSVG from '../../../../assets/images/link-external.inline.svg';
+import AboutPrerequisiteIconSVG from '../../../../assets/images/hardware-wallet/check-prerequisite-header-icon.inline.svg';
+import AboutPrerequisiteTrezorSVG from '../../../../assets/images/hardware-wallet/trezor/check.inline.svg';
+import AboutTrezorSvg from '../../../../assets/images/hardware-wallet/trezor/check-modern.inline.svg';
 
 import { ProgressInfo } from '../../../../types/HWConnectStoreTypes';
 
@@ -84,11 +83,11 @@ export default class CheckDialog extends Component<Props> {
 
     const middleBlock = (
       <div className={classnames([styles.middleBlock, styles.component])}>
-        {!classicTheme && <SvgInline svg={aboutTrezorSvg} />}
+        {!classicTheme && <AboutTrezorSvg />}
 
         <div className={styles.prerequisiteBlock}>
           <div>
-            <SvgInline svg={aboutPrerequisiteIconSVG} />
+            <AboutPrerequisiteIconSVG />
             <span className={styles.prerequisiteHeaderText}>
               {intl.formatMessage(globalMessages.hwConnectDialogAboutPrerequisiteHeader)}
             </span>
@@ -100,7 +99,7 @@ export default class CheckDialog extends Component<Props> {
                 onClick={event => onExternalLinkClick(event)}
               >
                 {intl.formatMessage(messages.aboutPrerequisite1Part1Text) + ' '}
-                <SvgInline svg={externalLinkSVG} />
+                <ExternalLinkSVG />
               </a>
               {intl.formatMessage(messages.aboutPrerequisite1Part2)}
             </li>
@@ -113,7 +112,7 @@ export default class CheckDialog extends Component<Props> {
 
         {classicTheme && (
           <div className={styles.hwImageBlock}>
-            <SvgInline svg={aboutPrerequisiteTrezorSVG} />
+            <AboutPrerequisiteTrezorSVG />
           </div>
         )}
       </div>);

--- a/app/components/wallet/hwConnect/trezor/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/trezor/ConnectDialog.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 
 import globalMessages from '../../../../i18n/global-messages';
 import LocalizableError from '../../../../i18n/LocalizableError';
@@ -17,10 +16,10 @@ import HelpLinkBlock from './HelpLinkBlock';
 import HWErrorBlock from '../common/HWErrorBlock';
 
 import connectLoadImage from '../../../../assets/images/hardware-wallet/trezor/connect-load-modern.inline.gif';
-import connectErrorImage from '../../../../assets/images/hardware-wallet/trezor/connect-error-modern.inline.svg';
+import ConnectErrorImage from '../../../../assets/images/hardware-wallet/trezor/connect-error-modern.inline.svg';
 
 import connectLoadGIF from '../../../../assets/images/hardware-wallet/trezor/connect-load.gif';
-import connectErrorSVG from '../../../../assets/images/hardware-wallet/trezor/connect-error.inline.svg';
+import ConnectErrorSVG from '../../../../assets/images/hardware-wallet/trezor/connect-error.inline.svg';
 
 import { ProgressInfo } from '../../../../types/HWConnectStoreTypes';
 import { StepState } from '../../../widgets/ProgressSteps';
@@ -114,7 +113,10 @@ export default class ConnectDialog extends Component<Props> {
         backButton = (<DialogBackButton onBack={goBack} />);
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleConnectErrorBlock])}>
-            <SvgInline svg={classicTheme ? connectErrorSVG : connectErrorImage} />
+            {classicTheme
+              ? <ConnectErrorSVG />
+              : <ConnectErrorImage />
+            }
           </div>);
         break;
       default:

--- a/app/components/wallet/hwConnect/trezor/HelpLinkBlock.js
+++ b/app/components/wallet/hwConnect/trezor/HelpLinkBlock.js
@@ -2,9 +2,8 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 
-import externalLinkSVG from '../../../../assets/images/link-external.inline.svg';
+import ExternalLinkSVG from '../../../../assets/images/link-external.inline.svg';
 import styles from '../common/HelpLinkBlock.scss';
 
 const messages = defineMessages({
@@ -40,7 +39,7 @@ export default class HelpLinkBlock extends Component<Props> {
           onClick={event => onExternalLinkClick(event)}
         >
           {intl.formatMessage(messages.helpLinkYoroiWithTrezorText)}
-          <SvgInline svg={externalLinkSVG} />
+          <ExternalLinkSVG />
         </a>
       </div>);
   }

--- a/app/components/wallet/hwConnect/trezor/SaveDialog.js
+++ b/app/components/wallet/hwConnect/trezor/SaveDialog.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 import { Input } from 'react-polymorph/lib/components/Input';
 import { InputOwnSkin } from '../../../../themes/skins/InputOwnSkin';
 
@@ -17,13 +16,13 @@ import ProgressStepBlock from '../common/ProgressStepBlock';
 import HelpLinkBlock from './HelpLinkBlock';
 import HWErrorBlock from '../common/HWErrorBlock';
 
-import infoIconSVG from '../../../../assets/images/info-icon.inline.svg';
+import InfoIconSVG from '../../../../assets/images/info-icon.inline.svg';
 
-import saveLoadImage from '../../../../assets/images/hardware-wallet/trezor/save-load-modern.inline.svg';
-import saveErrorImage from '../../../../assets/images/hardware-wallet/trezor/save-error-modern.inline.svg';
+import SaveLoadImage from '../../../../assets/images/hardware-wallet/trezor/save-load-modern.inline.svg';
+import SaveErrorImage from '../../../../assets/images/hardware-wallet/trezor/save-error-modern.inline.svg';
 
-import saveLoadSVG from '../../../../assets/images/hardware-wallet/trezor/save-load.inline.svg';
-import saveErrorSVG from '../../../../assets/images/hardware-wallet/trezor/save-error.inline.svg';
+import SaveLoadSVG from '../../../../assets/images/hardware-wallet/trezor/save-load.inline.svg';
+import SaveErrorSVG from '../../../../assets/images/hardware-wallet/trezor/save-error.inline.svg';
 
 import ReactToolboxMobxForm from '../../../../utils/ReactToolboxMobxForm';
 import vjf from 'mobx-react-form/lib/validators/VJF';
@@ -38,7 +37,7 @@ import styles from '../common/SaveDialog.scss';
 import headerMixin from '../../../mixins/HeaderBlock.scss';
 import config from '../../../../config';
 
-const saveStartSVG = saveLoadSVG;
+const SaveStartSVG = SaveLoadSVG;
 
 const messages = defineMessages({
   saveWalletNameInputBottomInfo: {
@@ -121,7 +120,7 @@ export default class SaveDialog extends Component<Props> {
       <div className={classnames([headerMixin.headerBlock, styles.headerSaveBlock])}>
         <div className={styles.walletNameInfoWrapper}>
           <div className={styles.walletNameInfoIcon}>
-            <SvgInline svg={infoIconSVG} width="20" height="20" />
+            <InfoIconSVG width="20" height="20" />
           </div>
           <div className={styles.walletNameInfo}>
             {intl.formatMessage(messages.saveWalletNameInputBottomInfo)}
@@ -142,19 +141,28 @@ export default class SaveDialog extends Component<Props> {
       case StepState.LOAD:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveLoadBlock])}>
-            <SvgInline svg={classicTheme ? saveLoadSVG : saveLoadImage} />
+            {classicTheme
+              ? <SaveLoadSVG />
+              : <SaveLoadImage />
+            }
           </div>);
         break;
       case StepState.PROCESS:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveStartProcessBlock])}>
-            <SvgInline svg={classicTheme ? saveStartSVG : saveLoadImage} />
+            {classicTheme
+              ? <SaveStartSVG />
+              : <SaveLoadImage />
+            }
           </div>);
         break;
       case StepState.ERROR:
         middleBlock = (
           <div className={classnames([styles.middleBlock, styles.middleSaveErrorBlock])}>
-            <SvgInline svg={classicTheme ? saveErrorSVG : saveErrorImage} />
+            {classicTheme
+              ? <SaveErrorSVG />
+              : <SaveErrorImage />
+            }
           </div>);
         break;
       default:

--- a/app/components/wallet/summary/WalletSummary.js
+++ b/app/components/wallet/summary/WalletSummary.js
@@ -2,9 +2,8 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
-import adaSymbolSmallest from '../../../assets/images/ada-symbol-smallest-dark.inline.svg';
-import exportTxToFileSvg from '../../../assets/images/transaction/export-tx-to-file.inline.svg';
+import AdaSymbolSmallest from '../../../assets/images/ada-symbol-smallest-dark.inline.svg';
+import ExportTxToFileSvg from '../../../assets/images/transaction/export-tx-to-file.inline.svg';
 import BorderedBox from '../../widgets/BorderedBox';
 import { DECIMAL_PLACES_IN_ADA } from '../../../config/numbersConfig';
 import type { UnconfirmedAmount } from '../../../types/unconfirmedAmountType';
@@ -61,14 +60,18 @@ export default class WalletSummary extends Component<Props> {
               <div className={styles.pendingConfirmation}>
                 {`${intl.formatMessage(messages.pendingIncomingConfirmationLabel)}`}
                 : <span>{pendingAmount.incoming.toFormat(DECIMAL_PLACES_IN_ADA)}</span>
-                <SvgInline svg={adaSymbolSmallest} className={styles.currencySymbolSmallest} />
+                <span className={styles.currencySymbolSmallest}>
+                  <AdaSymbolSmallest />
+                </span>
               </div>
             }
             {pendingAmount.outgoing.isGreaterThan(0) &&
               <div className={styles.pendingConfirmation}>
                 {`${intl.formatMessage(messages.pendingOutgoingConfirmationLabel)}`}
                 : <span>{pendingAmount.outgoing.toFormat(DECIMAL_PLACES_IN_ADA)}</span>
-                <SvgInline svg={adaSymbolSmallest} className={styles.currencySymbolSmallest} />
+                <span className={styles.currencySymbolSmallest}>
+                  <AdaSymbolSmallest />
+                </span>
               </div>
             }
             {!isLoadingTransactions ? (
@@ -80,13 +83,16 @@ export default class WalletSummary extends Component<Props> {
         </div>
         <div className={styles.rightBlock}>
           {!isLoadingTransactions ? (
-            <SvgInline
-              svg={exportTxToFileSvg}
-
+            <span
               className={styles.exportTxToFileSvg}
               title={intl.formatMessage(messages.exportIconTooltip)}
               onClick={openExportTxToFileDialog}
-            />
+              onKeyPress={openExportTxToFileDialog}
+              role="button"
+              tabIndex="0"
+            >
+              <ExportTxToFileSvg />
+            </span>
           ) : null}
         </div>
       </div>

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -4,11 +4,10 @@ import BigNumber from 'bignumber.js';
 import { defineMessages, intlShape } from 'react-intl';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import moment from 'moment';
-import SvgInline from 'react-svg-inline';
 import classNames from 'classnames';
 import { uniq } from 'lodash';
 import styles from './Transaction.scss';
-import adaSymbol from '../../../assets/images/ada-symbol.inline.svg';
+import AdaSymbol from '../../../assets/images/ada-symbol.inline.svg';
 import WalletTransaction from '../../../domain/WalletTransaction';
 import { environmentSpecificMessages } from '../../../i18n/global-messages';
 import type { TransactionDirectionType, } from '../../../api/ada/transactions/types';
@@ -16,7 +15,7 @@ import { transactionTypes } from '../../../api/ada/transactions/types';
 import type { AssuranceLevel } from '../../../types/transactionAssuranceTypes';
 import environment from '../../../environment';
 import { Logger } from '../../../utils/logging';
-import expandArrow from '../../../assets/images/expand-arrow.inline.svg';
+import ExpandArrow from '../../../assets/images/expand-arrow.inline.svg';
 import RawHash from '../../widgets/hashWrappers/RawHash';
 import ExplorableHashContainer from '../../../containers/widgets/ExplorableHashContainer';
 import type { ExplorerType } from '../../../domain/Explorer';
@@ -236,7 +235,6 @@ export default class Transaction extends Component<Props, State> {
     const status = this.getStatusString(intl, state, assuranceLevel);
 
     const currency = intl.formatMessage(environmentSpecificMessages[environment.API].currency);
-    const symbol = adaSymbol;
 
     return (
       <div className={componentStyles}>
@@ -264,11 +262,11 @@ export default class Transaction extends Component<Props, State> {
                   // hide currency (we are showing symbol instead)
                   formattedWalletAmount(data.amount, false)
                 }
-                <SvgInline svg={symbol} className={styles.currencySymbol} />
+                <span className={styles.currencySymbol}><AdaSymbol /></span>
               </div>
 
               <div className={styles.expandArrowBox}>
-                <SvgInline className={arrowClasses} svg={expandArrow} />
+                <span className={arrowClasses}><ExpandArrow /></span>
               </div>
             </div>
           </div>

--- a/app/components/wallet/transactions/TransactionTypeIcon.js
+++ b/app/components/wallet/transactions/TransactionTypeIcon.js
@@ -1,11 +1,10 @@
 // @flow
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import SvgInline from 'react-svg-inline';
-import expendIcon from '../../../assets/images/transaction/send-ic.inline.svg';
-import incomeIcon from '../../../assets/images/transaction/receive-ic.inline.svg';
-import exchangeIcon from '../../../assets/images/exchange-ic.inline.svg';
-import failedIcon from '../../../assets/images/transaction/deny-ic.inline.svg';
+import ExpendIcon from '../../../assets/images/transaction/send-ic.inline.svg';
+import IncomeIcon from '../../../assets/images/transaction/receive-ic.inline.svg';
+import ExchangeIcon from '../../../assets/images/exchange-ic.inline.svg';
+import FailedIcon from '../../../assets/images/transaction/deny-ic.inline.svg';
 import styles from './TransactionTypeIcon.scss';
 
 type Props = {|
@@ -22,28 +21,28 @@ export default class TransactionTypeIcon extends Component<Props> {
       styles[iconType],
     ]);
 
-    let icon;
+    let Icon;
     switch (iconType) {
       case 'expend':
-        icon = expendIcon;
+        Icon = ExpendIcon;
         break;
       case 'income':
-        icon = incomeIcon;
+        Icon = IncomeIcon;
         break;
       case 'exchange':
-        icon = exchangeIcon;
+        Icon = ExchangeIcon;
         break;
       case 'failed':
-        icon = failedIcon;
+        Icon = FailedIcon;
         break;
       default:
-        icon = '';
+        Icon = '';
         break;
     }
 
     return (
       <div className={transactionTypeIconClasses}>
-        <SvgInline svg={icon} className={styles.transactionTypeIcon} />
+        <span className={styles.transactionTypeIcon}><Icon /></span>
       </div>
     );
   }

--- a/app/components/wallet/transactions/WalletNoTransactions.js
+++ b/app/components/wallet/transactions/WalletNoTransactions.js
@@ -1,10 +1,9 @@
 // @flow
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
-import SvgInline from 'react-svg-inline';
 import styles from './WalletNoTransactions.scss';
-import noTransactionClassicSvg from '../../../assets/images/transaction/no-transactions-yet.classic.inline.svg';
-import noTransactionModernSvg from '../../../assets/images/transaction/no-transactions-yet.modern.inline.svg';
+import NoTransactionClassicSvg from '../../../assets/images/transaction/no-transactions-yet.classic.inline.svg';
+import NoTransactionModernSvg from '../../../assets/images/transaction/no-transactions-yet.modern.inline.svg';
 
 type Props = {|
   +label: string,
@@ -16,10 +15,10 @@ export default class WalletNoTransactions extends Component<Props> {
 
   render() {
     const { classicTheme } = this.props;
-    const noTransactionSvg = classicTheme ? noTransactionClassicSvg : noTransactionModernSvg;
+    const NoTransactionSvg = classicTheme ? NoTransactionClassicSvg : NoTransactionModernSvg;
     return (
       <div className={styles.component}>
-        <SvgInline className={styles.imageWrappper} svg={noTransactionSvg} />
+        <span className={styles.imageWrappper}><NoTransactionSvg /></span>
         <div className={styles.label}>{this.props.label}</div>
       </div>
     );

--- a/app/components/widgets/CopyableAddress.js
+++ b/app/components/widgets/CopyableAddress.js
@@ -3,10 +3,9 @@ import { observer } from 'mobx-react';
 import React, { Component } from 'react';
 import { defineMessages, intlShape } from 'react-intl';
 import type { Node } from 'react';
-import SvgInline from 'react-svg-inline';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import iconCopy from '../../assets/images/copy.inline.svg';
-import iconCopied from '../../assets/images/copied.inline.svg';
+import IconCopy from '../../assets/images/copy.inline.svg';
+import IconCopied from '../../assets/images/copied.inline.svg';
 import styles from './CopyableAddress.scss';
 import { Tooltip } from 'react-polymorph/lib/components/Tooltip';
 import { TooltipSkin } from 'react-polymorph/lib/skins/simple/TooltipSkin';
@@ -46,6 +45,9 @@ export default class CopyableAddress extends Component<Props> {
     const { hash, elementId, onCopyAddress, notification } = this.props;
     const { intl } = this.context;
 
+    const Icon = notification && notification.id === elementId
+      ? IconCopied
+      : IconCopy;
     const tooltipComponent = (
       <Tooltip
         className={styles.SimpleTooltip}
@@ -57,10 +59,8 @@ export default class CopyableAddress extends Component<Props> {
           : intl.formatMessage(messages.copyTooltipMessage)
         }
       >
-        <SvgInline
-          svg={notification && notification.id === elementId ? iconCopied : iconCopy}
-          className={styles.copyIconBig}
-        />
+
+        <span className={styles.copyIconBig}><Icon /></span>
       </Tooltip>
     );
 

--- a/app/components/widgets/CustomTooltip.js
+++ b/app/components/widgets/CustomTooltip.js
@@ -4,11 +4,10 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import type { MessageDescriptor } from 'react-intl';
 import { intlShape, FormattedHTMLMessage } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import { Tooltip } from 'react-polymorph/lib/components/Tooltip';
 import { TooltipSkin } from 'react-polymorph/lib/skins/simple/TooltipSkin';
 
-import infoIcon from '../../assets/images/info-icon.inline.svg';
+import InfoIcon from '../../assets/images/info-icon.inline.svg';
 import styles from './CustomTooltip.scss';
 
 type Props = {|
@@ -41,12 +40,9 @@ export default class CustomTooltip extends Component<Props> {
 
   makeDefaultChild = (): Node => {
     return (
-      <SvgInline
-        svg={infoIcon}
-        width="14"
-        height="14"
-        className={styles.infoIcon}
-      />
+      <span className={styles.infoIcon}>
+        <InfoIcon width="14" height="14" />
+      </span>
     );
   }
 }

--- a/app/components/widgets/DialogBackButton.js
+++ b/app/components/widgets/DialogBackButton.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import SvgInline from 'react-svg-inline';
-import backArrow from '../../assets/images/back-arrow-ic.inline.svg';
+import BackArrow from '../../assets/images/back-arrow-ic.inline.svg';
 import styles from './DialogBackButton.scss';
 
 type Props = {|
@@ -14,7 +13,7 @@ export default class DialogBackButton extends Component<Props> {
     const { onBack } = this.props;
     return (
       <button tabIndex="-1" type="button" onClick={onBack} className={styles.component}>
-        <SvgInline svg={backArrow} />
+        <BackArrow />
       </button>
     );
   }

--- a/app/components/widgets/DialogCloseButton.js
+++ b/app/components/widgets/DialogCloseButton.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import SvgInline from 'react-svg-inline';
-import closeCross from '../../assets/images/close-cross.inline.svg';
+import CloseCross from '../../assets/images/close-cross.inline.svg';
 import styles from './DialogCloseButton.scss';
 
 type Props = {|
@@ -17,9 +16,12 @@ export default class DialogCloseButton extends Component<Props> {
 
   render() {
     const { onClose, icon } = this.props;
+    const Svg = (icon != null && icon !== '')
+      ? icon
+      : CloseCross;
     return (
       <button tabIndex="-1" type="button" onClick={onClose} className={styles.component}>
-        <SvgInline svg={(icon != null && icon !== '') ? icon : closeCross} />
+        <Svg />
       </button>
     );
   }

--- a/app/components/widgets/FlagLabel.js
+++ b/app/components/widgets/FlagLabel.js
@@ -1,28 +1,21 @@
 // @flow
 import React, { Component } from 'react';
 import styles from './FlagLabel.scss';
-import SvgInline from 'react-svg-inline';
 
 type Props = {|
   +svg: string,
   +label: string,
-  +width?: string,
-  +height?: string
 |};
 
 export default class FlagLabel extends Component<Props> {
 
-  static defaultProps = {
-    width: '18px',
-    height: '18px'
-  };
-
   render() {
-    const { svg, label, width, height } = this.props;
+    const { svg, label, } = this.props;
+    const SvgElem = svg;
     return (
 
       <div className={styles.wrapper}>
-        <SvgInline svg={svg} className={styles.flag} width={width} height={height} />
+        <span className={styles.flag}><SvgElem /></span>
         <span>{label}</span>
       </div>
     );

--- a/app/components/widgets/LinkButton.js
+++ b/app/components/widgets/LinkButton.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
 import type { MessageDescriptor } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import { intlShape } from 'react-intl';
 import styles from './LinkButton.scss';
 
@@ -34,6 +33,7 @@ export default class LinkButton extends Component<Props> {
       onExternalLinkClick
     } = this.props;
 
+    const SvgElem = svg;
     return (
       <div className={styles.component}>
         <a
@@ -43,7 +43,7 @@ export default class LinkButton extends Component<Props> {
           title={intl.formatMessage(message)}
         >
           <div className={styles.icon}>
-            <SvgInline svg={svg} className={svgClass} />
+            <span className={svgClass}><SvgElem /></span>
           </div>
           <div className={styles.text}>
             <span className={textClassName}>

--- a/app/components/widgets/NotificationMessage.js
+++ b/app/components/widgets/NotificationMessage.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
 import type { Node } from 'react';
-import SvgInline from 'react-svg-inline';
 import classNames from 'classnames';
 import styles from './NotificationMessage.scss';
 
@@ -24,10 +23,11 @@ export default class NotificationMessage extends Component<Props> {
       show ? styles.show : null,
     ]);
 
+    const SvgElem = icon;
     return (
       <div className={notificationMessageStyles}>
 
-        {icon && <SvgInline svg={icon} className={styles.icon} />}
+        {icon && <span className={styles.icon}><SvgElem /></span>}
 
         <div className={styles.message}>
           {children}

--- a/app/components/widgets/ProgressSteps.js
+++ b/app/components/widgets/ProgressSteps.js
@@ -3,12 +3,11 @@ import React, { Component } from 'react';
 import type { Element } from 'react';
 import { observer } from 'mobx-react';
 import classNames from 'classnames';
-import SvgInline from 'react-svg-inline';
 
-import iconTickSVG from '../../assets/images/widget/tick.inline.svg';
-import iconTickGreenSVG from '../../assets/images/widget/tick-green.inline.svg';
-import iconCrossSVG from '../../assets/images/widget/cross.inline.svg';
-import iconCrossGreenSVG from '../../assets/images/widget/cross-green.inline.svg';
+import IconTickSVG from '../../assets/images/widget/tick.inline.svg';
+import IconTickGreenSVG from '../../assets/images/widget/tick-green.inline.svg';
+import IconCrossSVG from '../../assets/images/widget/cross.inline.svg';
+import IconCrossGreenSVG from '../../assets/images/widget/cross-green.inline.svg';
 import styles from './ProgressSteps.scss';
 
 // TODO: move to type folder?
@@ -66,13 +65,19 @@ export default class ProgressSteps extends Component<Props> {
         ]);
       }
 
+      const DoneIcon = classicTheme
+        ? IconTickSVG
+        : IconTickGreenSVG;
+      const ErrorIcon = classicTheme
+        ? IconCrossSVG
+        : IconCrossGreenSVG;
       steps.push(
         <div key={idx} className={styles.stepBlock}>
           <div className={stepTopBarStyle} />
           <div className={styles.stepBottomBlock}>
             <div className={styles.stepStateIconContainer}>
-              {(displayIcon === 'done') && <SvgInline svg={classicTheme ? iconTickSVG : iconTickGreenSVG} />}
-              {(displayIcon === 'error') && <SvgInline svg={classicTheme ? iconCrossSVG : iconCrossGreenSVG} />}
+              {(displayIcon === 'done') && <DoneIcon />}
+              {(displayIcon === 'error') && <ErrorIcon />}
             </div>
             <div className={styles.stepTextContainer}>
               <span className={stepTextStyle}>{stepText}</span>

--- a/app/components/widgets/forms/ReadOnlyInput.js
+++ b/app/components/widgets/forms/ReadOnlyInput.js
@@ -3,11 +3,10 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import { intlShape } from 'react-intl';
-import SvgInline from 'react-svg-inline';
 import { Input } from 'react-polymorph/lib/components/Input';
 import globalMessages from '../../../i18n/global-messages';
 import { InputOwnSkin } from '../../../themes/skins/InputOwnSkin';
-import editSvg from '../../../assets/images/edit.inline.svg';
+import EditSvg from '../../../assets/images/edit.inline.svg';
 import styles from './ReadOnlyInput.scss';
 
 type Props = {|
@@ -58,7 +57,7 @@ export default class ReadOnlyInput extends Component<Props> {
           className={styles.button}
           onClick={onClick}
         >
-          {classicTheme ? buttonLabel : <SvgInline svg={editSvg} className={styles.icon} />}
+          {classicTheme ? buttonLabel : <span className={styles.icon}><EditSvg /></span>}
         </button>
 
       </div>

--- a/app/i18n/translations.js
+++ b/app/i18n/translations.js
@@ -1,6 +1,17 @@
 // @flow
 import globalMessages from './global-messages';
 
+import EnglishFlag from '../assets/images/flags/english.inline.svg';
+import JapaneseFlag from '../assets/images/flags/japanese.inline.svg';
+import KoreanFlag from '../assets/images/flags/korean.inline.svg';
+import Chinese from '../assets/images/flags/chinese.inline.svg';
+import RussianFlag from '../assets/images/flags/russian.inline.svg';
+import GermanFlag from '../assets/images/flags/german.inline.svg';
+import FrenchFlag from '../assets/images/flags/french.inline.svg';
+import SpanishFlag from '../assets/images/flags/spanish.inline.svg';
+import ItalianFlag from '../assets/images/flags/italian.inline.svg';
+import IdonesianFlag from '../assets/images/flags/indonesian.inline.svg';
+
 // This is essentially bulk require
 
 // $FlowFixMe require.context comes from webpack
@@ -16,56 +27,56 @@ export const LANGUAGES = [
   {
     value: 'en-US',
     label: globalMessages.languageEnglish,
-    svg: require('../assets/images/flags/english.inline.svg')
+    svg: EnglishFlag
   },
   {
     value: 'ja-JP',
     label: globalMessages.languageJapanese,
-    svg: require('../assets/images/flags/japanese.inline.svg')
+    svg: JapaneseFlag
   },
   {
     value: 'ko-KR',
     label: globalMessages.languageKorean,
-    svg: require('../assets/images/flags/korean.inline.svg')
+    svg: KoreanFlag
   },
   {
     value: 'zh-Hans',
     label: globalMessages.languageChineseSimplified,
-    svg: require('../assets/images/flags/chinese.inline.svg')
+    svg: Chinese
   },
   {
     value: 'zh-Hant',
     label: globalMessages.languageChineseTraditional,
-    svg: require('../assets/images/flags/chinese.inline.svg')
+    svg: Chinese
   },
   {
     value: 'ru-RU',
     label: globalMessages.languageRussian,
-    svg: require('../assets/images/flags/russian.inline.svg')
+    svg: RussianFlag
   },
   {
     value: 'de-DE',
     label: globalMessages.languageGerman,
-    svg: require('../assets/images/flags/german.inline.svg')
+    svg: GermanFlag
   },
   {
     value: 'fr-FR',
     label: globalMessages.languageFrench,
-    svg: require('../assets/images/flags/french.inline.svg')
+    svg: FrenchFlag
   },
   {
     value: 'es-ES',
     label: globalMessages.languageSpanish,
-    svg: require('../assets/images/flags/spanish.inline.svg')
+    svg: SpanishFlag
   },
   {
     value: 'it-IT',
     label: globalMessages.languageItalian,
-    svg: require('../assets/images/flags/italian.inline.svg')
+    svg: ItalianFlag
   },
   {
     value: 'id-ID',
     label: globalMessages.languageIndonesian,
-    svg: require('../assets/images/flags/indonesian.inline.svg')
+    svg: IdonesianFlag
   },
 ];

--- a/app/themes/skins/FormFieldOwnSkin.js
+++ b/app/themes/skins/FormFieldOwnSkin.js
@@ -3,7 +3,6 @@ import React from 'react';
 import type { Element } from 'react';
 import { omit } from 'lodash';
 import classnames from 'classnames';
-import SvgInline from 'react-svg-inline';
 import ErrorSvg from '../../assets/images/input/exclamationmark.inline.svg';
 import PasswordSvg from '../../assets/images/input/password.watch.inline.svg';
 import PasswordHiddenSvg from '../../assets/images/input/password.hiden.inline.svg';
@@ -71,13 +70,13 @@ export const FormFieldOwnSkin = class extends React.Component<Props, State> {
         >
 
           <div className={styles.iconsWrapper}>
-            {this.props.done === true && <SvgInline svg={SuccessSvg} />}
-            {(this.props.error != null && this.props.error !== '') && <SvgInline svg={ErrorSvg} />}
+            {this.props.done === true && <SuccessSvg />}
+            {(this.props.error != null && this.props.error !== '') && <ErrorSvg />}
             {(this.props.type === 'password') ? (
               <button tabIndex="-1" type="button" onClick={this.showPassword}>
                 {isPasswordShown
-                  ? <SvgInline svg={PasswordSvg} />
-                  : <SvgInline svg={PasswordHiddenSvg} />}
+                  ? <PasswordSvg />
+                  : <PasswordHiddenSvg />}
               </button>
             ) : null}
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
@@ -17,7 +16,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
       "integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "@babel/generator": "^7.7.2",
@@ -39,7 +37,6 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
@@ -48,7 +45,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
           "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
@@ -60,7 +56,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -71,7 +66,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -80,7 +74,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -88,14 +81,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -106,7 +97,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
           "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.7.2",
@@ -123,7 +113,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -134,7 +123,6 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
           "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
           }
@@ -143,7 +131,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -152,7 +139,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -160,8 +146,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -182,7 +167,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
       "integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.7.0"
       },
@@ -191,7 +175,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -204,7 +187,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.0.tgz",
       "integrity": "sha512-Cd8r8zs4RKDwMG/92lpZcnn5WPQ3LAMQbCw42oqUh4s7vsSN5ANUZjMel0OOnxDLq57hoDDbai+ryygYfCTOsw==",
-      "dev": true,
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.7.0",
         "@babel/types": "^7.7.0"
@@ -214,7 +196,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -227,7 +208,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.0.tgz",
       "integrity": "sha512-LSln3cexwInTMYYoFeVLKnYPPMfWNJ8PubTBs3hkh7wCu9iBaqq1OOyW+xGmEdLxT1nhsl+9SJ+h2oUDYz0l2A==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.7.0",
         "esutils": "^2.0.0"
@@ -237,7 +217,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -250,7 +229,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.0.tgz",
       "integrity": "sha512-Su0Mdq7uSSWGZayGMMQ+z6lnL00mMCnGAbO/R0ZO9odIdB/WNU/VfQKqMQU0fdIsxQYbRjDM4BixIa93SQIpvw==",
-      "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.7.0",
         "@babel/traverse": "^7.7.0",
@@ -261,7 +239,6 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
@@ -270,7 +247,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
           "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
@@ -282,7 +258,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -293,7 +268,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -302,7 +276,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -310,14 +283,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -328,7 +299,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
           "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.7.2",
@@ -345,7 +315,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -356,7 +325,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -440,7 +408,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.2.tgz",
       "integrity": "sha512-pAil/ZixjTlrzNpjx+l/C/wJk002Wo7XbbZ8oujH/AoJ3Juv0iN/UTcPUHXKMFLqsfS0Hy6Aow8M31brUYBlQQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-regex": "^7.4.4",
         "regexpu-core": "^4.6.0"
@@ -450,7 +417,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.0.tgz",
       "integrity": "sha512-kPKWPb0dMpZi+ov1hJiwse9dWweZsz3V9rP4KdytnX1E7z3cTNmFGglwklzFPuqIcHLIY3bgKSs4vkwXXdflQA==",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.7.0",
         "@babel/types": "^7.7.0",
@@ -461,7 +427,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -472,7 +437,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -480,14 +444,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -498,7 +460,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -511,7 +472,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.0.tgz",
       "integrity": "sha512-CDs26w2shdD1urNUAji2RJXyBFCaR+iBEGnFz3l7maizMkQe3saVw9WtjG1tz8CwbjvlFnaSLVhgnu1SWaherg==",
-      "dev": true,
       "requires": {
         "@babel/traverse": "^7.7.0",
         "@babel/types": "^7.7.0"
@@ -521,7 +481,6 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
@@ -530,7 +489,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
           "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
@@ -542,7 +500,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -553,7 +510,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -562,7 +518,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -570,14 +525,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -588,7 +541,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
           "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.7.2",
@@ -605,7 +557,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -616,7 +567,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -638,7 +588,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -647,7 +596,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.0.tgz",
       "integrity": "sha512-LUe/92NqsDAkJjjCEWkNe+/PcpnisvnqdlRe19FahVapa4jndeuJ+FBiTX1rcAKWKcJGE+C3Q3tuEuxkSmCEiQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.7.0"
       },
@@ -656,7 +604,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -669,7 +616,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.0.tgz",
       "integrity": "sha512-QaCZLO2RtBcmvO/ekOLp8p7R5X2JriKRizeDpm5ChATAFWrrYDcDxPuCIBXKyBjY+i1vYSdcUTMIb8psfxHDPA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.7.0"
       },
@@ -678,7 +624,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -700,7 +645,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz",
       "integrity": "sha512-rXEefBuheUYQyX4WjV19tuknrJFwyKw0HgzRwbkyTbB+Dshlq7eqkWbyjzToLrMZk/5wKVKdWFluiAsVkHXvuQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.0",
         "@babel/helper-simple-access": "^7.7.0",
@@ -714,7 +658,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
           "integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -723,7 +666,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -731,14 +673,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -749,7 +689,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -762,7 +701,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.0.tgz",
       "integrity": "sha512-48TeqmbazjNU/65niiiJIJRc5JozB8acui1OS7bSd6PgxfuovWsvjfWSzlgx+gPFdVveNzUdpdIg5l56Pl5jqg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.7.0"
       },
@@ -771,7 +709,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -783,14 +720,12 @@
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
-      "dev": true
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
     },
     "@babel/helper-regex": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
       "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.13"
       }
@@ -799,7 +734,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.0.tgz",
       "integrity": "sha512-pHx7RN8X0UNHPB/fnuDnRXVZ316ZigkO8y8D835JlZ2SSdFKb6yH9MIYRU4fy/KPe5sPHDFOPvf8QLdbAGGiyw==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.7.0",
         "@babel/helper-wrap-function": "^7.7.0",
@@ -812,7 +746,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
           "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
@@ -824,7 +757,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -835,7 +767,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -844,7 +775,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -852,14 +782,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -870,7 +798,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
           "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.7.2",
@@ -887,7 +814,6 @@
               "version": "7.5.5",
               "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
               "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-              "dev": true,
               "requires": {
                 "@babel/highlight": "^7.0.0"
               }
@@ -898,7 +824,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -909,7 +834,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -920,7 +844,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.0.tgz",
       "integrity": "sha512-5ALYEul5V8xNdxEeWvRsBzLMxQksT7MaStpxjJf9KsnLxpAKBtfw5NeMKZJSYDa0lKdOcy0g+JT/f5mPSulUgg==",
-      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.7.0",
         "@babel/helper-optimise-call-expression": "^7.7.0",
@@ -932,7 +855,6 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
@@ -941,7 +863,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
           "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
@@ -953,7 +874,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -964,7 +884,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -973,7 +892,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -981,14 +899,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -999,7 +915,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
           "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.7.2",
@@ -1016,7 +931,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1027,7 +941,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1038,7 +951,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.0.tgz",
       "integrity": "sha512-AJ7IZD7Eem3zZRuj5JtzFAptBw7pMlS3y8Qv09vaBWoFsle0d1kAn5Wq6Q9MyBXITPOKnxwkZKoAm4bopmv26g==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.7.0",
         "@babel/types": "^7.7.0"
@@ -1047,14 +959,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -1065,7 +975,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1087,7 +996,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz",
       "integrity": "sha512-sd4QjeMgQqzshSjecZjOp8uKfUtnpmCyQhKQrVJBBgeHAB/0FPi33h3AbVlVp07qQtMD4QgYSzaMI7VwncNK/w==",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.7.0",
         "@babel/template": "^7.7.0",
@@ -1099,7 +1007,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
           "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
@@ -1111,7 +1018,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -1122,7 +1028,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -1131,7 +1036,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -1139,14 +1043,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -1157,7 +1059,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
           "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.7.2",
@@ -1174,7 +1075,6 @@
               "version": "7.5.5",
               "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
               "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-              "dev": true,
               "requires": {
                 "@babel/highlight": "^7.0.0"
               }
@@ -1185,7 +1085,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1196,7 +1095,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1207,7 +1105,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
       "integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.7.0",
         "@babel/traverse": "^7.7.0",
@@ -1218,7 +1115,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
           "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
@@ -1230,7 +1126,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -1241,7 +1136,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -1250,7 +1144,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -1258,14 +1151,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -1276,7 +1167,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
           "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.7.2",
@@ -1293,7 +1183,6 @@
               "version": "7.5.5",
               "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
               "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-              "dev": true,
               "requires": {
                 "@babel/highlight": "^7.0.0"
               }
@@ -1304,7 +1193,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1315,7 +1203,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1326,7 +1213,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -1372,7 +1258,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.0.tgz",
       "integrity": "sha512-ot/EZVvf3mXtZq0Pd0+tSOfGWMizqmOohXmNZg6LNFjHOV+wOPv7BvVYh8oPR8LhpIP3ye8nNooKL50YRWxpYA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.7.0",
@@ -1404,7 +1289,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.0.tgz",
       "integrity": "sha512-7poL3Xi+QFPC7sGAzEIbXUyYzGJwbc2+gSD0AkiC5k52kH2cqHdqxm5hNFfLW3cRSTcx9bN0Fl7/6zWcLLnKAQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-dynamic-import": "^7.2.0"
@@ -1434,7 +1318,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
       "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0"
@@ -1444,7 +1327,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
       "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -1454,7 +1336,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
@@ -1464,7 +1345,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.0.tgz",
       "integrity": "sha512-mk34H+hp7kRBWJOOAR0ZMGCydgKMD4iN9TpDRp3IIcbunltxEY89XSimc6WbtSLCDrwcdy/EEw7h5CFCzxTchw==",
-      "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -1474,7 +1354,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1492,7 +1371,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1528,7 +1406,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
       "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1537,7 +1414,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
       "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1546,7 +1422,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1555,7 +1430,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1564,7 +1438,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.0.tgz",
       "integrity": "sha512-hi8FUNiFIY1fnUI2n1ViB1DR0R4QeK4iHcTlW6aJkrPoTdb8Rf1EMQ6GT3f67DDkYyWgew9DFoOZ6gOoEsdzTA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1582,7 +1455,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
       "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1591,7 +1463,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.0.tgz",
       "integrity": "sha512-vLI2EFLVvRBL3d8roAMqtVY0Bm9C1QzLkdS57hiKrjUBSqsQYrBsMCeOg/0KK7B0eK9V71J5mWcha9yyoI2tZw==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1602,7 +1473,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
           "integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -1611,7 +1481,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1624,7 +1493,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
       "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1633,7 +1501,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
       "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "lodash": "^4.17.13"
@@ -1643,7 +1510,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.0.tgz",
       "integrity": "sha512-/b3cKIZwGeUesZheU9jNYcwrEA7f/Bo4IdPmvp7oHgvks2majB5BoT5byAql44fiNQYOPzhk2w8DbgfuafkMoA==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.7.0",
         "@babel/helper-define-map": "^7.7.0",
@@ -1659,7 +1525,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -1670,7 +1535,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -1679,7 +1543,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
           "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -1687,14 +1550,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -1705,7 +1566,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1718,7 +1578,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
       "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1727,7 +1586,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
       "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1736,7 +1594,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.0.tgz",
       "integrity": "sha512-3QQlF7hSBnSuM1hQ0pS3pmAbWLax/uGNCbPBND9y+oJ4Y776jsyujG2k0Sn2Aj2a0QwVOiOFL5QVPA7spjvzSA==",
-      "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -1746,7 +1603,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
       "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1755,7 +1611,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
       "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
-      "dev": true,
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -1775,7 +1630,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
       "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1784,7 +1638,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.0.tgz",
       "integrity": "sha512-P5HKu0d9+CzZxP5jcrWdpe7ZlFDe24bmqP6a6X8BHEBl/eizAsY8K6LX8LASZL0Jxdjm5eEfzp+FIrxCm/p8bA==",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -1794,7 +1647,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
           "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.7.0",
             "@babel/template": "^7.7.0",
@@ -1805,7 +1657,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
           "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -1813,14 +1664,12 @@
         "@babel/parser": {
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
-          "dev": true
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w=="
         },
         "@babel/template": {
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
           "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.7.0",
@@ -1831,7 +1680,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1844,7 +1692,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
       "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1853,7 +1700,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
       "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1862,7 +1708,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
       "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1873,7 +1718,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.0.tgz",
       "integrity": "sha512-KEMyWNNWnjOom8vR/1+d+Ocz/mILZG/eyHHO06OuBQ2aNhxT62fr4y6fGOplRx+CxCSp3IFwesL8WdINfY/3kg==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1885,7 +1729,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.0.tgz",
       "integrity": "sha512-ZAuFgYjJzDNv77AjXRqzQGlQl4HdUM6j296ee4fwKVZfhDR9LAGxfvXjBkb06gNETPnN0sLqRm9Gxg4wZH6dXg==",
-      "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1896,7 +1739,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.0.tgz",
       "integrity": "sha512-u7eBA03zmUswQ9LQ7Qw0/ieC1pcAkbp5OQatbWUzY1PaBccvuJXUkYzoN1g7cqp7dbTu6Dp9bXyalBvD04AANA==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -1906,7 +1748,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.0.tgz",
       "integrity": "sha512-+SicSJoKouPctL+j1pqktRVCgy+xAch1hWWTMy13j0IflnyNjaoskj+DwRQFimHbLqO3sq2oN2CXMvXq3Bgapg==",
-      "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.0"
       }
@@ -1915,7 +1756,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
       "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1924,7 +1764,6 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
       "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-replace-supers": "^7.5.5"
@@ -1934,7 +1773,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
       "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
-      "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.4.4",
         "@babel/helper-get-function-arity": "^7.0.0",
@@ -1945,7 +1783,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
       "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1954,7 +1791,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.6.3.tgz",
       "integrity": "sha512-1/YogSSU7Tby9rq2VCmhuRg+6pxsHy2rI7w/oo8RKoBt6uBUFG+mk6x13kK+FY1/ggN92HAfg7ADd1v1+NCOKg==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -1964,7 +1800,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
       "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1973,7 +1808,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.0.tgz",
       "integrity": "sha512-mXhBtyVB1Ujfy+0L6934jeJcSXj/VCg6whZzEcgiiZHNS0PGC7vUCsZDQCxxztkpIdF+dY1fUMcjAgEOC3ZOMQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-builder-react-jsx": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1984,7 +1818,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
       "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -1994,7 +1827,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
       "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -2004,7 +1836,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.0.tgz",
       "integrity": "sha512-AXmvnC+0wuj/cFkkS/HFHIojxH3ffSXE+ttulrqWjZZRaUOonfJc60e1wSNT4rV8tIunvu/R3wCp71/tLAa9xg==",
-      "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.0"
       }
@@ -2013,7 +1844,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
       "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2042,7 +1872,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
       "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2051,7 +1880,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
       "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2060,7 +1888,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
       "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.0.0"
@@ -2070,7 +1897,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
       "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -2080,7 +1906,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
       "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2100,7 +1925,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.0.tgz",
       "integrity": "sha512-RrThb0gdrNwFAqEAAx9OWgtx6ICK69x7i9tCnMdVrxQwSDp/Abu9DXFU5Hh16VP33Rmxh04+NGW28NsIkFvFKA==",
-      "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -2128,7 +1952,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.1.tgz",
       "integrity": "sha512-/93SWhi3PxcVTDpSqC+Dp4YxUu3qZ4m7I76k0w73wYfn7bGVuRIO4QUz95aJksbS+AD1/mT1Ie7rbkT0wSplaA==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -2187,7 +2010,6 @@
           "version": "7.7.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
           "integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.7.0"
           }
@@ -2196,7 +2018,6 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
           "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -2206,8 +2027,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -2225,7 +2045,6 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.0.tgz",
       "integrity": "sha512-IXXgSUYBPHUGhUkH+89TR6faMcBtuMW0h5OHbMuVbL3/5wK2g6a2M2BBpkLa+Kw0sAHiZ9dNVgqJMDP/O4GRBA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-transform-react-display-name": "^7.0.0",
@@ -2373,7 +2192,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
       "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -5809,56 +5627,47 @@
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
-      "integrity": "sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig==",
-      "dev": true
+      "integrity": "sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig=="
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.2.0.tgz",
-      "integrity": "sha512-3XHLtJ+HbRCH4n28S7y/yZoEQnRpl0tvTZQsHqvaeNXPra+6vE5tbRliH3ox1yZYPCxrlqaJT/Mg+75GpDKlvQ==",
-      "dev": true
+      "integrity": "sha512-3XHLtJ+HbRCH4n28S7y/yZoEQnRpl0tvTZQsHqvaeNXPra+6vE5tbRliH3ox1yZYPCxrlqaJT/Mg+75GpDKlvQ=="
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.2.0.tgz",
-      "integrity": "sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w==",
-      "dev": true
+      "integrity": "sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w=="
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz",
-      "integrity": "sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w==",
-      "dev": true
+      "integrity": "sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w=="
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.3.3.tgz",
-      "integrity": "sha512-w3Be6xUNdwgParsvxkkeZb545VhXEwjGMwExMVBIdPQJeyMQHqm9Msnb2a1teHBqUYL66qtwfhNkbj1iarCG7w==",
-      "dev": true
+      "integrity": "sha512-w3Be6xUNdwgParsvxkkeZb545VhXEwjGMwExMVBIdPQJeyMQHqm9Msnb2a1teHBqUYL66qtwfhNkbj1iarCG7w=="
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz",
-      "integrity": "sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w==",
-      "dev": true
+      "integrity": "sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w=="
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz",
-      "integrity": "sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw==",
-      "dev": true
+      "integrity": "sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw=="
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz",
-      "integrity": "sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw==",
-      "dev": true
+      "integrity": "sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw=="
     },
     "@svgr/babel-preset": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-4.3.3.tgz",
       "integrity": "sha512-6PG80tdz4eAlYUN3g5GZiUjg2FMcp+Wn6rtnz5WJG9ITGEF1pmFdzq02597Hn0OmnQuCVaBYQE1OVFAnwOl+0A==",
-      "dev": true,
       "requires": {
         "@svgr/babel-plugin-add-jsx-attribute": "^4.2.0",
         "@svgr/babel-plugin-remove-jsx-attribute": "^4.2.0",
@@ -5874,7 +5683,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-4.3.3.tgz",
       "integrity": "sha512-qNuGF1QON1626UCaZamWt5yedpgOytvLj5BQZe2j1k1B8DUG4OyugZyfEwBeXozCUwhLEpsrgPrE+eCu4fY17w==",
-      "dev": true,
       "requires": {
         "@svgr/plugin-jsx": "^4.3.3",
         "camelcase": "^5.3.1",
@@ -5885,7 +5693,6 @@
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
           "requires": {
             "sprintf-js": "~1.0.2"
           }
@@ -5893,14 +5700,12 @@
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
         "cosmiconfig": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
           "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-          "dev": true,
           "requires": {
             "import-fresh": "^2.0.0",
             "is-directory": "^0.3.1",
@@ -5911,14 +5716,12 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "import-fresh": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-          "dev": true,
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
@@ -5928,7 +5731,6 @@
           "version": "3.13.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -5937,8 +5739,7 @@
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
         }
       }
     },
@@ -5946,7 +5747,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.3.2.tgz",
       "integrity": "sha512-JioXclZGhFIDL3ddn4Kiq8qEqYM2PyDKV0aYno8+IXTLuYt6TOgHUbUAAFvqtb0Xn37NwP0BTHglejFoYr8RZg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
       }
@@ -5955,7 +5755,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-4.3.3.tgz",
       "integrity": "sha512-cLOCSpNWQnDB1/v+SUENHH7a0XY09bfuMKdq9+gYvtuwzC2rU4I0wKGFEp1i24holdQdwodCtDQdFtJiTCWc+w==",
-      "dev": true,
       "requires": {
         "@babel/core": "^7.4.5",
         "@svgr/babel-preset": "^4.3.3",
@@ -5967,7 +5766,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-4.3.1.tgz",
       "integrity": "sha512-PrMtEDUWjX3Ea65JsVCwTIXuSqa3CG9px+DluF1/eo9mlDrgrtFE7NE/DjdhjJgSM9wenlVBzkzneSIUgfUI/w==",
-      "dev": true,
       "requires": {
         "cosmiconfig": "^5.2.1",
         "merge-deep": "^3.0.2",
@@ -5978,7 +5776,6 @@
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
           "requires": {
             "sprintf-js": "~1.0.2"
           }
@@ -5987,7 +5784,6 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
           "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-          "dev": true,
           "requires": {
             "import-fresh": "^2.0.0",
             "is-directory": "^0.3.1",
@@ -5998,14 +5794,12 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "import-fresh": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-          "dev": true,
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
@@ -6015,7 +5809,6 @@
           "version": "3.13.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -6024,8 +5817,7 @@
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
         }
       }
     },
@@ -6033,7 +5825,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-4.3.3.tgz",
       "integrity": "sha512-bjnWolZ6KVsHhgyCoYRFmbd26p8XVbulCzSG53BDQqAr+JOAderYK7CuYrB3bDjHJuF6LJ7Wrr42+goLRV9qIg==",
-      "dev": true,
       "requires": {
         "@babel/core": "^7.4.5",
         "@babel/plugin-transform-react-constant-elements": "^7.0.0",
@@ -6174,8 +5965,7 @@
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
-      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
-      "dev": true
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/reach__router": {
       "version": "1.2.5",
@@ -6624,7 +6414,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -6798,8 +6587,7 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-equal": {
       "version": "1.0.0",
@@ -7288,7 +7076,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
       "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
-      "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
       }
@@ -8433,8 +8220,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boxen": {
       "version": "3.2.0",
@@ -8635,7 +8421,6 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
       "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001004",
         "electron-to-chromium": "^1.3.295",
@@ -8872,7 +8657,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "dev": true,
       "requires": {
         "callsites": "^2.0.0"
       },
@@ -8880,8 +8664,7 @@
         "callsites": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
         }
       }
     },
@@ -8889,7 +8672,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "dev": true,
       "requires": {
         "caller-callsite": "^2.0.0"
       }
@@ -8935,8 +8717,7 @@
     "caniuse-lite": {
       "version": "1.0.30001008",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001008.tgz",
-      "integrity": "sha512-b8DJyb+VVXZGRgJUa30cbk8gKHZ3LOZTBLaUEEVr2P4xpmFigOCc62CO4uzquW641Ouq1Rm9N+rWLWdSYDaDIw==",
-      "dev": true
+      "integrity": "sha512-b8DJyb+VVXZGRgJUa30cbk8gKHZ3LOZTBLaUEEVr2P4xpmFigOCc62CO4uzquW641Ouq1Rm9N+rWLWdSYDaDIw=="
     },
     "canvg": {
       "version": "1.5.3",
@@ -9108,7 +8889,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -9371,7 +9151,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
       "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
-      "dev": true,
       "requires": {
         "@types/q": "^1.5.1",
         "chalk": "^2.4.1",
@@ -9403,7 +9182,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -9411,8 +9189,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.3.3",
@@ -9689,7 +9466,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.0.tgz",
       "integrity": "sha512-pgQUcgT2+v9/yxHgMynYjNj7nmxLRXv3UC39rjCjDwpe63ev2rioQTju1PKLYUBbPCQQvZNWvQC8tBJd65q11g==",
-      "dev": true,
       "requires": {
         "browserslist": "^4.7.2",
         "semver": "^6.3.0"
@@ -9993,14 +9769,12 @@
     "css-select-base-adapter": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
-      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
-      "dev": true
+      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
       "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
-      "dev": true,
       "requires": {
         "mdn-data": "2.0.4",
         "source-map": "^0.6.1"
@@ -10009,8 +9783,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -10036,7 +9809,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
       "integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
-      "dev": true,
       "requires": {
         "css-tree": "1.0.0-alpha.37"
       }
@@ -10239,7 +10011,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -10466,7 +10237,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
@@ -10486,8 +10256,7 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -10623,8 +10392,7 @@
     "electron-to-chromium": {
       "version": "1.3.306",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz",
-      "integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==",
-      "dev": true
+      "integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A=="
     },
     "element-resize-detector": {
       "version": "1.1.15",
@@ -10709,8 +10477,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "errno": {
       "version": "0.1.7",
@@ -10725,7 +10492,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -10771,7 +10537,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -10785,7 +10550,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -10875,8 +10639,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.11.1",
@@ -12549,14 +12312,12 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
       "requires": {
         "for-in": "^1.0.1"
       }
@@ -13310,8 +13071,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
       "version": "1.1.1",
@@ -13613,8 +13373,7 @@
     "globals": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
-      "dev": true
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw=="
     },
     "globalthis": {
       "version": "1.0.0",
@@ -13790,7 +13549,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -13807,8 +13565,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -13819,8 +13576,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -14759,8 +14515,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -14779,8 +14534,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -14814,8 +14568,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
       "version": "1.0.3",
@@ -14844,8 +14597,7 @@
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-dom": {
       "version": "1.1.0",
@@ -14860,8 +14612,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -15008,7 +14759,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -15029,7 +14779,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -15055,7 +14804,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -15136,8 +14884,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -17629,8 +17376,7 @@
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -17705,8 +17451,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -17717,8 +17462,7 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-parse-helpfulerror": {
       "version": "1.0.3",
@@ -18231,8 +17975,7 @@
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lazy-universal-dotenv": {
       "version": "3.0.1",
@@ -18687,8 +18430,7 @@
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
-      "dev": true
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -18858,7 +18600,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
       "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
-      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "clone-deep": "^0.2.4",
@@ -18869,7 +18610,6 @@
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
           "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
-          "dev": true,
           "requires": {
             "for-own": "^0.1.3",
             "is-plain-object": "^2.0.1",
@@ -18882,7 +18622,6 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -18891,7 +18630,6 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
           "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
-          "dev": true,
           "requires": {
             "is-extendable": "^0.1.1",
             "kind-of": "^2.0.1",
@@ -18903,7 +18641,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
               "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.0.2"
               }
@@ -18911,8 +18648,7 @@
             "lazy-cache": {
               "version": "0.2.7",
               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-              "dev": true
+              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
             }
           }
         }
@@ -19175,7 +18911,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-      "dev": true,
       "requires": {
         "for-in": "^0.1.3",
         "is-extendable": "^0.1.1"
@@ -19184,8 +18919,7 @@
         "for-in": {
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-          "dev": true
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
         }
       }
     },
@@ -19198,7 +18932,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -19206,8 +18939,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -19305,8 +19037,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -19577,7 +19308,6 @@
       "version": "1.1.39",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
       "integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
-      "dev": true,
       "requires": {
         "semver": "^6.3.0"
       }
@@ -19739,7 +19469,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
       "requires": {
         "boolbase": "~1.0.0"
       }
@@ -19817,8 +19546,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -19833,7 +19561,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -19869,7 +19596,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -19888,7 +19614,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -20328,7 +20053,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -20397,8 +20121,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -20801,8 +20524,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.11.10",
@@ -20979,8 +20701,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qr-image": {
       "version": "3.2.0",
@@ -21970,14 +21691,12 @@
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerate-unicode-properties": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
-      "dev": true,
       "requires": {
         "regenerate": "^1.4.0"
       }
@@ -21991,7 +21710,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
       "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
-      "dev": true,
       "requires": {
         "private": "^0.1.6"
       }
@@ -22025,7 +21743,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
       "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
-      "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^8.1.0",
@@ -22057,14 +21774,12 @@
     "regjsgen": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-      "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
-      "dev": true
+      "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
     },
     "regjsparser": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-      "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
       },
@@ -22072,8 +21787,7 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
@@ -22242,7 +21956,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
       "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -22994,12 +22707,6 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
-    "simple-html-tokenizer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz",
-      "integrity": "sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=",
-      "dev": true
-    },
     "simplebar": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.1.0.tgz",
@@ -23209,8 +22916,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -23299,8 +23005,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -23330,8 +23035,7 @@
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "dev": true
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "stack-chain": {
       "version": "2.0.0",
@@ -23707,59 +23411,19 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "svg-inline-loader": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/svg-inline-loader/-/svg-inline-loader-0.8.0.tgz",
-      "integrity": "sha512-rynplY2eXFrdNomL1FvyTFQlP+dx0WqbzHglmNtA9M4IHRC3no2aPAl3ny9lUpJzFzFMZfWRK5YIclNU+FRePA==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^0.2.11",
-        "object-assign": "^4.0.1",
-        "simple-html-tokenizer": "^0.1.1"
-      },
-      "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
-          }
-        }
       }
     },
     "svg-parser": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.2.tgz",
-      "integrity": "sha512-1gtApepKFweigFZj3sGO8KT8LvVZK8io146EzXrpVuWCDAbISz/yMucco3hWTkpZNoPabM+dnMOpy6Swue68Zg==",
-      "dev": true
+      "integrity": "sha512-1gtApepKFweigFZj3sGO8KT8LvVZK8io146EzXrpVuWCDAbISz/yMucco3hWTkpZNoPabM+dnMOpy6Swue68Zg=="
     },
     "svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
       "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
@@ -23780,28 +23444,30 @@
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
           "requires": {
             "sprintf-js": "~1.0.2"
           }
         },
         "css-select": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
-          "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
-          "dev": true,
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+          "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
           "requires": {
             "boolbase": "^1.0.0",
-            "css-what": "^2.1.2",
+            "css-what": "^3.2.1",
             "domutils": "^1.7.0",
             "nth-check": "^1.0.2"
           }
+        },
+        "css-what": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
+          "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw=="
         },
         "domutils": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
           "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-          "dev": true,
           "requires": {
             "dom-serializer": "0",
             "domelementtype": "1"
@@ -23810,14 +23476,12 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "js-yaml": {
           "version": "3.13.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -24215,8 +23879,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -24495,14 +24158,12 @@
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "dev": true
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "dev": true,
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
         "unicode-property-aliases-ecmascript": "^1.0.4"
@@ -24511,14 +24172,12 @@
     "unicode-match-property-value-ecmascript": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-      "dev": true
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
-      "dev": true
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "unified": {
       "version": "6.2.0",
@@ -24656,8 +24315,7 @@
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-      "dev": true
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -24909,7 +24567,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12472,28 +12472,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -12504,14 +12504,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -12527,35 +12527,35 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -12565,21 +12565,21 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
@@ -12594,14 +12594,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -12618,7 +12618,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -12633,14 +12633,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -12650,7 +12650,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -12660,7 +12660,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -12671,21 +12671,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -12695,14 +12695,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -12712,7 +12712,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
@@ -12736,7 +12736,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -12746,14 +12746,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -12765,7 +12765,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -12784,7 +12784,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -12795,14 +12795,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -12813,7 +12813,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -12826,21 +12826,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -12850,21 +12850,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -12875,21 +12875,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -12902,7 +12902,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -12911,7 +12911,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -12927,7 +12927,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -12937,47 +12937,47 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -12989,7 +12989,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -12999,7 +12999,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -13009,21 +13009,21 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -13033,7 +13033,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
@@ -21437,22 +21437,6 @@
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0",
         "throttle-debounce": "^2.1.0"
-      }
-    },
-    "react-svg-inline": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-svg-inline/-/react-svg-inline-2.1.1.tgz",
-      "integrity": "sha512-mN7/qwq133dHMMQdtJRMtZ6tK1ynzOJMZBKR34blzv3HqQpNBsaOKXkEe1kN14hcJJhzrUbsB+uix2ZOpF4kQg==",
-      "requires": {
-        "classnames": "^2.2.1",
-        "prop-types": "^15.5.8"
-      },
-      "dependencies": {
-        "classnames": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-          "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-        }
       }
     },
     "react-syntax-highlighter": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
     "react-polymorph": "git+https://github.com/rcmorano/react-polymorph-fix.git",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
-    "react-svg-inline": "2.1.1",
     "ringbufferjs": "1.1.0",
     "route-parser": "0.0.5",
     "semver": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "selenium-webdriver": "4.0.0-alpha.5",
     "shelljs": "0.8.3",
     "style-loader": "1.0.0",
-    "svg-inline-loader": "0.8.0",
     "url-loader": "2.2.0",
     "webpack": "4.41.2",
     "webpack-cli": "3.3.10",
@@ -141,6 +140,7 @@
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "1.0.7",
     "@download/blockies": "1.0.3",
+    "@svgr/webpack": "4.3.3",
     "axios": "0.19.0",
     "bech32": "1.1.3",
     "bignumber.js": "9.0.0",

--- a/webpack/commonConfig.js
+++ b/webpack/commonConfig.js
@@ -114,7 +114,16 @@ const rules = [
   {
     test: /\.inline\.svg$/,
     issuer: /\.js$/,
-    loader: 'svg-inline-loader?removeSVGTagAttrs=false&removeTags=true&removingTags[]=title&removingTags[]=desc&idPrefix=[sha512:hash:hex:5]-',
+    use: [{
+      loader: '@svgr/webpack',
+      options: {
+        svgoConfig: {
+          plugins: {
+            removeViewBox: false
+          }
+        }
+      }
+    }]
   },
   {
     test: /\.md$/,


### PR DESCRIPTION
The [react-svg-inline](https://github.com/MoOx/react-svg-inline#readme) is deprecated and no longer kept up-to-date.

This PR replaces it with the recommended alternative: [https://github.com/smooth-code/svgr](svgr)