### PR TITLE
Bumpt to corejs3

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,7 +17,7 @@ module.exports = function (api /*: ApiType */) {
       [
         '@babel/preset-env',
         {
-          corejs: 2,
+          corejs: 3,
           modules: (api.env('test') || api.env('jest')) ? 'commonjs' : 'auto',
           useBuiltIns: 'entry'
         }
@@ -38,7 +38,7 @@ module.exports = function (api /*: ApiType */) {
         '@babel/plugin-transform-runtime',
         {
           // CoreJS breaks Jest mocks for some reason
-          corejs: (api.env('test') || api.env('jest')) ? false : 2,
+          corejs: (api.env('test') || api.env('jest')) ? false : 3,
           helpers: true,
           regenerator: true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2556,13 +2556,13 @@
         }
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.2.tgz",
-      "integrity": "sha512-GfVnHchOBvIMsweQ13l4jd9lT4brkevnavnVOej5g2y7PpTRY+R4pcQlCjWMZoUla5rMLFzaS/Ll2s59cB1TqQ==",
+    "@babel/runtime-corejs3": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.4.tgz",
+      "integrity": "sha512-BBIEhzk8McXDcB3IbOi8zQPzzINUp4zcLesVlBSOcyGhzPUU8Xezk5GAG7Sy5GVhGmAO0zGd2qRSeY2g4Obqxw==",
       "dev": true,
       "requires": {
-        "core-js": "^2.6.5",
+        "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-react": "7.7.0",
     "@babel/register": "7.7.0",
     "@babel/runtime": "7.7.2",
-    "@babel/runtime-corejs2": "7.7.2",
+    "@babel/runtime-corejs3": "7.7.4",
     "@emurgo/js-chain-libs-node": "git+https://github.com/SebastienGllmt/js-chain-libs-node-pkg.git",
     "@przemyslawzalewski/babel-eslint": "11.0.0",
     "@storybook/addon-actions": "5.2.5",


### PR DESCRIPTION
Support for CoreJS3 was added to Babel a few months ago.

There are two problems with CoreJS2

1) It struggles to polyfill instance methods
2) It hasn't been updated in a while (so its list of polyfills is out-of-date)

This is important because we recently started using `flatMap` in multiple places and CoreJS2 fails to polyfill it causing some of our users no longer to be able to run Yoroi (had a few users report this issue). Hopefully this fixes it (would need to get an old browser to test)