### PR TITLE
Refactor transfer tx generation

### DIFF
--- a/app/api/ada/lib/cardanoCrypto/paperWallet.test.js
+++ b/app/api/ada/lib/cardanoCrypto/paperWallet.test.js
@@ -14,7 +14,7 @@ import {
 } from './paperWallet';
 import {
   getAddressesKeys,
-} from '../../daedalusTransfer';
+} from '../../transactions/byron/daedalusTransfer';
 import { RustModule } from './rustLoader';
 import {
   silenceLogsForTesting,

--- a/app/api/ada/lib/storage/models/utils.js
+++ b/app/api/ada/lib/storage/models/utils.js
@@ -142,14 +142,14 @@ export function normalizeBip32Ed25519ToPubDeriverLevel(request: {
     request.privateKeyRow,
     request.password,
   );
-  const wasmKey = RustModule.WalletV2.PrivateKey.from_hex(prvKey);
+  const wasmKey = RustModule.WalletV3.Bip32PrivateKey.from_bytes(Buffer.from(prvKey, 'hex'));
   const newKey = deriveKeyV2(
     wasmKey,
     request.path,
   );
   return {
-    prvKeyHex: newKey.to_hex(),
-    pubKeyHex: newKey.public().to_hex()
+    prvKeyHex: Buffer.from(newKey.as_bytes()).toString('hex'),
+    pubKeyHex: Buffer.from(newKey.to_public().as_bytes()).toString('hex'),
   };
 }
 
@@ -173,13 +173,12 @@ export function decryptKey(
 
 
 export function deriveKeyV2(
-  startingKey: RustModule.WalletV2.PrivateKey,
+  startingKey: RustModule.WalletV3.Bip32PrivateKey,
   pathToPublic: Array<number>,
-): RustModule.WalletV2.PrivateKey {
+): RustModule.WalletV3.Bip32PrivateKey {
   let currKey = startingKey;
   for (let i = 0; i < pathToPublic.length; i++) {
     currKey = currKey.derive(
-      RustModule.WalletV2.DerivationScheme.v2(),
       pathToPublic[i],
     );
   }

--- a/app/api/ada/transactions/byron/daedalusTransfer.js
+++ b/app/api/ada/transactions/byron/daedalusTransfer.js
@@ -4,37 +4,38 @@
 
 import { isEmpty } from 'lodash';
 import BigNumber from 'bignumber.js';
-import { coinToBigNumber } from './transactions/utils';
+import { coinToBigNumber, } from '../utils';
 import {
   Logger,
   stringifyError,
-} from '../../utils/logging';
-import { LOVELACES_PER_ADA } from '../../config/numbersConfig';
+} from '../../../../utils/logging';
+import { LOVELACES_PER_ADA } from '../../../../config/numbersConfig';
 import {
   GetAddressesKeysError,
   NoInputsError,
   GenerateTransferTxError
-} from './errors';
+} from '../../errors';
 import {
   sendAllUnsignedTxFromUtxo,
-} from './transactions/byron/transactionsV2';
+} from './transactionsV2';
 import type {
   AddressUtxoFunc,
   RemoteUnspentOutput
-} from './lib/state-fetch/types';
+} from '../../lib/state-fetch/types';
 import type {
   TransferTx
-} from '../../types/TransferTypes';
-import { RustModule } from './lib/cardanoCrypto/rustLoader';
+} from '../../../../types/TransferTypes';
+import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
 
-import type { ConfigType } from '../../../config/config-types';
+import type { ConfigType } from '../../../../../config/config-types';
 
 declare var CONFIG : ConfigType;
 const protocolMagic = CONFIG.network.protocolMagic;
 
 type AddressKeyMap = { [addr: string]: RustModule.WalletV2.PrivateKey };
 
