### PR TITLE
Fix tx history page

### DIFF
--- a/app/api/ada/lib/cardanoCrypto/plate.js
+++ b/app/api/ada/lib/cardanoCrypto/plate.js
@@ -6,7 +6,7 @@
 import { RustModule } from './rustLoader';
 import type { GenerateAddressFunc } from '../adaAddressProcessing';
 import { v2genAddressBatchFunc } from '../../restoration/byron/scan';
-import { v3genAddressBatchFunc } from '../../restoration/shelley/scan';
+import { genSingleAddressBatchFunc } from '../../restoration/shelley/scan';
 import blakejs from 'blakejs';
 import crc32 from 'buffer-crc32';
 import type { WalletAccountNumberPlate } from '../storage/models/PublicDeriver/interfaces';
@@ -67,7 +67,7 @@ export const generateStandardPlate = (
           RustModule.WalletV2.DerivationScheme.v2()
         ),
       )
-      : v3genAddressBatchFunc(
+      : genSingleAddressBatchFunc(
         chainKey,
         discrimination,
       ),

--- a/app/api/ada/lib/storage/bridge/hashMapper.js
+++ b/app/api/ada/lib/storage/bridge/hashMapper.js
@@ -56,13 +56,17 @@ export function rawGenAddByHash(
         return;
       }
     }
-    await deps.AddAddress.addFromCanonicalByHash(
+    const newHashes = await deps.AddAddress.addFromCanonicalByHash(
       request.db, request.tx,
       [{
         ...request.address,
         keyDerivationId: request.keyDerivationId,
       }]
     );
+
+    for (const row of newHashes) {
+      ownAddressIds.add(row.AddressId);
+    }
   };
 }
 

--- a/app/api/ada/lib/storage/models/utils.js
+++ b/app/api/ada/lib/storage/models/utils.js
@@ -196,7 +196,7 @@ export async function rawGetDerivationsByPath<
     GetPathWithSpecific: Class<GetPathWithSpecific>,
   |},
   request: GetPathWithSpecificByTreeRequest,
-  level: number,
+  finalLevel: number,
   derivationTables: Map<number, string>,
 ): Promise<Array<{|
   row: $ReadOnly<Row>,
@@ -209,7 +209,7 @@ export async function rawGetDerivationsByPath<
       const result = await deps.GetDerivationSpecific.get<Row>(
         db, tx,
         derivationIds,
-        level,
+        finalLevel,
         derivationTables,
       );
       return result;


### PR DESCRIPTION
The tx history page wasn't working in the shelley branch because the staking key wasn't being committed to indexdb (was only kept in-memory). This was a mistake on my part so this PR commits it to indexdb to fix the issue.