### PR TITLE
Fix switching back to English after language change

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -42,7 +42,9 @@ class App extends Component<Props> {
     // Merged english messages with selected by user locale messages
     // In this case all english data would be overridden to user selected locale, but untranslated
     // (missed in object keys) just stay in english
+    // eslint-disable-next-line prefer-object-spread
     const mergedMessages: { [key: string]: string } = Object.assign(
+      {},
       translations['en-US'],
       translations[locale]
     );

--- a/features/mock-chain/TestWallets.js
+++ b/features/mock-chain/TestWallets.js
@@ -24,7 +24,9 @@ function createWallet(payload: {
 // You can use this website to generate more mnemoncis if you need for testing
 // https://iancoleman.io/bip39/
 
+// eslint-disable-next-line prefer-object-spread
 export const testWallets: { [key: string]: RestorationInput } = Object.assign(
+  {},
   createWallet({
     name: 'small-single-tx',
     mnemonic: 'eight country switch draw meat scout mystery blade tip drift useless good keep usage title',

--- a/stories/helpers/StoryWrapper.js
+++ b/stories/helpers/StoryWrapper.js
@@ -56,8 +56,10 @@ export default class StoryWrapper extends Component<Props> {
     // Merged english messages with selected by user locale messages
     // In this case all english data would be overridden to user selected locale, but untranslated
     // (missed in object keys) just stay in english
+    // eslint-disable-next-line prefer-object-spread
     const mergedMessages = Object.assign({}, translations['en-US'], translations[locale]);
 
+    // eslint-disable-next-line prefer-object-spread
     const themeVars = Object.assign({}, themes[currentTheme]);
 
     changeToplevelTheme(currentTheme);


### PR DESCRIPTION
Introduced by #1013 

Bug reason: `Object.assign` modifies its first argument so it modified the English locale when switching languages (instead of combining English + selected locale)