### PR TITLE
Add nameof babel transform

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -116,6 +116,7 @@ module.exports = {
     NETWORK: true,
     MOBX_DEV_TOOLS: true,
     CONFIG: true,
-    yoroi: true
+    yoroi: true,
+    nameof: true,
   }
 }

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -724,7 +724,7 @@ export default class AdaApi {
   async signAndBroadcast(
     request: SignAndBroadcastRequest
   ): Promise<SignAndBroadcastResponse> {
-    Logger.debug('AdaApi::signAndBroadcast called');
+    Logger.debug(`${nameof(AdaApi)}::${nameof(this.signAndBroadcast)} called`);
     const { password, signRequest } = request;
     try {
       const signingKey = await request.publicDeriver.getSigningKey();
@@ -763,7 +763,7 @@ export default class AdaApi {
         id = Buffer.from(signedTx.id().as_bytes()).toString('hex');
         encodedTx = signedTx.as_bytes();
       } else {
-        throw new Error('signAndBroadcast not supported');
+        throw new Error(`${nameof(this.signAndBroadcast)} not supported`);
       }
       const response = request.sendTx({
         id,
@@ -1074,7 +1074,7 @@ export default class AdaApi {
   async restoreWallet(
     request: RestoreWalletRequest
   ): Promise<RestoreWalletResponse> {
-    Logger.debug('AdaApi::restoreWallet called');
+    Logger.debug(`${nameof(AdaApi)}::${nameof(this.restoreWallet)} called`);
     const { recoveryPhrase, walletName, walletPassword, } = request;
 
     try {

--- a/babel.config.js
+++ b/babel.config.js
@@ -26,6 +26,7 @@ module.exports = function (api /*: ApiType */) {
       '@babel/preset-react'
     ],
     plugins: [
+      'nameof-js',
       [
         '@babel/plugin-proposal-decorators',
         {

--- a/flow/declarations/babelPlugin.js
+++ b/flow/declarations/babelPlugin.js
@@ -1,0 +1,3 @@
+// @flow
+
+declare function nameof(identifier: any): string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8069,6 +8069,12 @@
       "integrity": "sha512-S6d+tEzc5Af1tKIMbsf2QirCcPdQ+mKUCY2H1nJj1DyA1ShwpsoxEOAwbWsG5gcXNV/olpvQd9vrUWRx4bnhpw==",
       "dev": true
     },
+    "babel-plugin-nameof-js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-nameof-js/-/babel-plugin-nameof-js-0.0.2.tgz",
+      "integrity": "sha1-fJqorwAmvZ41UAQjWjN8EydT/fM=",
+      "dev": true
+    },
     "babel-plugin-react-docgen": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "babel-plugin-add-module-exports": "1.0.2",
     "babel-plugin-dynamic-import-node": "2.3.0",
     "babel-plugin-module-resolver": "3.2.0",
+    "babel-plugin-nameof-js": "0.0.2",
     "babel-plugin-react-intl": "5.1.9",
     "babel-preset-react-optimize": "1.0.1",
     "blake2b": "2.1.3",


### PR DESCRIPTION
In many places in our code, we use variable names inside strings. This makes refactoring harder and I've noticed many times functions getting refactored while forgetting to modify the strings.

C# solved this problem with a `nameof` keyword that turns an identifier into a string. I looked it up and sure enough somebody made the same util for Babel

I didn't convert all our strings to use this but hopefully we can slowly transition to using this. This PR only shows examples of how we can use it.

See also: https://github.com/aimed/babel-plugin-nameof-js#usage