### PR TITLE
Enable Shelley transactions on send screen

### DIFF
--- a/app/actions/ada/ledger-send-actions.js
+++ b/app/actions/ada/ledger-send-actions.js
@@ -1,10 +1,11 @@
 // @flow
 import Action from '../lib/Action';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
+import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
-export type SendUsingLedgerParams = {
-  signRequest: BaseSignRequest,
-};
+export type SendUsingLedgerParams = {|
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
+|};
 
 // ======= Sending ADA using Ledger ACTIONS =======
 

--- a/app/actions/ada/trezor-send-actions.js
+++ b/app/actions/ada/trezor-send-actions.js
@@ -1,9 +1,10 @@
 // @flow
 import Action from '../lib/Action';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
+import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
 export type SendUsingTrezorParams = {
-  signRequest: BaseSignRequest,
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
 };
 
 // ======= Sending ADA using Trezor ACTIONS =======

--- a/app/actions/ada/wallets-actions.js
+++ b/app/actions/ada/wallets-actions.js
@@ -2,6 +2,7 @@
 import BigNumber from 'bignumber.js';
 import Action from '../lib/Action';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
+import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
 // ======= WALLET ACTIONS =======
 
@@ -13,7 +14,7 @@ export default class WalletsActions {
     walletPassword: string
   |}> = new Action();
   sendMoney: Action<{|
-    signRequest: BaseSignRequest,
+    signRequest: BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput>,
     password: string,
   |}> = new Action();
   updateBalance: Action<BigNumber> = new Action();

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -1024,7 +1024,7 @@ export default class AdaApi {
     request: IsValidAddressRequest
   ): Promise<IsValidAddressResponse> {
     try {
-      return Promise.resolve(verifyAddress(request.address));
+      return Promise.resolve(verifyAddress(request.address, environment.isShelley()));
     } catch (validateAddressError) {
       Logger.error('AdaApi::isValidAdaAddress error: ' +
         stringifyError(validateAddressError));

--- a/app/api/ada/lib/storage/bridge/utils.js
+++ b/app/api/ada/lib/storage/bridge/utils.js
@@ -3,7 +3,6 @@
 import type { CoreAddressT } from '../database/primitives/enums';
 import { CoreAddressTypes } from '../database/primitives/enums';
 import { RustModule } from '../../cardanoCrypto/rustLoader';
-import envrionment from '../../../../../environment';
 
 export function addressToKind(
   address: string
@@ -32,9 +31,10 @@ export function addressToKind(
 }
 
 export function verifyAddress(
-  address: string
+  address: string,
+  isShelley: boolean,
 ): boolean {
-  if (envrionment.isShelley()) {
+  if (isShelley) {
     try {
       RustModule.WalletV3.Address.from_string(address);
       return true;

--- a/app/api/ada/lib/storage/bridge/utils.js
+++ b/app/api/ada/lib/storage/bridge/utils.js
@@ -3,6 +3,7 @@
 import type { CoreAddressT } from '../database/primitives/enums';
 import { CoreAddressTypes } from '../database/primitives/enums';
 import { RustModule } from '../../cardanoCrypto/rustLoader';
+import envrionment from '../../../../../environment';
 
 export function addressToKind(
   address: string
@@ -26,6 +27,26 @@ export function addressToKind(
       }
     } catch (_e2) {
       throw new Error('addressToKind failed to parse address type ' + address);
+    }
+  }
+}
+
+export function verifyAddress(
+  address: string
+): boolean {
+  if (envrionment.isShelley()) {
+    try {
+      RustModule.WalletV3.Address.from_string(address);
+      return true;
+    } catch (_e2) {
+      return false;
+    }
+  } else {
+    try {
+      RustModule.WalletV2.Address.from_base58(address);
+      return true;
+    } catch (_e1) {
+      return false;
     }
   }
 }

--- a/app/api/ada/lib/storage/models/PublicDeriver/interfaces.js
+++ b/app/api/ada/lib/storage/models/PublicDeriver/interfaces.js
@@ -494,3 +494,20 @@ export interface IAddBip44FromPublic {
   >;
   +addBip44FromPublic: IAddBip44FromPublicFunc;
 }
+
+export type IPickInternalRequest = BaseAddressPath;
+export type IPickInternalResponse = BaseSingleAddressPath;
+export type IPickInternalFunc = (
+  body: IPickInternalRequest
+) => Promise<IPickInternalResponse>;
+export interface IPickInternal {
+  +rawPickInternal: RawTableVariation<
+    IPickInternalFunc,
+    {|
+      GetPathWithSpecific: Class<GetPathWithSpecific>,
+      GetAddress: Class<GetAddress>,
+      GetDerivationSpecific: Class<GetDerivationSpecific>,
+    |},
+    IPickInternalRequest
+  >;
+}

--- a/app/api/ada/lib/storage/models/utils.js
+++ b/app/api/ada/lib/storage/models/utils.js
@@ -528,7 +528,7 @@ export async function getAllAddressesForDisplay(
   );
 }
 
-export type NextUnusedResponose = {|
+export type NextUnusedResponse = {|
   addressInfo: void | UtxoAddressPath,
   index: number,
 |}
@@ -541,7 +541,7 @@ export async function rawGetNextUnusedIndex(
   request:  {|
     addressesForChain: Array<UtxoAddressPath>,
   |}
-): Promise<NextUnusedResponose> {
+): Promise<NextUnusedResponse> {
   const usedStatus = await rawGetUtxoUsedStatus(
     db, tx,
     { GetUtxoTxOutputsWithTx: deps.GetUtxoTxOutputsWithTx },

--- a/app/api/ada/transactions/byron/daedalusTransfer.js
+++ b/app/api/ada/transactions/byron/daedalusTransfer.js
@@ -3,7 +3,7 @@
 // Create byron transactions for wallets created with the v1 address scheme
 
 import BigNumber from 'bignumber.js';
-import { coinToBigNumber, } from '../utils';
+import { coinToBigNumber, } from './utils';
 import {
   Logger,
   stringifyError,

--- a/app/api/ada/transactions/byron/hwTransactions.js
+++ b/app/api/ada/transactions/byron/hwTransactions.js
@@ -51,7 +51,7 @@ declare var CONFIG: ConfigType;
 // ==================== TREZOR ==================== //
 /** Generate a payload for Trezor SignTx */
 export async function createTrezorSignTxPayload(
-  signRequest: BaseSignRequest,
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
   getTxsBodiesForUTXOs: TxBodiesFunc,
 ): Promise<$CardanoSignTransaction> {
   const txJson = signRequest.unsignedTx.to_json();
@@ -167,7 +167,7 @@ function _generateTrezorOutputs(
 // ==================== LEDGER ==================== //
 /** Generate a payload for Ledger SignTx */
 export async function createLedgerSignTxPayload(
-  signRequest: BaseSignRequest,
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
   getTxsBodiesForUTXOs: TxBodiesFunc,
 ): Promise<LedgerSignTxPayload> {
   const txJson = signRequest.unsignedTx.to_json();

--- a/app/api/ada/transactions/byron/transactionsV2.js
+++ b/app/api/ada/transactions/byron/transactionsV2.js
@@ -14,7 +14,8 @@ import {
   NotEnoughMoneyToSendError,
 } from '../../errors';
 import type { ConfigType } from '../../../../../config/config-types';
-import { utxosToLookupMap, coinToBigNumber } from '../utils';
+import { utxosToLookupMap, } from '../utils';
+import { coinToBigNumber } from './utils';
 
 import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
 
@@ -232,7 +233,7 @@ function filterToUsedChange(
 }
 
 export function signTransaction(
-  signRequest: BaseSignRequest,
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
   keyLevel: number,
   signingKey: RustModule.WalletV2.PrivateKey
 ): RustModule.WalletV2.SignedTransaction {

--- a/app/api/ada/transactions/byron/utils.js
+++ b/app/api/ada/transactions/byron/utils.js
@@ -1,0 +1,95 @@
+// @flow
+
+import BigNumber from 'bignumber.js';
+import type {
+  BaseSignRequest,
+} from '../types';
+import {
+  DECIMAL_PLACES_IN_ADA,
+  LOVELACES_PER_ADA,
+} from '../../../../config/numbersConfig';
+import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
+
+export function coinToBigNumber(coin: RustModule.WalletV2.Coin): BigNumber {
+  const ada = new BigNumber(coin.ada());
+  const lovelace = ada.times(LOVELACES_PER_ADA).plus(coin.lovelace());
+  return lovelace;
+}
+
+export function signRequestFee(
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
+  shift: boolean
+): BigNumber {
+  const inputTotal = signRequest.senderUtxos
+    .map(utxo => new BigNumber(utxo.amount))
+    .reduce((sum, val) => sum.plus(val), new BigNumber(0));
+
+  const tx = signRequest.unsignedTx.to_json();
+  const outputTotal = tx.outputs
+    .map(val => new BigNumber(val.value))
+    .reduce((sum, val) => sum.plus(val), new BigNumber(0));
+
+  let result = inputTotal.minus(outputTotal);
+  if (shift) {
+    result = result.shiftedBy(-DECIMAL_PLACES_IN_ADA);
+  }
+  return result;
+}
+
+export function signRequestTotalInput(
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
+  shift: boolean
+): BigNumber {
+  const inputTotal = signRequest.senderUtxos
+    .map(utxo => new BigNumber(utxo.amount))
+    .reduce((sum, val) => sum.plus(val), new BigNumber(0));
+
+  const change = signRequest.changeAddr
+    .map(val => new BigNumber(val.value || new BigNumber(0)))
+    .reduce((sum, val) => sum.plus(val), new BigNumber(0));
+
+  let result = inputTotal.minus(change);
+  if (shift) {
+    result = result.shiftedBy(-DECIMAL_PLACES_IN_ADA);
+  }
+  return result;
+}
+
+export function signRequestReceivers(
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
+  includeChange: boolean
+): Array<string> {
+  const tx = signRequest.unsignedTx.to_json();
+  let receivers = tx.outputs
+    .map(val => val.address);
+
+  if (!includeChange) {
+    const changeAddrs = signRequest.changeAddr.map(change => change.address);
+    receivers = receivers.filter(addr => !changeAddrs.includes(addr));
+  }
+  return receivers;
+}
+
+/**
+ * Signing a tx is a destructive operation in Rust
+ * We create a copy of the tx so the user can retry if they get the password wrong
+ */
+export function copySignRequest(
+  signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>
+): BaseSignRequest<RustModule.WalletV2.Transaction> {
+  return {
+    changeAddr: signRequest.changeAddr,
+    senderUtxos: signRequest.senderUtxos,
+    unsignedTx: signRequest.unsignedTx.clone(),
+  };
+}
+
+export function byronTxEqual(
+  req1: RustModule.WalletV2.Transaction,
+  req2: RustModule.WalletV2.Transaction,
+): boolean {
+  const tentativeTxJson = JSON.stringify(req1.to_json());
+  const plannedTxJson = JSON.stringify(req2.to_json());
+
+  return tentativeTxJson === plannedTxJson;
+}

--- a/app/api/ada/transactions/byron/yoroiTransfer.js
+++ b/app/api/ada/transactions/byron/yoroiTransfer.js
@@ -1,7 +1,8 @@
 // @flow
 
 import BigNumber from 'bignumber.js';
-import { coinToBigNumber, v3SecretToV2, } from '../utils';
+import { v3SecretToV2, } from '../utils';
+import { coinToBigNumber, } from './utils';
 import {
   Logger,
   stringifyError,

--- a/app/api/ada/transactions/shelley/accountingTransaction.test.js
+++ b/app/api/ada/transactions/shelley/accountingTransaction.test.js
@@ -33,19 +33,19 @@ describe('Create unsigned TX for account', () => {
       },
       new BigNumber(5000000),
     );
-    const inputSum = getTxInputTotal(unsignedTxResponse);
-    const outputSum = getTxOutputTotal(unsignedTxResponse);
+    const inputSum = getTxInputTotal(unsignedTxResponse, false);
+    const outputSum = getTxOutputTotal(unsignedTxResponse, false);
     expect(inputSum.toString()).toEqual('2155383');
     expect(outputSum.toString()).toEqual('2000000');
     expect(inputSum.minus(outputSum).toString()).toEqual('155383');
 
-    const signedTx = signTransaction(
+    const fragment = signTransaction(
       unsignedTxResponse,
       0,
       undefined,
       senderKey,
     );
-
+    const signedTx = fragment.get_transaction();
     const witnesses = signedTx.witnesses();
 
     expect(witnesses.size()).toEqual(1);

--- a/app/api/ada/transactions/shelley/accountingTransactions.js
+++ b/app/api/ada/transactions/shelley/accountingTransactions.js
@@ -118,7 +118,7 @@ export function signTransaction(
   accountCounter: number,
   certificate: ?RustModule.WalletV3.Certificate,
   accountPrivateKey: RustModule.WalletV3.PrivateKey
-): RustModule.WalletV3.Transaction {
+): RustModule.WalletV3.Fragment {
   const txbuilder = new RustModule.WalletV3.TransactionBuilder();
 
   const builderSetIOs = certificate != null
@@ -152,5 +152,6 @@ export function signTransaction(
   const signedTx = builderSignCertificate.set_payload_auth(
     payloadAuthData
   );
-  return signedTx;
+  const fragment = RustModule.WalletV3.Fragment.from_transaction(signedTx);
+  return fragment;
 }

--- a/app/api/ada/transactions/shelley/daedalusTransfer.js
+++ b/app/api/ada/transactions/shelley/daedalusTransfer.js
@@ -3,7 +3,7 @@
 // Create byron transactions for wallets created with the v1 address scheme
 
 import BigNumber from 'bignumber.js';
-import { getFee, } from './utils';
+import { getShelleyTxFee, } from './utils';
 import {
   Logger,
   stringifyError,
@@ -54,7 +54,7 @@ export async function buildDaedalusTransferTx(payload: {|
       outputAddr,
       senderUtxos
     );
-    const fee = getFee(utxoResponse.IOs);
+    const fee = getShelleyTxFee(utxoResponse.IOs, false);
 
     // sign
     const signedTx = signDaedalusTransaction(

--- a/app/api/ada/transactions/shelley/utils.js
+++ b/app/api/ada/transactions/shelley/utils.js
@@ -2,9 +2,16 @@
 
 import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
 import BigNumber from 'bignumber.js';
+import {
+  DECIMAL_PLACES_IN_ADA,
+} from '../../../../config/numbersConfig';
+import type {
+  BaseSignRequest,
+} from '../types';
 
 export function getTxInputTotal(
   IOs: RustModule.WalletV3.InputOutput,
+  shift: boolean
 ): BigNumber {
   let sum = new BigNumber(0);
 
@@ -14,11 +21,15 @@ export function getTxInputTotal(
     const value = new BigNumber(input.value().to_str());
     sum = sum.plus(value);
   }
+  if (shift) {
+    return sum.shiftedBy(-DECIMAL_PLACES_IN_ADA);
+  }
   return sum;
 }
 
 export function getTxOutputTotal(
   IOs: RustModule.WalletV3.InputOutput,
+  shift: boolean
 ): BigNumber {
   let sum = new BigNumber(0);
 
@@ -28,13 +39,82 @@ export function getTxOutputTotal(
     const value = new BigNumber(output.value().to_str());
     sum = sum.plus(value);
   }
+  if (shift) {
+    return sum.shiftedBy(-DECIMAL_PLACES_IN_ADA);
+  }
   return sum;
 }
 
-export function getFee(
+export function getShelleyTxFee(
   IOs: RustModule.WalletV3.InputOutput,
+  shift: boolean,
 ): BigNumber {
-  const out = getTxOutputTotal(IOs);
-  const ins = getTxInputTotal(IOs);
-  return ins.minus(out);
+  const out = getTxOutputTotal(IOs, false);
+  const ins = getTxInputTotal(IOs, false);
+  const result = ins.minus(out);
+  if (shift) {
+    return result.shiftedBy(-DECIMAL_PLACES_IN_ADA);
+  }
+  return result;
+}
+
+export function getShelleyTxReceivers(
+  signRequest: BaseSignRequest<RustModule.WalletV3.InputOutput>,
+  includeChange: boolean
+): Array<string> {
+  const receivers: Array<string> = [];
+
+  const changeAddrs = new Set(signRequest.changeAddr.map(change => change.address));
+  const outputs = signRequest.unsignedTx.outputs();
+  for (let i = 0; i < outputs.size(); i++) {
+    const output = outputs.get(i);
+    const addr = Buffer.from(output.address().as_bytes()).toString('hex');
+    if (!includeChange) {
+      if (changeAddrs.has(addr)) {
+        continue;
+      }
+    }
+    receivers.push(addr);
+  }
+  return receivers;
+}
+
+export function shelleyTxEqual(
+  req1: RustModule.WalletV3.InputOutput,
+  req2: RustModule.WalletV3.InputOutput,
+): boolean {
+  const inputs1 = req1.inputs();
+  const inputs2 = req2.inputs();
+  if (inputs1.size() !== inputs2.size()) {
+    return false;
+  }
+
+  const outputs1 = req1.outputs();
+  const outputs2 = req2.outputs();
+  if (outputs1.size() !== outputs2.size()) {
+    return false;
+  }
+
+  for (let i = 0; i < inputs1.size(); i++) {
+    const input1 = Buffer.from(inputs1.get(i).as_bytes()).toString('hex');
+    const input2 = Buffer.from(inputs2.get(i).as_bytes()).toString('hex');
+    if (input1 !== input2) {
+      return false;
+    }
+  }
+  for (let i = 0; i < outputs1.size(); i++) {
+    const output1 = outputs1.get(i);
+    const output2 = outputs2.get(i);
+
+    if (output1.value().to_str() !== output2.value().to_str()) {
+      return false;
+    }
+    const out1Addr = Buffer.from(output1.address().as_bytes()).toString('hex');
+    const out2Addr = Buffer.from(output2.address().as_bytes()).toString('hex');
+    if (out1Addr !== out2Addr) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/app/api/ada/transactions/shelley/utxoTransactions.test.js
+++ b/app/api/ada/transactions/shelley/utxoTransactions.test.js
@@ -131,8 +131,8 @@ describe('Create unsigned TX from UTXO', () => {
       utxos
     );
     expect(unsignedTxResponse.senderUtxos).toEqual(utxos);
-    const inputSum = getTxInputTotal(unsignedTxResponse.IOs);
-    const outputSum = getTxOutputTotal(unsignedTxResponse.IOs);
+    const inputSum = getTxInputTotal(unsignedTxResponse.IOs, false);
+    const outputSum = getTxOutputTotal(unsignedTxResponse.IOs, false);
     expect(inputSum.toString()).toEqual('1000001');
     expect(outputSum.toString()).toEqual('5001');
     expect(inputSum.minus(outputSum).toString()).toEqual('995000');
@@ -178,8 +178,8 @@ describe('Create unsigned TX from UTXO', () => {
     // input selection will only take 2 of the 3 inputs
     // it takes 2 inputs because input selection algorithm
     expect(unsignedTxResponse.senderUtxos).toEqual([utxos[0], utxos[1]]);
-    const inputSum = getTxInputTotal(unsignedTxResponse.IOs);
-    const outputSum = getTxOutputTotal(unsignedTxResponse.IOs);
+    const inputSum = getTxInputTotal(unsignedTxResponse.IOs, false);
+    const outputSum = getTxOutputTotal(unsignedTxResponse.IOs, false);
     expect(inputSum.toString()).toEqual('1007002');
     expect(outputSum.toString()).toEqual('851617');
     expect(inputSum.minus(outputSum).toString()).toEqual('155385');
@@ -228,8 +228,8 @@ describe('Create unsigned TX from addresses', () => {
       [addressedUtxos[0], addressedUtxos[1]],
     );
     expect(unsignedTxResponse.senderUtxos).toEqual([addressedUtxos[0], addressedUtxos[1]]);
-    const inputSum = getTxInputTotal(unsignedTxResponse.IOs);
-    const outputSum = getTxOutputTotal(unsignedTxResponse.IOs);
+    const inputSum = getTxInputTotal(unsignedTxResponse.IOs, false);
+    const outputSum = getTxOutputTotal(unsignedTxResponse.IOs, false);
     expect(inputSum.toString()).toEqual('1007002');
     expect(outputSum.toString()).toEqual('5001');
     expect(inputSum.minus(outputSum).toString()).toEqual('1002001');
@@ -335,8 +335,8 @@ describe('Create sendAll unsigned TX from UTXO', () => {
       );
 
       expect(sendAllResponse.senderUtxos).toEqual([utxos[0], utxos[1]]);
-      const inputSum = getTxInputTotal(sendAllResponse.IOs);
-      const outputSum = getTxOutputTotal(sendAllResponse.IOs);
+      const inputSum = getTxInputTotal(sendAllResponse.IOs, false);
+      const outputSum = getTxOutputTotal(sendAllResponse.IOs, false);
       expect(inputSum.toString()).toEqual('11000002');
       expect(outputSum.toString()).toEqual('10844618');
       expect(inputSum.minus(outputSum).toString()).toEqual('155384');

--- a/app/api/ada/transactions/shelley/yoroiTransfer.js
+++ b/app/api/ada/transactions/shelley/yoroiTransfer.js
@@ -1,7 +1,7 @@
 // @flow
 
 import BigNumber from 'bignumber.js';
-import { getFee, } from './utils';
+import { getShelleyTxFee, } from './utils';
 import {
   Logger,
   stringifyError,
@@ -44,7 +44,7 @@ export async function buildYoroiTransferTx(payload: {|
       outputAddr,
       senderUtxos
     );
-    const fee = getFee(unsignedTxResponse.IOs);
+    const fee = getShelleyTxFee(unsignedTxResponse.IOs, false);
 
     // sign inputs
     const fragment = signTransaction(

--- a/app/api/ada/transactions/types.js
+++ b/app/api/ada/transactions/types.js
@@ -53,9 +53,11 @@ export type UnsignedTxResponse = {|
   txBuilder: RustModule.WalletV2.TransactionBuilder,
   changeAddr: Array<{| ...Address, ...Value, ...Addressing |}>,
 |};
-export type BaseSignRequest = {|
+export type BaseSignRequest<
+  T: RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput
+> = {|
   senderUtxos: Array<AddressedUtxo>,
-  unsignedTx: RustModule.WalletV2.Transaction,
+  unsignedTx: T,
   changeAddr: Array<{| ...Address, ...Value, ...Addressing |}>,
 |};
 

--- a/app/components/wallet/send/WalletSendConfirmationDialog.js
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.js
@@ -21,7 +21,6 @@ import RawHash from '../../widgets/hashWrappers/RawHash';
 import type { ExplorerType } from '../../../domain/Explorer';
 
 import WarningBox from '../../widgets/WarningBox';
-import type { BaseSignRequest } from '../../../api/ada/transactions/types';
 
 const messages = defineMessages({
   walletPasswordLabel: {
@@ -47,7 +46,6 @@ type Props = {|
   +transactionFee: string,
   +onSubmit: ({ password: string }) => void,
   +amountToNaturalUnits: (amountWithFractions: string) => string,
-  +signRequest: BaseSignRequest,
   +onCancel: Function,
   +isSubmitting: boolean,
   +error: ?LocalizableError,

--- a/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
@@ -6,18 +6,19 @@ import type { InjectedProps } from '../../../types/injectedPropsType';
 import type { BaseSignRequest } from '../../../api/ada/transactions/types';
 import {
   copySignRequest,
-  signRequestFee,
-  signRequestReceivers,
-  signRequestTotalInput,
+  IGetFee,
+  IReceivers,
+  ITotalInput,
 } from '../../../api/ada/transactions/utils';
 import WalletSendConfirmationDialog from '../../../components/wallet/send/WalletSendConfirmationDialog';
 import {
   formattedWalletAmount,
   formattedAmountToNaturalUnits,
 } from '../../../utils/formatters';
+import { RustModule } from '../../../api/ada/lib/cardanoCrypto/rustLoader';
 
 type DialogProps = {|
-  +signRequest: BaseSignRequest,
+  +signRequest: BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput>,
   +currencyUnit: string,
   +staleTx: boolean,
 |};
@@ -42,9 +43,9 @@ export default class WalletSendConfirmationDialogContainer extends Component<Pro
 
     if (publicDeriver == null) throw new Error('Active wallet required for WalletSendPage.');
 
-    const totalInput = signRequestTotalInput(signRequest, true);
-    const fee = signRequestFee(signRequest, true);
-    const receivers = signRequestReceivers(signRequest, false);
+    const totalInput = ITotalInput(signRequest, true);
+    const fee = IGetFee(signRequest, true);
+    const receivers = IReceivers(signRequest, false);
     return (
       <WalletSendConfirmationDialog
         staleTx={this.props.staleTx}
@@ -54,7 +55,6 @@ export default class WalletSendConfirmationDialogContainer extends Component<Pro
         totalAmount={formattedWalletAmount(totalInput)}
         transactionFee={formattedWalletAmount(fee)}
         amountToNaturalUnits={formattedAmountToNaturalUnits}
-        signRequest={signRequest}
         onSubmit={({ password }) => {
           const copyRequest = copySignRequest(signRequest);
           sendMoney.trigger({

--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -18,6 +18,7 @@ import type { BaseSignRequest } from '../../api/ada/transactions/types';
 import {
   asGetSigningKey,
 } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
+import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
 export default class AdaWalletsStore extends WalletStore {
 
@@ -53,7 +54,7 @@ export default class AdaWalletsStore extends WalletStore {
 
   /** Send money and then return to transaction screen */
   _sendMoney = async (transactionDetails: {|
-    signRequest: BaseSignRequest,
+    signRequest: BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput>,
     password: string,
   |}): Promise<void> => {
     const publicDeriver = this.selected;

--- a/app/stores/base/AddressesStore.js
+++ b/app/stores/base/AddressesStore.js
@@ -208,6 +208,7 @@ export default class AddressesStore extends Store {
       Logger.error(`_wrapForAllAddresses incorrect public deriver`);
       return Promise.resolve([]);
     }
+    // TODO: filter group keys to only get key with our staking key?
     return this.api[environment.API].getAllAddressesForDisplay({
       publicDeriver: withUtxos,
       type: environment.isShelley()
@@ -226,6 +227,7 @@ export default class AddressesStore extends Store {
       Logger.error(`_wrapForChainAddresses incorrect public deriver`);
       return Promise.resolve([]);
     }
+    // TODO: filter group keys to only get key with our staking key?
     return this.api[environment.API].getChainAddressesForDisplay({
       publicDeriver: withHasUtxoChains,
       chainsRequest: request.chainsRequest,

--- a/flow-typed/npm/js-chain-libs_v0.1.2.js
+++ b/flow-typed/npm/js-chain-libs_v0.1.2.js
@@ -55,6 +55,12 @@ declare module 'js-chain-libs' { // need to wrap flowgen output into module
   |};
   declare export type CertificateTypeT = $Values<typeof CertificateType>;
 
+  declare export var InputKind: {|
+    +Account: 0, // 0
+    +Utxo: 1 // 1
+  |};
+  declare export type InputKindType = $Values<typeof InputKind>;
+
   /**
    * This is either an single account or a multisig account depending on the witness type
    */
@@ -948,10 +954,9 @@ declare module 'js-chain-libs' { // need to wrap flowgen output into module
     static from_account(account: Account, v: Value): Input;
 
     /**
-     * Get the kind of Input, this can be either \"Account\" or \"Utxo\
-     * @returns {string}
+     * @returns {InputKindType}
      */
-    get_type(): string;
+    get_type(): InputKindType;
 
     /**
      * @returns {boolean}
@@ -979,6 +984,17 @@ declare module 'js-chain-libs' { // need to wrap flowgen output into module
      * @returns {AccountIdentifier}
      */
     get_account_identifier(): AccountIdentifier;
+
+    /**
+     * @returns {Uint8Array}
+     */
+    as_bytes(): Uint8Array;
+
+    /**
+     * @param {Uint8Array} bytes
+     * @returns {Input}
+     */
+    static from_bytes(bytes: Uint8Array): Input;
   }
   /**
    */


### PR DESCRIPTION
This PR makes that the send screen builds Shelley transactions when building on the Shelley branch.

Part of this is hacky because the way transactions are built/signed in Yoroi isn't generic enough to work for arbitrary logic (it was all hardcoded for Byron-style transactions). It wasn't clear how much work it would be to rewrite the flow to allow for generic logic so I played it safe and made a bunch of if/else switches for byron/shelley where necessary. We can revisit this to clean it up later when we have more time or when Shelley ships to mainnet which will allow us to delete the Byron code.