-/** Go through the whole UTXO and find the addresses that belong to the user along with the keys
+/**
+ * Go through the whole UTXO and find the addresses that belong to the user along with the keys
  * @param fullUtxo the full utxo of the Cardano blockchain
  */
 export function getAddressesKeys(payload: {
@@ -44,12 +45,13 @@ export function getAddressesKeys(payload: {
   try {
     const { checker, fullUtxo } = payload;
 
-    const addrKeyMap = {};
+    const addrKeyMap: { [addr: string]: RustModule.WalletV2.PrivateKey } = {};
     for (const addr of fullUtxo) {
       const rustAddr = RustModule.WalletV2.Address.from_base58(addr);
       const checkedAddr = checker.check_address(rustAddr);
       if (checkedAddr.is_checked()) {
-        addrKeyMap[addr] = checkedAddr.private_key();
+        const v2Key = checkedAddr.private_key();
+        addrKeyMap[addr] = v2Key;
       }
     }
     return addrKeyMap;
@@ -60,19 +62,16 @@ export function getAddressesKeys(payload: {
 }
 
 /**
- Generate transaction including all addresses with no change.
- If filterSenders is true, only include addresses that have outstanding
- UTXOs in the senders property.
+ * Generate transaction including all addresses with no change.
 */
-export async function generateTransferTx(
+export async function generateDaedalusTransferTx(
   payload: {
     outputAddr: string,
     addressKeys: AddressKeyMap,
     getUTXOsForAddresses: AddressUtxoFunc,
-    filterSenders?: boolean
   }
 ): Promise<TransferTx> {
-  const { outputAddr, addressKeys, getUTXOsForAddresses, filterSenders = false } = payload;
+  const { outputAddr, addressKeys, getUTXOsForAddresses } = payload;
 
   // fetch data to make transaction
   const senders = Object.keys(addressKeys);
@@ -84,29 +83,25 @@ export async function generateTransferTx(
     throw error;
   }
 
-  return buildTransferTx({
+  return buildDaedalusTransferTx({
     addressKeys,
     senderUtxos,
     outputAddr,
-    filterSenders,
   });
 }
 
 /**
-  Generate transaction including all addresses with no change.
-  If filterSenders is true, only include addresses that have outstanding
-  UTXOs in the senders property.
+ * Generate transaction including all addresses with no change.
 */
-export async function buildTransferTx(
+export async function buildDaedalusTransferTx(
   payload: {
     addressKeys: AddressKeyMap,
     senderUtxos: Array<RemoteUnspentOutput>,
     outputAddr: string,
-    filterSenders?: boolean
   }
 ): Promise<TransferTx> {
   try {
-    const { addressKeys, senderUtxos, outputAddr, filterSenders = false } = payload;
+    const { addressKeys, senderUtxos, outputAddr } = payload;
 
     const totalBalance = senderUtxos
       .map(utxo => new BigNumber(utxo.amount))
@@ -115,46 +110,53 @@ export async function buildTransferTx(
         new BigNumber(0)
       );
 
-    // first build a transaction to see what the fee will be
+    // build tx
     const txBuilder = sendAllUnsignedTxFromUtxo(
       outputAddr,
       senderUtxos
     ).txBuilder;
     const fee = coinToBigNumber(txBuilder.get_balance_without_fees().value());
 
-    // sign inputs
-    const txFinalizer = new RustModule.WalletV2.TransactionFinalized(
-      txBuilder.make_transaction()
+    // sign
+    const signedTx = signDaedalusTransaction(
+      txBuilder.make_transaction(),
+      addressKeys,
+      senderUtxos,
     );
-    const setting = RustModule.WalletV2.BlockchainSettings.from_json({
-      protocol_magic: protocolMagic
-    });
-    for (let i = 0; i < senderUtxos.length; i++) {
-      const witness = RustModule.WalletV2.Witness.new_extended_key(
-        setting,
-        addressKeys[senderUtxos[i].receiver],
-        txFinalizer.id()
-      );
-      txFinalizer.add_witness(witness);
-    }
 
-    const signedTx = txFinalizer.finalize();
-
-    let senders = Object.keys(addressKeys);
-
-    if (filterSenders) {
-      senders = senders.filter(addr => senderUtxos.some(({ receiver }) => receiver === addr));
-    }
     // return summary of transaction
     return {
       recoveredBalance: totalBalance.dividedBy(LOVELACES_PER_ADA),
       fee: fee.dividedBy(LOVELACES_PER_ADA),
       signedTx,
-      senders,
+      senders: Object.keys(addressKeys),
       receiver: outputAddr,
     };
   } catch (error) {
     Logger.error(`daedalusTransfer::buildTransferTx ${stringifyError(error)}`);
     throw new GenerateTransferTxError();
   }
+}
+
+export function signDaedalusTransaction(
+  unsignedTx: RustModule.WalletV2.Transaction,
+  addressKeys: AddressKeyMap,
+  senderUtxos: Array<RemoteUnspentOutput>,
+): RustModule.WalletV2.SignedTransaction {
+  const txFinalizer = new RustModule.WalletV2.TransactionFinalized(unsignedTx);
+
+  const setting = RustModule.WalletV2.BlockchainSettings.from_json({
+    protocol_magic: protocolMagic
+  });
+  for (let i = 0; i < senderUtxos.length; i++) {
+    const witness = RustModule.WalletV2.Witness.new_extended_key(
+      setting,
+      addressKeys[senderUtxos[i].receiver],
+      txFinalizer.id()
+    );
+    txFinalizer.add_witness(witness);
+  }
+
+  const signedTx = txFinalizer.finalize();
+  return signedTx;
 }

--- a/app/api/ada/transactions/byron/daedalusTransfer.test.js
+++ b/app/api/ada/transactions/byron/daedalusTransfer.test.js
@@ -1,26 +1,26 @@
 /* eslint-disable camelcase */
 // @flow
-import './lib/test-config';
+import '../../lib/test-config';
 import { schema } from 'lovefield';
 import {
   getCryptoDaedalusWalletFromMnemonics,
-} from './lib/cardanoCrypto/cryptoWallet';
+} from '../../lib/cardanoCrypto/cryptoWallet';
 import {
   getAddressesKeys,
-  buildTransferTx,
+  buildDaedalusTransferTx,
 } from './daedalusTransfer';
 import {
   GenerateTransferTxError,
-} from './errors';
+} from '../../errors';
 import {
   silenceLogsForTesting,
-} from '../../utils/logging';
+} from '../../../../utils/logging';
 
 import {
   loadLovefieldDB,
-} from './lib/storage/database/index';
+} from '../../lib/storage/database/index';
 
-import { RustModule } from './lib/cardanoCrypto/rustLoader';
+import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
 
 beforeAll(async () => {
   await RustModule.load();
@@ -51,7 +51,7 @@ test('Daedalus transfer from single small UTXO', async () => {
     amount: inputAmount
   };
 
-  const transferInfo = await buildTransferTx({
+  const transferInfo = await buildDaedalusTransferTx({
     addressKeys: addressMap,
     senderUtxos: [utxo],
     outputAddr: outAddress
@@ -102,7 +102,7 @@ test('Daedalus transfer fails from too small UTXO', async () => {
     amount: inputAmount
   };
 
-  expect(buildTransferTx({
+  expect(buildDaedalusTransferTx({
     addressKeys: addressMap,
     senderUtxos: [utxo],
     outputAddr: outAddress
@@ -152,7 +152,7 @@ test('Daedalus transfer from many UTXO', async () => {
     });
   }
 
-  const transferInfo = await buildTransferTx({
+  const transferInfo = await buildDaedalusTransferTx({
     addressKeys: addressMap,
     senderUtxos: utxo,
     outputAddr: outAddress

--- a/app/api/ada/transactions/byron/yoroiTransfer.js
+++ b/app/api/ada/transactions/byron/yoroiTransfer.js
@@ -1,0 +1,130 @@
+// @flow
+
+import { isEmpty } from 'lodash';
+import BigNumber from 'bignumber.js';
+import { coinToBigNumber, v3SecretToV2, } from '../utils';
+import {
+  Logger,
+  stringifyError,
+} from '../../../../utils/logging';
+import { LOVELACES_PER_ADA } from '../../../../config/numbersConfig';
+import {
+  NoInputsError,
+  GenerateTransferTxError
+} from '../../errors';
+import {
+  sendAllUnsignedTx,
+  signTransaction,
+} from './transactionsV2';
+import type { AddressedUtxo } from '../types';
+import type {
+  AddressUtxoFunc,
+} from '../../lib/state-fetch/types';
+import type {
+  TransferTx
+} from '../../../../types/TransferTypes';
+import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
+import type {
+  Address, Addressing
+} from '../../lib/storage/models/PublicDeriver/interfaces';
+
+/**
+ * Generate transaction including all addresses with no change.
+*/
+export async function generateYoroiTransferTx(payload: {
+  addresses: Array<{| ...Address, ...Addressing |}>,
+  outputAddr: string,
+  keyLevel: number,
+  signingKey: RustModule.WalletV3.Bip32PrivateKey,
+  getUTXOsForAddresses: AddressUtxoFunc,
+}): Promise<TransferTx> {
+  // fetch UTXO
+  const utxos = await payload.getUTXOsForAddresses({
+    addresses: payload.addresses.map(addr => addr.address)
+  });
+
+  // add addressing info to the UTXO
+  const addressingMap = new Map<string, Addressing>(
+    payload.addresses.map(entry => [
+      entry.address,
+      { addressing: entry.addressing }
+    ])
+  );
+  const senderUtxos = utxos.map(utxo => {
+    const addressing = addressingMap.get(utxo.receiver);
+    if (addressing == null) {
+      throw new Error('should never happen');
+    }
+    return {
+      ...utxo,
+      addressing: addressing.addressing
+    };
+  });
+
+  if (isEmpty(utxos)) {
+    const error = new NoInputsError();
+    Logger.error(`yoroiTransfer::generateYoroiTransferTx ${stringifyError(error)}`);
+    throw error;
+  }
+
+  return buildYoroiTransferTx({
+    senderUtxos,
+    outputAddr: payload.outputAddr,
+    keyLevel: payload.keyLevel,
+    signingKey: payload.signingKey,
+  });
+}
+
+/**
+ * Generate transaction including all addresses with no change.
+*/
+export async function buildYoroiTransferTx(payload: {
+  senderUtxos: Array<AddressedUtxo>,
+  outputAddr: string,
+  keyLevel: number,
+  signingKey: RustModule.WalletV3.Bip32PrivateKey,
+}): Promise<TransferTx> {
+  try {
+    const { senderUtxos, outputAddr, } = payload;
+
+    const totalBalance = senderUtxos
+      .map(utxo => new BigNumber(utxo.amount))
+      .reduce(
+        (acc, amount) => acc.plus(amount),
+        new BigNumber(0)
+      );
+
+    // first build a transaction to see what the fee will be
+    const unsignedTxResponse = sendAllUnsignedTx(
+      outputAddr,
+      senderUtxos
+    );
+    const fee = coinToBigNumber(
+      unsignedTxResponse.txBuilder.get_balance_without_fees().value()
+    );
+
+    // sign inputs
+    const signedTx = signTransaction(
+      {
+        senderUtxos: unsignedTxResponse.senderUtxos,
+        unsignedTx: unsignedTxResponse.txBuilder.make_transaction(),
+        changeAddr: unsignedTxResponse.changeAddr,
+      },
+      payload.keyLevel,
+      v3SecretToV2(payload.signingKey)
+      ,
+    );
+
+    // return summary of transaction
+    return {
+      recoveredBalance: totalBalance.dividedBy(LOVELACES_PER_ADA),
+      fee: fee.dividedBy(LOVELACES_PER_ADA),
+      signedTx,
+      senders: senderUtxos.map(utxo => utxo.receiver),
+      receiver: outputAddr,
+    };
+  } catch (error) {
+    Logger.error(`transfer::buildTransferTx ${stringifyError(error)}`);
+    throw new GenerateTransferTxError();
+  }
+}

--- a/app/api/ada/transactions/byron/yoroiTransfer.js
+++ b/app/api/ada/transactions/byron/yoroiTransfer.js
@@ -120,7 +120,8 @@ export async function buildYoroiTransferTx(payload: {
       recoveredBalance: totalBalance.dividedBy(LOVELACES_PER_ADA),
       fee: fee.dividedBy(LOVELACES_PER_ADA),
       signedTx,
-      senders: senderUtxos.map(utxo => utxo.receiver),
+      // only display unique addresses
+      senders: Array.from(new Set(senderUtxos.map(utxo => utxo.receiver))),
       receiver: outputAddr,
     };
   } catch (error) {

--- a/app/api/ada/transactions/shelley/utxoTransactions.test.js
+++ b/app/api/ada/transactions/shelley/utxoTransactions.test.js
@@ -194,9 +194,6 @@ describe('Create legacy witness TX from UTXO', () => {
       [],
       [addressedUtxos[0], addressedUtxos[1]],
     );
-    console.log(JSON.stringify(addressedUtxos[0]));
-    console.log(JSON.stringify(addressedUtxos[1]));
-    console.log(JSON.stringify(unsignedTxResponse.changeAddr));
     const accountPrivateKey = RustModule.WalletV3.Bip32PrivateKey.from_bytes(
       Buffer.from(
         '70afd5ff1f7f551c481b7e3f3541f7c63f5f6bcb293af92565af3deea0bcd6481a6e7b8acbe38f3906c63ccbe8b2d9b876572651ac5d2afc0aca284d9412bb1b4839bf02e1d990056d0f06af22ce4bcca52ac00f1074324aab96bbaaaccf290d',

--- a/app/api/ada/transactions/utils.js
+++ b/app/api/ada/transactions/utils.js
@@ -256,19 +256,46 @@ export function copySignRequest(req: BaseSignRequest): BaseSignRequest {
   };
 }
 
-export function v2SkKeyToV3Key(
-  v2Key: RustModule.WalletV2.PrivateKey,
-): RustModule.WalletV3.PrivateKey {
-  return RustModule.WalletV3.PrivateKey.from_extended_bytes(
-    // need to slice out the chain code from the private key
-    Buffer.from(v2Key.to_hex().slice(0, 128), 'hex')
+export function v3SecretToV2(
+  v3Key: RustModule.WalletV3.Bip32PrivateKey,
+): RustModule.WalletV2.PrivateKey {
+  return RustModule.WalletV2.PrivateKey.from_hex(
+    Buffer.from(v3Key.as_bytes()).toString('hex')
   );
 }
-export function v2PkKeyToV3Key(
-  v2Key: RustModule.WalletV2.PublicKey,
-): RustModule.WalletV3.PublicKey {
-  return RustModule.WalletV3.PublicKey.from_bytes(
-    // need to slice out the chain code from the public key
-    Buffer.from(v2Key.to_hex().slice(0, 64), 'hex')
+export function v3PublicToV2(
+  v3Key: RustModule.WalletV3.Bip32PublicKey,
+): RustModule.WalletV2.PublicKey {
+  return RustModule.WalletV2.PublicKey.from_hex(
+    Buffer.from(v3Key.as_bytes()).toString('hex')
   );
+}
+
+/**
+ * Will return undefined for Daedalus addresses (can't be represented by v3 WASM)
+ */
+export function v2SecretToV3(
+  v2Key: RustModule.WalletV2.PrivateKey,
+): RustModule.WalletV3.Bip32PrivateKey | void {
+  try {
+    return RustModule.WalletV3.Bip32PrivateKey.from_bytes(
+      Buffer.from(v2Key.to_hex(), 'hex')
+    );
+  } catch (_e) {
+    return undefined;
+  }
+}
+/**
+ * Will return undefined for Daedalus addresses (can't be represented by v3 WASM)
+ */
+export function v2PublicToV3(
+  v2Key: RustModule.WalletV2.PublicKey,
+): RustModule.WalletV3.Bip32PublicKey | void {
+  try {
+    return RustModule.WalletV3.Bip32PublicKey.from_bytes(
+      Buffer.from(v2Key.to_hex(), 'hex')
+    );
+  } catch (_e) {
+    return undefined;
+  }
 }

--- a/app/stores/ada/DaedalusTransferStore.js
+++ b/app/stores/ada/DaedalusTransferStore.js
@@ -18,8 +18,8 @@ import type {
 import { TransferStatus } from '../../types/TransferTypes';
 import {
   getAddressesKeys,
-  generateTransferTx
-} from '../../api/ada/daedalusTransfer';
+  generateDaedalusTransferTx
+} from '../../api/ada/transactions/byron/daedalusTransfer';
 import environment from '../../environment';
 import type { SignedResponse } from '../../api/ada/lib/state-fetch/types';
 import {
@@ -154,7 +154,7 @@ export default class DaedalusTransferStore extends Store {
           const addressKeys = getAddressesKeys({ checker, fullUtxo: data.addresses });
           this._updateStatus(TransferStatus.GENERATING_TX);
 
-          const transferTx = await generateTransferTx({
+          const transferTx = await generateDaedalusTransferTx({
             outputAddr: nextInternalAddress,
             addressKeys,
             getUTXOsForAddresses:

--- a/flow/declarations/cardano-wasm.js
+++ b/flow/declarations/cardano-wasm.js
@@ -12,13 +12,13 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
    * @param {Entropy} entropy
    * @param {Uint8Array} iv
    * @param {string} password
-   * @returns {any}
+   * @returns {Uint8Array}
    */
   declare export function paper_wallet_scramble(
     entropy: Entropy,
     iv: Uint8Array,
     password: string
-  ): any;
+  ): Uint8Array;
 
   /**
    * @param {Uint8Array} paper
@@ -39,25 +39,25 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
    * @param {Uint8Array} salt
    * @param {Uint8Array} nonce
    * @param {Uint8Array} data
-   * @returns {any}
+   * @returns {Uint8Array}
    */
   declare export function password_encrypt(
     password: string,
     salt: Uint8Array,
     nonce: Uint8Array,
     data: Uint8Array
-  ): any;
+  ): Uint8Array;
 
   /**
    * decrypt the data with the password
    * @param {string} password
    * @param {Uint8Array} encrypted_data
-   * @returns {any}
+   * @returns {aUint8Arrayny}
    */
   declare export function password_decrypt(
     password: string,
     encrypted_data: Uint8Array
-  ): any;
+  ): Uint8Array;
 
   /**
    */
@@ -266,16 +266,16 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
      * Note that this is not recommended to change the settings on the fly. Doing
      * so you might not be able to recover your funds anymore or to send new
      * transactions.
-     * @returns {any}
+     * @returns {BlockchainSettingsType}
      */
-    to_json(): any;
+    to_json(): BlockchainSettingsType;
 
     /**
      * retrieve the object from a JsValue.
-     * @param {any} value
+     * @param {BlockchainSettingsType} value
      * @returns {BlockchainSettings}
      */
-    static from_json(value: any): BlockchainSettings;
+    static from_json(value: BlockchainSettingsType): BlockchainSettings;
 
     /**
      * default settings to work with Cardano Mainnet
@@ -473,7 +473,7 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
     to_english_mnemonics(): string;
 
     /**
-     * @returns {any}
+     * @returns {Array<number>}
      */
     to_array(): Array<number>;
   }
@@ -831,15 +831,15 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
     id(): string;
 
     /**
-     * @returns {any}
+     * @returns {SignedTransactionType}
      */
     to_json(): SignedTransactionType;
 
     /**
-     * @param {any} value
+     * @param {SignedTransactionType} value
      * @returns {SignedTransaction}
      */
-    static from_json(value: any): SignedTransaction;
+    static from_json(value: SignedTransactionType): SignedTransaction;
 
     /**
      * @param {Uint8Array} bytes
@@ -869,15 +869,15 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
     id(): TransactionId;
 
     /**
-     * @returns {any}
+     * @returns {TransactionType}
      */
     to_json(): TransactionType;
 
     /**
-     * @param {any} value
+     * @param {TransactionType} value
      * @returns {Transaction}
      */
-    static from_json(value: any): Transaction;
+    static from_json(value: TransactionType): Transaction;
 
     /**
      * @returns {Transaction}
@@ -1029,15 +1029,15 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
     static new(ptr: TxoPointer, value: TxOut): TxInput;
 
     /**
-     * @returns {any}
+     * @returns {TxInputType}
      */
     to_json(): TxInputType;
 
     /**
-     * @param {any} value
+     * @param {TxInputType} value
      * @returns {TxInput}
      */
-    static from_json(value: any): TxInput;
+    static from_json(value: TxInputType): TxInput;
   }
   /**
    */
@@ -1053,16 +1053,16 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
 
     /**
      * serialize into a JsValue object
-     * @returns {any}
+     * @returns {TxOutType<string>}
      */
     to_json(): TxOutType<string>;
 
     /**
      * retrieve the object from a JsValue.
-     * @param {any} value
+     * @param {TxOutType<string>} value
      * @returns {TxOut}
      */
-    static from_json(value: any): TxOut;
+    static from_json(value: TxOutType<string>): TxOut;
   }
   /**
    */
@@ -1078,16 +1078,16 @@ declare module 'cardano-wallet-browser' { // need to wrap flowgen output into mo
 
     /**
      * serialize into a JsValue object
-     * @returns {any}
+     * @returns {TxoPointerType}
      */
     to_json(): TxoPointerType;
 
     /**
      * retrieve the object from a JsValue.
-     * @param {any} value
+     * @param {TxoPointerType} value
      * @returns {TxoPointer}
      */
-    static from_json(value: any): TxoPointer;
+    static from_json(value: TxoPointerType): TxoPointer;
   }
   /**
    * sign the inputs of the transaction (i.e. unlock the funds the input are
@@ -1167,4 +1167,8 @@ declare type TxOutType<T> = {|
 declare type TxInputType = {|
   ptr: TxoPointerType,
   value: TxOutType<string>,
+|};
+
+declare type BlockchainSettingsType = {|
+  protocol_magic: number
 |};


### PR DESCRIPTION
This refactors code for generating transfer transactions so it will be easier in a follow-up PR to toggle legacy/shelley mode for transferring.