### PR TITLE
Wasm usage for mock chain generation

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -710,7 +710,7 @@ export default class AdaApi {
 
       const lastSyncInfo = await request.publicDeriver.getLastSyncInfo();
       const mappedTransactions = fetchedTxs.txs.map(tx => {
-        return WalletTransaction.fromAnnotatedUtxoTx({
+        return WalletTransaction.fromAnnotatedTx({
           tx,
           addressLookupMap: fetchedTxs.addressLookupMap,
           lastBlockNumber: lastSyncInfo.SlotNum,
@@ -738,7 +738,7 @@ export default class AdaApi {
 
       const lastSyncInfo = await request.publicDeriver.getLastSyncInfo();
       const mappedTransactions = fetchedTxs.txs.map(tx => {
-        return WalletTransaction.fromAnnotatedUtxoTx({
+        return WalletTransaction.fromAnnotatedTx({
           tx,
           addressLookupMap: fetchedTxs.addressLookupMap,
           lastBlockNumber: lastSyncInfo.SlotNum,

--- a/app/api/ada/lib/cardanoCrypto/rustLoader.js
+++ b/app/api/ada/lib/cardanoCrypto/rustLoader.js
@@ -8,6 +8,7 @@ class Module {
   _wasmv3: WasmV3;
 
   async load(): Promise<void> {
+    if (this._wasmv2 != null || this._wasmv3 != null) return;
     this._wasmv2 = await import('cardano-wallet-browser');
     this._wasmv3 = await import('@emurgo/js-chain-libs/js_chain_libs');
   }

--- a/app/api/ada/lib/storage/bridge/tests/common.js
+++ b/app/api/ada/lib/storage/bridge/tests/common.js
@@ -24,11 +24,6 @@ import type { WalletTypePurposeT } from '../../../../../../config/numbersConfig'
 import {
   mnemonicToEntropy
 } from 'bip39';
-import { CoreAddressTypes } from '../../database/primitives/enums';
-import type { CoreAddressT } from '../../database/primitives/enums';
-import {
-  Bip44DerivationLevels,
-} from '../../database/walletTypes/bip44/api/utils';
 
 import { RustModule } from '../../../cardanoCrypto/rustLoader';
 
@@ -122,95 +117,6 @@ async function setupCip1852(
   );
 
   return publicDeriver;
-}
-
-export function getSingleAddressString(
-  mnemonic: string,
-  path: Array<number>,
-): string {
-  const bip39entropy = mnemonicToEntropy(mnemonic);
-  const EMPTY_PASSWORD = Buffer.from('');
-  const rootKey = RustModule.WalletV3.Bip32PrivateKey.from_bip39_entropy(
-    Buffer.from(bip39entropy, 'hex'),
-    EMPTY_PASSWORD
-  );
-  const derivedKey = derivePath(rootKey, path);
-
-  if (path[0] === WalletTypePurpose.BIP44) {
-    const v2Key = RustModule.WalletV2.PublicKey.from_hex(
-      Buffer.from(derivedKey.to_public().as_bytes()).toString('hex')
-    );
-    const settings = RustModule.WalletV2.BlockchainSettings.from_json({
-      protocol_magic: protocolMagic
-    });
-    const addr = v2Key.bootstrap_era_address(settings);
-    const hex = addr.to_base58();
-    return hex;
-  }
-  if (path[0] === WalletTypePurpose.CIP1852) {
-    const addr = RustModule.WalletV3.Address.single_from_public_key(
-      derivedKey.to_public().to_raw_key(),
-      RustModule.WalletV3.AddressDiscrimination.Production,
-    );
-    return Buffer.from(addr.as_bytes()).toString('hex');
-  }
-  throw new Error('Unexpected purpose');
-}
-
-export function getAddressForType(
-  mnemonic: string,
-  path: Array<number>,
-  type: CoreAddressT,
-): string {
-  const bip39entropy = mnemonicToEntropy(mnemonic);
-  const EMPTY_PASSWORD = Buffer.from('');
-  const rootKey = RustModule.WalletV3.Bip32PrivateKey.from_bip39_entropy(
-    Buffer.from(bip39entropy, 'hex'),
-    EMPTY_PASSWORD
-  );
-  const derivedKey = derivePath(rootKey, path);
-
-  switch (type) {
-    case CoreAddressTypes.SHELLEY_SINGLE: {
-      const addr = RustModule.WalletV3.Address.single_from_public_key(
-        derivedKey.to_public().to_raw_key(),
-        RustModule.WalletV3.AddressDiscrimination.Production,
-      );
-      return Buffer.from(addr.as_bytes()).toString('hex');
-    }
-    case CoreAddressTypes.SHELLEY_ACCOUNT: {
-      const addr = RustModule.WalletV3.Address.account_from_public_key(
-        derivedKey.to_public().to_raw_key(),
-        RustModule.WalletV3.AddressDiscrimination.Production,
-      );
-      return Buffer.from(addr.as_bytes()).toString('hex');
-    }
-    case CoreAddressTypes.SHELLEY_GROUP: {
-      const newPath = [...path];
-      // -1 because newPath here starts at PURPOSE and not at ROOT
-      newPath[Bip44DerivationLevels.CHAIN.level - 1] = 2;
-      newPath[Bip44DerivationLevels.ADDRESS.level - 1] = 0;
-      const stakingKey = derivePath(rootKey, newPath);
-      const addr = RustModule.WalletV3.Address.delegation_from_public_key(
-        derivedKey.to_public().to_raw_key(),
-        stakingKey.to_public().to_raw_key(),
-        RustModule.WalletV3.AddressDiscrimination.Production,
-      );
-      return Buffer.from(addr.as_bytes()).toString('hex');
-    }
-    default: throw new Error('getAddressForType unknown type ' + type);
-  }
-}
-
-function derivePath(
-  startKey: RustModule.WalletV3.Bip32PrivateKey,
-  path: Array<number>
-): RustModule.WalletV3.Bip32PrivateKey {
-  let currKey = startKey;
-  for (let i = 0; i < path.length; i++) {
-    currKey = currKey.derive(path[i]);
-  }
-  return currKey;
 }
 
 export function mockDate(): void {

--- a/app/api/ada/lib/storage/bridge/tests/multiwallet.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/multiwallet.test.js
@@ -10,7 +10,6 @@ import {
   setup,
   mockDate,
   filterDbSnapshot,
-  getSingleAddressString,
   ABANDON_SHARE,
   TX_TEST_MNEMONIC_1,
 } from './common';
@@ -25,6 +24,7 @@ import {
   genCheckAddressesInUse,
   genGetTransactionsHistoryForAddresses,
   genGetBestBlock,
+  getSingleAddressString,
 } from './mockNetwork';
 import { loadLovefieldDB } from '../../database/index';
 

--- a/app/api/ada/lib/storage/bridge/tests/shelleyGroup.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/shelleyGroup.test.js
@@ -10,8 +10,6 @@ import {
   setup,
   filterDbSnapshot,
   mockDate,
-  getSingleAddressString,
-  getAddressForType,
   ABANDON_SHARE,
   TX_TEST_MNEMONIC_1,
 } from './common';
@@ -19,6 +17,8 @@ import {
   genCheckAddressesInUse,
   genGetTransactionsHistoryForAddresses,
   genGetBestBlock,
+  getAddressForType,
+  getSingleAddressString,
 } from './mockNetwork';
 import {
   HARD_DERIVATION_START,

--- a/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
@@ -11,7 +11,6 @@ import {
   setup,
   filterDbSnapshot,
   mockDate,
-  getSingleAddressString,
   ABANDON_SHARE,
   TX_TEST_MNEMONIC_1,
 } from './common';
@@ -19,6 +18,7 @@ import {
   genCheckAddressesInUse,
   genGetTransactionsHistoryForAddresses,
   genGetBestBlock,
+  getSingleAddressString,
 } from './mockNetwork';
 import {
   HARD_DERIVATION_START,

--- a/app/api/ada/lib/storage/bridge/tests/status.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/status.test.js
@@ -10,7 +10,6 @@ import {
   setup,
   mockDate,
   filterDbSnapshot,
-  getSingleAddressString,
   ABANDON_SHARE,
   TX_TEST_MNEMONIC_1,
 } from './common';
@@ -18,6 +17,7 @@ import {
   genCheckAddressesInUse,
   genGetTransactionsHistoryForAddresses,
   genGetBestBlock,
+  getSingleAddressString,
 } from './mockNetwork';
 import { loadLovefieldDB } from '../../database/index';
 import {

--- a/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -166,7 +166,9 @@ export async function rawGetUtxoTransactions(
   {
     const allAddressIds = txsWithIOs.flatMap(txWithIO => [
       ...txWithIO.utxoInputs.map(input => input.AddressId),
-      ...txWithIO.utxoOutputs.map(output => output.AddressId)
+      ...txWithIO.utxoOutputs.map(output => output.AddressId),
+      ...txWithIO.accountingInputs.map(input => input.AddressId),
+      ...txWithIO.accountingOutputs.map(output => output.AddressId),
     ]);
     const addressRows = await GetAddress.getById(
       db, dbTx,

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -21,6 +21,7 @@ import ExplorableHashContainer from '../../../containers/widgets/ExplorableHashC
 import type { ExplorerType } from '../../../domain/Explorer';
 import { TxStatusCodes, } from '../../../api/ada/lib/storage/database/primitives/enums';
 import type { TxStatusCodesType, } from '../../../api/ada/lib/storage/database/primitives/enums';
+import { addressToDisplayString } from '../../../api/ada/lib/storage/bridge/utils';
 
 const messages = defineMessages({
   type: {
@@ -304,12 +305,12 @@ export default class Transaction extends Component<Props, State> {
                 <ExplorableHashContainer
                   key={`${data.id}-from-${address}`}
                   selectedExplorer={this.props.selectedExplorer}
-                  hash={address}
+                  hash={addressToDisplayString(address)}
                   light
                   linkType="address"
                 >
                   <RawHash light>
-                    {address}<br />
+                    {addressToDisplayString(address)}<br />
                   </RawHash>
                 </ExplorableHashContainer>
               ))}
@@ -321,12 +322,12 @@ export default class Transaction extends Component<Props, State> {
                   // eslint-disable-next-line react/no-array-index-key
                   key={`${data.id}-to-${address}-${addressIndex}`}
                   selectedExplorer={this.props.selectedExplorer}
-                  hash={address}
+                  hash={addressToDisplayString(address)}
                   light
                   linkType="address"
                 >
                   <RawHash light>
-                    {address}<br />
+                    {addressToDisplayString(address)}<br />
                   </RawHash>
                 </ExplorableHashContainer>
               ))}

--- a/app/domain/WalletTransaction.js
+++ b/app/domain/WalletTransaction.js
@@ -57,7 +57,7 @@ export default class WalletTransaction {
   }
 
   @action
-  static fromAnnotatedUtxoTx(request: {
+  static fromAnnotatedTx(request: {
     tx: {|
       ...DbTxIO,
       ...WithNullableFields<DbBlock>,
@@ -73,7 +73,7 @@ export default class WalletTransaction {
       for (const row of rows) {
         const val = addressLookupMap.get(row.AddressId);
         if (val == null) {
-          throw new Error('fromAnnotatedUtxoTx address not in map');
+          throw new Error(`${nameof(WalletTransaction.fromAnnotatedTx)} address not in map`);
         }
         result.push(val);
       }
@@ -91,8 +91,14 @@ export default class WalletTransaction {
         ? request.lastBlockNumber - tx.block.SlotNum
         : 0,
       addresses: {
-        from: toAddr(tx.utxoInputs),
-        to: toAddr(tx.utxoOutputs),
+        from: [
+          ...toAddr(tx.utxoInputs),
+          ...toAddr(tx.accountingInputs),
+        ],
+        to: [
+          ...toAddr(tx.utxoOutputs),
+          ...toAddr(tx.accountingOutputs),
+        ]
       },
       state: tx.transaction.Status,
       errorMsg: tx.transaction.ErrorMessage,

--- a/features/mock-chain/TestWallets.js
+++ b/features/mock-chain/TestWallets.js
@@ -24,37 +24,53 @@ function createWallet(payload: {
 // You can use this website to generate more mnemoncis if you need for testing
 // https://iancoleman.io/bip39/
 
+type WalletNames =
+  'small-single-tx' |
+  'failed-single-tx' |
+  'many-tx-wallet' |
+  'empty-wallet' |
+  'simple-pending-wallet' |
+  'tx-big-input-wallet' |
+  'dump-wallet';
+
 // eslint-disable-next-line prefer-object-spread
-export const testWallets: { [key: string]: RestorationInput } = Object.assign(
+export const testWallets: { [key: WalletNames]: RestorationInput } = Object.assign(
   {},
   createWallet({
-    name: 'small-single-tx',
+    name: ('small-single-tx': WalletNames),
     mnemonic: 'eight country switch draw meat scout mystery blade tip drift useless good keep usage title',
     plate: 'EAJD-7036',
   }),
   createWallet({
-    name: 'failed-single-tx',
+    name: ('failed-single-tx': WalletNames),
     mnemonic: 'broken common spring toilet work safe decrease equal velvet cluster myth old toy hold rain',
     plate: 'JSLX-5059',
   }),
   createWallet({
-    name: 'many-tx-wallet',
+    name: ('many-tx-wallet': WalletNames),
     mnemonic: 'final autumn bacon fold horse scissors act pole country focus task blush basket move view',
     plate: 'ZKTZ-4614',
   }),
   createWallet({
-    name: 'empty-wallet',
+    name: ('empty-wallet': WalletNames),
     mnemonic: 'burst hood dance captain city crane over olive notice sugar what bubble butter wealth grace',
     plate: 'ZPOX-6942',
   }),
   createWallet({
-    name: 'simple-pending-wallet',
+    name: ('simple-pending-wallet': WalletNames),
     mnemonic: 'ritual horn upon plastic foster enemy expect hand control coil jeans wolf arch isolate farm',
     plate: 'DPAH-1099',
   }),
   createWallet({
-    name: 'tx-big-input-wallet',
+    name: ('tx-big-input-wallet': WalletNames),
     mnemonic: 'dragon mango general very inmate idea rabbit pencil element bleak term cart critic kite pill',
     plate: 'EDAO-9229',
+  }),
+  createWallet({
+    // a wallet to send stuff to when you need a tx output
+    // but don't want to affect the other wallets for testing
+    name: ('dump-wallet': WalletNames),
+    mnemonic: 'proud nuclear patch arm digital theory peasant winner person knock mirror across immune certain power',
+    plate: 'XXXX-1111',
   }),
 );

--- a/features/mock-chain/mockImporter.js
+++ b/features/mock-chain/mockImporter.js
@@ -139,7 +139,6 @@ export const generateTransction = () => {
         ),
         amount: '1000000'
       },
-      // many-tx-wallet
       {
         // Ae2tdPwUPEZ9uHfzhw3vXUrTFLowct5hMMHeNjfsrkQv5XSi5PhSs2yRNUb
         address: getSingleAddressString(
@@ -411,7 +410,7 @@ export const generateTransction = () => {
     ],
     outputs: [
       {
-        // Ae2tdPwUPEZEXbmLnQ22Rxhv8a6hQ3C2673nkGsXKAgzqnuC1vqne9EtBkK
+        // Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr
         address: getSingleAddressString(
           testWallets['many-tx-wallet'].mnemonic,
           [
@@ -419,7 +418,7 @@ export const generateTransction = () => {
             CoinTypes.CARDANO,
             0 + HARD_DERIVATION_START,
             ChainDerivations.EXTERNAL,
-            1
+            9
           ]
         ),
         amount: '1'
@@ -470,7 +469,6 @@ export const generateTransction = () => {
       }
     ],
     outputs: [
-      // many-tx-wallet external
       {
         // Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr
         address: getSingleAddressString(
@@ -531,7 +529,6 @@ export const generateTransction = () => {
       }
     ],
     outputs: [
-      // many-tx-wallet external
       {
         // Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr
         address: getSingleAddressString(
@@ -546,7 +543,6 @@ export const generateTransction = () => {
         ),
         amount: '1'
       },
-      // many-tx-wallet internal
       {
         // Ae2tdPwUPEZHG9AGUYWqFcM5zFn74qdEx2TqyZxuU68CQ33EBodWAVJ523w
         address: getSingleAddressString(
@@ -594,7 +590,6 @@ export const generateTransction = () => {
       }
     ],
     outputs: [
-      // many-tx-wallet external (index 30)
       {
         // Ae2tdPwUPEYzkKjrqPw1GHUty25Cj5fWrBVsWxiQYCxfoe2d9iLjTnt34Aj
         address: getSingleAddressString(
@@ -609,7 +604,6 @@ export const generateTransction = () => {
         ),
         amount: '1'
       },
-      // many-tx-wallet internal
       {
         // Ae2tdPwUPEZ7VKG9jy6jJTxQCWNXoMeL2Airvzjv3dc3WCLhSBA7XbSMhKd
         address: getSingleAddressString(
@@ -769,7 +763,6 @@ export const generateTransction = () => {
         ),
         amount: '1'
       },
-      // failed-single-tx internal
       {
         // Ae2tdPwUPEZCqWsJkibw8BK2SgbmJ1rRG142Ru1CjSnRvKwDWbL4UYPN3eU
         address: getSingleAddressString(

--- a/features/mock-chain/mockImporter.js
+++ b/features/mock-chain/mockImporter.js
@@ -8,7 +8,18 @@ import {
   genCheckAddressesInUse,
   genUtxoForAddresses,
   genUtxoSumForAddresses,
+  getAddressForType,
+  getSingleAddressString,
 } from '../../app/api/ada/lib/storage/bridge/tests/mockNetwork';
+import {
+  HARD_DERIVATION_START,
+  WalletTypePurpose,
+  CoinTypes,
+  ChainDerivations,
+} from '../../app/config/numbersConfig';
+import { testWallets } from './TestWallets';
+
+const isShelley = false;
 
 // based on abandon x 14 + share
 const genesisTransaction = '52929ce6f1ab83b439e65f6613bad9590bd264c0d6c4f910e36e2369bb987b35';
@@ -33,346 +44,771 @@ type ServerStatus = {
  * You can generate more data for these tests using the Cardano-Wallet WASM library
  */
 
-const genesisTx = {
-  hash: cryptoRandomString({ length: 64 }),
-  inputs: [
-    {
-      address: genesisAddress,
-      id: genesisTransaction + '0',
-      amount: genesisTxValue.toString(),
-      txHash: '',
-      index: 0,
-    }
-  ],
-  outputs: [
-    { address: genesisTxReceiver, amount: genesisTxValue.toString() }
-  ],
-  height: 1,
-  epoch: 0,
-  slot: 1,
-  tx_ordinal: 0,
-  block_hash: '1',
-  time: '2019-04-19T15:13:33.000Z',
-  last_update: '2019-05-17T23:14:51.899Z',
-  tx_state: 'Successful'
-};
-const distributorTx = {
-  hash: cryptoRandomString({ length: 64 }),
-  inputs: [
-    {
-      address: genesisTxReceiver,
-      txHash: genesisTx.hash,
-      id: genesisTx.hash + '0',
-      index: 0,
-      amount: genesisTxValue.toString()
-    }
-  ],
-  outputs: [
-    // small-single-tx
-    { address: 'Ae2tdPwUPEZGLVbFwK5EnWiFxwWwLjVtV3CNzy7Hu7tB5nqFxS31uGjjhoc', amount: '20295' },
-    // tx-big-input-wallet
-    { address: 'Ae2tdPwUPEYx2dK1AMzRN1GqNd2eY7GCd7Z6aikMPJL3EkqqugoFQComQnV', amount: '1234567898765' },
-    // simple-pending-wallet
-    { address: 'Ae2tdPwUPEZ9ySSM18e2QGFnCgL8ViDqp8K3wU4i5DYTSf5w6e1cT2aGdSJ', amount: '1000000' },
-    { address: 'Ae2tdPwUPEZ9ySSM18e2QGFnCgL8ViDqp8K3wU4i5DYTSf5w6e1cT2aGdSJ', amount: '1000000' },
-    // many-tx-wallet
-    { address: 'Ae2tdPwUPEZ9uHfzhw3vXUrTFLowct5hMMHeNjfsrkQv5XSi5PhSs2yRNUb', amount: '1000000' },
-    { address: 'Ae2tdPwUPEZEXbmLnQ22Rxhv8a6hQ3C2673nkGsXKAgzqnuC1vqne9EtBkK', amount: '1000000' },
-    { address: 'Ae2tdPwUPEYwBZD5hPWCm3PUDYdMBfnLHsQmgUiexnkvDMTFCQ4gzRkgAEQ', amount: '1000000' },
-    { address: 'Ae2tdPwUPEYvzFpWJEGmSjLdz3DNY9WL5CbPjsouuM5M6YMsYWB1vsCS8j4', amount: '1000000' },
-    // failed-single-tx
-    { address: 'Ae2tdPwUPEYw8ScZrAvKbxai1TzG7BGC4n8PoF9JzE1abgHc3gBfkkDNBNv', amount: '1000000' },
-    // daedalus addresses
-    { address: 'DdzFFzCqrhstBgE23pfNLvukYhpTPUKgZsXWLN5GsawqFZd4Fq3aVuGEHk11LhfMfmfBCFCBGrdZHVExjiB4FY5Jkjj1EYcqfTTNcczb', amount: '500000' },
-    { address: 'DdzFFzCqrht74dr7DYmiyCobGFQcfLCsHJCCM6nEBTztrsEk5kwv48EWKVMFU9pswAkLX9CUs4yVhVxqZ7xCVDX1TdatFwX5W39cohvm', amount: '500000' },
-    // paper wallet
-    { address: 'Ae2tdPwUPEZ7TQpzbJZCbA5BjW4zWYFn47jKo43ouvfe4EABoCfvEjwYvJr', amount: '500000' },
-  ],
-  height: 1,
-  epoch: 0,
-  slot: 1,
-  tx_ordinal: 1,
-  block_hash: '1',
-  time: '2019-04-19T15:13:33.000Z',
-  last_update: '2019-05-17T23:14:51.899Z',
-  tx_state: 'Successful'
-};
+export const generateTransction = () => {
+  const genesisTx = {
+    hash: cryptoRandomString({ length: 64 }),
+    inputs: [
+      {
+        address: genesisAddress,
+        id: genesisTransaction + '0',
+        amount: genesisTxValue.toString(),
+        txHash: '',
+        index: 0,
+      }
+    ],
+    outputs: [
+      { address: genesisTxReceiver, amount: genesisTxValue.toString() }
+    ],
+    height: 1,
+    epoch: 0,
+    slot: 1,
+    tx_ordinal: 0,
+    block_hash: '1',
+    time: '2019-04-19T15:13:33.000Z',
+    last_update: '2019-05-17T23:14:51.899Z',
+    tx_state: 'Successful'
+  };
+  const distributorTx = {
+    hash: cryptoRandomString({ length: 64 }),
+    inputs: [
+      {
+        address: genesisTxReceiver,
+        txHash: genesisTx.hash,
+        id: genesisTx.hash + '0',
+        index: 0,
+        amount: genesisTxValue.toString()
+      }
+    ],
+    outputs: [
+      // small-single-tx
+      {
+        // Ae2tdPwUPEZGLVbFwK5EnWiFxwWwLjVtV3CNzy7Hu7tB5nqFxS31uGjjhoc
+        address: getSingleAddressString(
+          testWallets['small-single-tx'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '20295'
+      },
+      // tx-big-input-wallet
+      {
+        // Ae2tdPwUPEYx2dK1AMzRN1GqNd2eY7GCd7Z6aikMPJL3EkqqugoFQComQnV
+        address: getSingleAddressString(
+          testWallets['tx-big-input-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '1234567898765'
+      },
+      // simple-pending-wallet
+      {
+        // Ae2tdPwUPEZ9ySSM18e2QGFnCgL8ViDqp8K3wU4i5DYTSf5w6e1cT2aGdSJ
+        address: getSingleAddressString(
+          testWallets['simple-pending-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '1000000'
+      },
+      {
+        // Ae2tdPwUPEZ9ySSM18e2QGFnCgL8ViDqp8K3wU4i5DYTSf5w6e1cT2aGdSJ
+        address: getSingleAddressString(
+          testWallets['simple-pending-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '1000000'
+      },
+      // many-tx-wallet
+      {
+        // Ae2tdPwUPEZ9uHfzhw3vXUrTFLowct5hMMHeNjfsrkQv5XSi5PhSs2yRNUb
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '1000000'
+      },
+      {
+        // Ae2tdPwUPEZEXbmLnQ22Rxhv8a6hQ3C2673nkGsXKAgzqnuC1vqne9EtBkK
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ]
+        ),
+        amount: '1000000'
+      },
+      {
+        // Ae2tdPwUPEYwBZD5hPWCm3PUDYdMBfnLHsQmgUiexnkvDMTFCQ4gzRkgAEQ
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            2
+          ]
+        ),
+        amount: '1000000'
+      },
+      {
+        // Ae2tdPwUPEYvzFpWJEGmSjLdz3DNY9WL5CbPjsouuM5M6YMsYWB1vsCS8j4
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            3
+          ]
+        ),
+        amount: '1000000'
+      },
+      // failed-single-tx
+      {
+        // Ae2tdPwUPEYw8ScZrAvKbxai1TzG7BGC4n8PoF9JzE1abgHc3gBfkkDNBNv
+        address: getSingleAddressString(
+          testWallets['failed-single-tx'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '1000000'
+      },
+      // daedalus addresses
+      { address: 'DdzFFzCqrhstBgE23pfNLvukYhpTPUKgZsXWLN5GsawqFZd4Fq3aVuGEHk11LhfMfmfBCFCBGrdZHVExjiB4FY5Jkjj1EYcqfTTNcczb', amount: '500000' },
+      { address: 'DdzFFzCqrht74dr7DYmiyCobGFQcfLCsHJCCM6nEBTztrsEk5kwv48EWKVMFU9pswAkLX9CUs4yVhVxqZ7xCVDX1TdatFwX5W39cohvm', amount: '500000' },
+      // paper wallet
+      { address: 'Ae2tdPwUPEZ7TQpzbJZCbA5BjW4zWYFn47jKo43ouvfe4EABoCfvEjwYvJr', amount: '500000' },
+    ],
+    height: 1,
+    epoch: 0,
+    slot: 1,
+    tx_ordinal: 1,
+    block_hash: '1',
+    time: '2019-04-19T15:13:33.000Z',
+    last_update: '2019-05-17T23:14:51.899Z',
+    tx_state: 'Successful'
+  };
 
-// =========================
-//   simple-pending-wallet
-// =========================
+  // =========================
+  //   simple-pending-wallet
+  // =========================
 
-const pendingTx1 = {
-  hash: cryptoRandomString({ length: 64 }),
-  inputs: [
-    {
-      address: 'Ae2tdPwUPEZ9ySSM18e2QGFnCgL8ViDqp8K3wU4i5DYTSf5w6e1cT2aGdSJ',
-      txHash: distributorTx.hash,
-      id: distributorTx.hash + '2',
-      index: 2,
-      amount: '1000000'
-    }
-  ],
-  outputs: [
-    // simple-pending-wallet external
-    { address: 'Ae2tdPwUPEYw3yJyPX1LWKXpuUjKAt57TLdR5fF61PRvUyswE3m7WrKNbrr', amount: '1' },
-  ],
-  height: null,
-  block_hash: null,
-  tx_ordinal: null,
-  time: null,
-  epoch: null,
-  slot: null,
-  last_update: '2019-05-20T23:14:51.899Z',
-  tx_state: 'Pending'
-};
-const pendingTx2 = {
-  hash: 'fa6f2c82fb511d0cc9c12a540b5fac6e5a9b0f288f2d140f909f981279e16fbe',
-  inputs: [
-    {
-      // simple-pending-wallet external
-      address: 'Ae2tdPwUPEZ9ySSM18e2QGFnCgL8ViDqp8K3wU4i5DYTSf5w6e1cT2aGdSJ',
-      txHash: distributorTx.hash,
-      id: distributorTx.hash + '3',
-      index: 3,
-      amount: '1000000'
-    }
-  ],
-  outputs: [
-    // simple-pending-wallet external
-    { address: 'Ae2tdPwUPEYwEnNsuY9uMAphecEWipHKEy9g8yZCJTJm4zxV1sTrQfTxPVX', amount: '1' },
-  ],
-  height: null,
-  block_hash: null,
-  tx_ordinal: null,
-  time: null,
-  epoch: null,
-  slot: null,
-  last_update: '2019-05-20T23:14:52.899Z',
-  tx_state: 'Pending'
-};
+  const pendingTx1 = {
+    hash: cryptoRandomString({ length: 64 }),
+    inputs: [
+      {
+        // Ae2tdPwUPEZ9ySSM18e2QGFnCgL8ViDqp8K3wU4i5DYTSf5w6e1cT2aGdSJ
+        address: getSingleAddressString(
+          testWallets['simple-pending-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '2',
+        index: 2,
+        amount: '1000000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEYw3yJyPX1LWKXpuUjKAt57TLdR5fF61PRvUyswE3m7WrKNbrr
+        address: getSingleAddressString(
+          testWallets['simple-pending-wallet'].mnemonic,
+          [
+            isShelley ? WalletTypePurpose.CIP1852 : WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ]
+        ),
+        amount: '1'
+      },
+    ],
+    height: null,
+    block_hash: null,
+    tx_ordinal: null,
+    time: null,
+    epoch: null,
+    slot: null,
+    last_update: '2019-05-20T23:14:51.899Z',
+    tx_state: 'Pending'
+  };
+  const pendingTx2 = {
+    hash: 'fa6f2c82fb511d0cc9c12a540b5fac6e5a9b0f288f2d140f909f981279e16fbe',
+    inputs: [
+      {
+        // Ae2tdPwUPEZ9ySSM18e2QGFnCgL8ViDqp8K3wU4i5DYTSf5w6e1cT2aGdSJ
+        address: getSingleAddressString(
+          testWallets['simple-pending-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '3',
+        index: 3,
+        amount: '1000000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEYwEnNsuY9uMAphecEWipHKEy9g8yZCJTJm4zxV1sTrQfTxPVX
+        address: getSingleAddressString(
+          testWallets['simple-pending-wallet'].mnemonic,
+          [
+            isShelley ? WalletTypePurpose.CIP1852 : WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            2
+          ]
+        ),
+        amount: '1'
+      },
+    ],
+    height: null,
+    block_hash: null,
+    tx_ordinal: null,
+    time: null,
+    epoch: null,
+    slot: null,
+    last_update: '2019-05-20T23:14:52.899Z',
+    tx_state: 'Pending'
+  };
 
-// ==================
-//   many-tx-wallet
-// ==================
+  // ==================
+  //   many-tx-wallet
+  // ==================
 
-const manyTx1 = {
-  hash: cryptoRandomString({ length: 64 }),
-  inputs: [
-    {
+  const manyTx1 = {
+    hash: cryptoRandomString({ length: 64 }),
+    inputs: [
+      {
+        // Ae2tdPwUPEZ9uHfzhw3vXUrTFLowct5hMMHeNjfsrkQv5XSi5PhSs2yRNUb
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '4',
+        index: 4,
+        amount: '1000000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            9
+          ]
+        ),
+        amount: '1'
+      },
+      {
+        // Ae2tdPwUPEZ77uBBu8cMVxswVy1xfaMZR9wsUSwDNiB48MWqsVWfitHfUM9
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            0
+          ]
+        ),
+        amount: '820000'
+      },
+    ],
+    height: 100,
+    block_hash: '100',
+    tx_ordinal: 0,
+    time: '2019-04-20T15:15:33.000Z',
+    epoch: 0,
+    slot: 100,
+    last_update: '2019-05-20T23:16:51.899Z',
+    tx_state: 'Successful'
+  };
+  const manyTx2 = {
+    hash: '60493bf26e60b0b98f143647613be2ec1c6f50bd5fc15a14a2ff518f5fa36be0',
+    inputs: [
+      {
+        // Ae2tdPwUPEZEXbmLnQ22Rxhv8a6hQ3C2673nkGsXKAgzqnuC1vqne9EtBkK
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '5',
+        index: 5,
+        amount: '1000000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEZEXbmLnQ22Rxhv8a6hQ3C2673nkGsXKAgzqnuC1vqne9EtBkK
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ]
+        ),
+        amount: '1'
+      },
+      {
+        // Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            1
+          ]
+        ),
+        amount: '820000'
+      },
+    ],
+    height: 100,
+    block_hash: '100',
+    tx_ordinal: 0,
+    time: '2019-04-20T15:15:33.000Z',
+    epoch: 0,
+    slot: 100,
+    last_update: '2019-05-20T23:16:51.899Z',
+    tx_state: 'Successful'
+  };
+  const manyTx3 = {
+    hash: cryptoRandomString({ length: 64 }),
+    inputs: [
+      {
+        // Ae2tdPwUPEYwBZD5hPWCm3PUDYdMBfnLHsQmgUiexnkvDMTFCQ4gzRkgAEQ
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            2
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '6',
+        index: 6,
+        amount: '1000000'
+      }
+    ],
+    outputs: [
       // many-tx-wallet external
-      address: 'Ae2tdPwUPEZ9uHfzhw3vXUrTFLowct5hMMHeNjfsrkQv5XSi5PhSs2yRNUb',
-      txHash: distributorTx.hash,
-      id: distributorTx.hash + '4',
-      index: 4,
-      amount: '1000000'
-    }
-  ],
-  outputs: [
-    // many-tx-wallet external
-    { address: 'Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr', amount: '1' },
-    // many-tx-wallet internal
-    { address: 'Ae2tdPwUPEZ77uBBu8cMVxswVy1xfaMZR9wsUSwDNiB48MWqsVWfitHfUM9', amount: '820000' },
-  ],
-  height: 100,
-  block_hash: '100',
-  tx_ordinal: 0,
-  time: '2019-04-20T15:15:33.000Z',
-  epoch: 0,
-  slot: 100,
-  last_update: '2019-05-20T23:16:51.899Z',
-  tx_state: 'Successful'
-};
-const manyTx2 = {
-  hash: '60493bf26e60b0b98f143647613be2ec1c6f50bd5fc15a14a2ff518f5fa36be0',
-  inputs: [
-    {
+      {
+        // Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            9
+          ]
+        ),
+        amount: '1'
+      },
+      {
+        // Ae2tdPwUPEZJZPsFg8w5bXA4brfu8peYy5prmrFiYPACb7DX64iiBY8WvHD
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            2
+          ]
+        ),
+        amount: '820000'
+      },
+    ],
+    height: 100,
+    block_hash: '100',
+    tx_ordinal: 1,
+    time: '2019-04-20T15:15:33.000Z',
+    epoch: 0,
+    slot: 100,
+    last_update: '2019-05-20T23:16:51.899Z',
+    tx_state: 'Successful'
+  };
+  const manyTx4 = {
+    hash: cryptoRandomString({ length: 64 }),
+    inputs: [
+      {
+        // Ae2tdPwUPEYvzFpWJEGmSjLdz3DNY9WL5CbPjsouuM5M6YMsYWB1vsCS8j4
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            3
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '7',
+        index: 7,
+        amount: '1000000'
+      }
+    ],
+    outputs: [
       // many-tx-wallet external
-      address: 'Ae2tdPwUPEZEXbmLnQ22Rxhv8a6hQ3C2673nkGsXKAgzqnuC1vqne9EtBkK',
-      txHash: distributorTx.hash,
-      id: distributorTx.hash + '5',
-      index: 5,
-      amount: '1000000'
-    }
-  ],
-  outputs: [
-    // many-tx-wallet external
-    { address: 'Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr', amount: '1' },
-    // many-tx-wallet internal
-    { address: 'Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3', amount: '820000' },
-  ],
-  height: 100,
-  block_hash: '100',
-  tx_ordinal: 0,
-  time: '2019-04-20T15:15:33.000Z',
-  epoch: 0,
-  slot: 100,
-  last_update: '2019-05-20T23:16:51.899Z',
-  tx_state: 'Successful'
-};
-const manyTx3 = {
-  hash: cryptoRandomString({ length: 64 }),
-  inputs: [
-    {
-      // many-tx-wallet external
-      address: 'Ae2tdPwUPEYwBZD5hPWCm3PUDYdMBfnLHsQmgUiexnkvDMTFCQ4gzRkgAEQ',
-      txHash: distributorTx.hash,
-      id: distributorTx.hash + '6',
-      index: 6,
-      amount: '1000000'
-    }
-  ],
-  outputs: [
-    // many-tx-wallet external
-    { address: 'Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr', amount: '1' },
-    // many-tx-wallet internal
-    { address: 'Ae2tdPwUPEZJZPsFg8w5bXA4brfu8peYy5prmrFiYPACb7DX64iiBY8WvHD', amount: '820000' },
-  ],
-  height: 100,
-  block_hash: '100',
-  tx_ordinal: 1,
-  time: '2019-04-20T15:15:33.000Z',
-  epoch: 0,
-  slot: 100,
-  last_update: '2019-05-20T23:16:51.899Z',
-  tx_state: 'Successful'
-};
-const manyTx4 = {
-  hash: cryptoRandomString({ length: 64 }),
-  inputs: [
-    {
-      // many-tx-wallet external
-      address: 'Ae2tdPwUPEYvzFpWJEGmSjLdz3DNY9WL5CbPjsouuM5M6YMsYWB1vsCS8j4',
-      txHash: distributorTx.hash,
-      id: distributorTx.hash + '7',
-      index: 7,
-      amount: '1000000'
-    }
-  ],
-  outputs: [
-    // many-tx-wallet external
-    { address: 'Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr', amount: '1' },
-    // many-tx-wallet internal
-    { address: 'Ae2tdPwUPEZHG9AGUYWqFcM5zFn74qdEx2TqyZxuU68CQ33EBodWAVJ523w', amount: '820000' },
-  ],
-  height: 100,
-  block_hash: '100',
-  tx_ordinal: 2,
-  time: '2019-04-20T15:15:33.000Z',
-  epoch: 0,
-  slot: 100,
-  last_update: '2019-05-20T23:16:51.899Z',
-  tx_state: 'Successful'
-};
-
-const useChange = {
-  hash: '0a073669845fea4ae83cd4418a0b4fd56610097a89601a816b5891f667e3496c',
-  inputs: [
-    {
-      address: 'Ae2tdPwUPEZ77uBBu8cMVxswVy1xfaMZR9wsUSwDNiB48MWqsVWfitHfUM9',
-      txHash: manyTx1.hash,
-      id: manyTx1.hash + '1',
-      index: 1,
-      amount: '820000'
-    }
-  ],
-  outputs: [
-    // many-tx-wallet external (index 30)
-    { address: 'Ae2tdPwUPEYzkKjrqPw1GHUty25Cj5fWrBVsWxiQYCxfoe2d9iLjTnt34Aj', amount: '1' },
-    // many-tx-wallet internal
-    { address: 'Ae2tdPwUPEZ7VKG9jy6jJTxQCWNXoMeL2Airvzjv3dc3WCLhSBA7XbSMhKd', amount: '650000' },
-  ],
-  height: 200,
-  block_hash: '200',
-  tx_ordinal: 0,
-  time: '2019-04-21T15:13:33.000Z',
-  epoch: 0,
-  slot: 200,
-  last_update: '2019-05-21T23:14:51.899Z',
-  tx_state: 'Successful'
-};
-
-export const postLaunchSuccessfulTx = {
-  hash: '350632adedd456cf607ed01a84f8c6c49d32f17e0e63447be7f7b69cb37ef446',
-  inputs: [
-    {
+      {
+        // Ae2tdPwUPEZLcUx5AGMACPyLAuVXHisVyNBuiSk3Ru7qddYyn9ujDp1Ejwr
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            9
+          ]
+        ),
+        amount: '1'
+      },
       // many-tx-wallet internal
-      address: 'Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3',
-      txHash: manyTx2.hash,
-      id: manyTx2.hash + '1',
-      index: 1,
-      amount: '820000'
-    }
-  ],
-  outputs: [
-    // address not belonging to any wallet
-    { address: 'Ae2tdPwUPEZCvDkc6R9oNE7Qh1yFLDyu4mpVbGhqUHkNsoVjd2UPiWGoVes', amount: '500000' },
-  ],
-  height: 202,
-  block_hash: '202',
-  tx_ordinal: 0,
-  time: '2019-04-22T15:15:33.000Z',
-  epoch: 0,
-  slot: 202,
-  last_update: '2019-05-22T23:16:51.899Z',
-  tx_state: 'Successful'
-};
+      {
+        // Ae2tdPwUPEZHG9AGUYWqFcM5zFn74qdEx2TqyZxuU68CQ33EBodWAVJ523w
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            3
+          ]
+        ),
+        amount: '820000'
+      },
+    ],
+    height: 100,
+    block_hash: '100',
+    tx_ordinal: 2,
+    time: '2019-04-20T15:15:33.000Z',
+    epoch: 0,
+    slot: 100,
+    last_update: '2019-05-20T23:16:51.899Z',
+    tx_state: 'Successful'
+  };
 
-export const postLaunchPendingTx = {
-  hash: '350632adedd456cf607ed01a84f8c6c49d32f17e0e63447be7f7b69cb37ef446',
-  inputs: [
-    {
+  const useChange = {
+    hash: '0a073669845fea4ae83cd4418a0b4fd56610097a89601a816b5891f667e3496c',
+    inputs: [
+      {
+        // Ae2tdPwUPEZ77uBBu8cMVxswVy1xfaMZR9wsUSwDNiB48MWqsVWfitHfUM9
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            0
+          ]
+        ),
+        txHash: manyTx1.hash,
+        id: manyTx1.hash + '1',
+        index: 1,
+        amount: '820000'
+      }
+    ],
+    outputs: [
+      // many-tx-wallet external (index 30)
+      {
+        // Ae2tdPwUPEYzkKjrqPw1GHUty25Cj5fWrBVsWxiQYCxfoe2d9iLjTnt34Aj
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            30
+          ]
+        ),
+        amount: '1'
+      },
       // many-tx-wallet internal
-      address: 'Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3',
-      txHash: manyTx2.hash,
-      id: manyTx2.hash + '1',
-      index: 1,
-      amount: '820000'
-    }
-  ],
-  outputs: [
-    // address not belonging to any wallet
-    { address: 'Ae2tdPwUPEZCvDkc6R9oNE7Qh1yFLDyu4mpVbGhqUHkNsoVjd2UPiWGoVes', amount: '500000' },
-  ],
-  height: 202,
-  block_hash: '202',
-  tx_ordinal: 1,
-  time: '2019-04-22T15:15:33.000Z',
-  epoch: 0,
-  slot: 202,
-  last_update: '2019-05-22T23:16:51.899Z',
-  tx_state: 'Pending'
-};
+      {
+        // Ae2tdPwUPEZ7VKG9jy6jJTxQCWNXoMeL2Airvzjv3dc3WCLhSBA7XbSMhKd
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            4
+          ]
+        ),
+        amount: '650000'
+      },
+    ],
+    height: 200,
+    block_hash: '200',
+    tx_ordinal: 0,
+    time: '2019-04-21T15:13:33.000Z',
+    epoch: 0,
+    slot: 200,
+    last_update: '2019-05-21T23:14:51.899Z',
+    tx_state: 'Successful'
+  };
 
-// ====================
-//   failed-single-tx
-// ====================
+  const postLaunchSuccessfulTx = {
+    hash: '350632adedd456cf607ed01a84f8c6c49d32f17e0e63447be7f7b69cb37ef446',
+    inputs: [
+      {
+        // Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            1
+          ]
+        ),
+        txHash: manyTx2.hash,
+        id: manyTx2.hash + '1',
+        index: 1,
+        amount: '820000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEZCdSLM7bHhoC6xptW9SRW155PFFf4WYCKnpX4JrxJPmFzi6G2
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '500000'
+      },
+    ],
+    height: 202,
+    block_hash: '202',
+    tx_ordinal: 0,
+    time: '2019-04-22T15:15:33.000Z',
+    epoch: 0,
+    slot: 202,
+    last_update: '2019-05-22T23:16:51.899Z',
+    tx_state: 'Successful'
+  };
 
-const failedTx = {
-  hash: 'fc6a5f086c0810de3048651ddd9075e6e5543bf59cdfe5e0c73bf1ed9dcec1ab',
-  inputs: [
-    {
-      address: 'Ae2tdPwUPEYw8ScZrAvKbxai1TzG7BGC4n8PoF9JzE1abgHc3gBfkkDNBNv',
-      txHash: distributorTx.hash,
-      id: distributorTx.hash + '8',
-      index: 8,
-      amount: '1000000'
-    }
-  ],
-  outputs: [
-    // address not belonging to any wallet
-    { address: 'Ae2tdPwUPEZCvDkc6R9oNE7Qh1yFLDyu4mpVbGhqUHkNsoVjd2UPiWGoVes', amount: '1' },
-    // failed-single-tx internal
-    { address: 'Ae2tdPwUPEZCqWsJkibw8BK2SgbmJ1rRG142Ru1CjSnRvKwDWbL4UYPN3eU', amount: '820000' },
-  ],
-  height: null,
-  block_hash: null,
-  tx_ordinal: null,
-  time: null,
-  epoch: null,
-  slot: null,
-  last_update: '2019-05-21T23:14:51.899Z',
-  tx_state: 'Failed'
+  const postLaunchPendingTx = {
+    hash: '350632adedd456cf607ed01a84f8c6c49d32f17e0e63447be7f7b69cb37ef446',
+    inputs: [
+      {
+        // Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3
+        address: getSingleAddressString(
+          testWallets['many-tx-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            1
+          ]
+        ),
+        txHash: manyTx2.hash,
+        id: manyTx2.hash + '1',
+        index: 1,
+        amount: '820000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEZCdSLM7bHhoC6xptW9SRW155PFFf4WYCKnpX4JrxJPmFzi6G2
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '500000'
+      },
+    ],
+    height: 202,
+    block_hash: '202',
+    tx_ordinal: 1,
+    time: '2019-04-22T15:15:33.000Z',
+    epoch: 0,
+    slot: 202,
+    last_update: '2019-05-22T23:16:51.899Z',
+    tx_state: 'Pending'
+  };
+
+  // ====================
+  //   failed-single-tx
+  // ====================
+
+  const failedTx = {
+    hash: 'fc6a5f086c0810de3048651ddd9075e6e5543bf59cdfe5e0c73bf1ed9dcec1ab',
+    inputs: [
+      {
+        // Ae2tdPwUPEYw8ScZrAvKbxai1TzG7BGC4n8PoF9JzE1abgHc3gBfkkDNBNv
+        address: getSingleAddressString(
+          testWallets['failed-single-tx'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '8',
+        index: 8,
+        amount: '1000000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEZCdSLM7bHhoC6xptW9SRW155PFFf4WYCKnpX4JrxJPmFzi6G2
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ]
+        ),
+        amount: '1'
+      },
+      // failed-single-tx internal
+      {
+        // Ae2tdPwUPEZCqWsJkibw8BK2SgbmJ1rRG142Ru1CjSnRvKwDWbL4UYPN3eU
+        address: getSingleAddressString(
+          testWallets['failed-single-tx'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            0
+          ]
+        ),
+        amount: '820000'
+      },
+    ],
+    height: null,
+    block_hash: null,
+    tx_ordinal: null,
+    time: null,
+    epoch: null,
+    slot: null,
+    last_update: '2019-05-21T23:14:51.899Z',
+    tx_state: 'Failed'
+  };
+
+  return {
+    genesisTx,
+    distributorTx,
+    pendingTx1,
+    pendingTx2,
+    manyTx1,
+    manyTx2,
+    manyTx3,
+    manyTx4,
+    useChange,
+    postLaunchSuccessfulTx,
+    postLaunchPendingTx,
+    failedTx,
+  };
 };
 
 // =================
@@ -391,23 +827,24 @@ export function resetChain() {
     transactions.pop();
   }
 
+  const txs = generateTransction();
   // test setup
-  addTransaction(genesisTx);
-  addTransaction(distributorTx);
+  addTransaction(txs.genesisTx);
+  addTransaction(txs.distributorTx);
   // test setup
-  addTransaction(genesisTx);
-  addTransaction(distributorTx);
+  addTransaction(txs.genesisTx);
+  addTransaction(txs.distributorTx);
   // simple-pending-wallet
-  addTransaction(pendingTx1);
-  addTransaction(pendingTx2);
+  addTransaction(txs.pendingTx1);
+  addTransaction(txs.pendingTx2);
   // many-tx-wallet
-  addTransaction(manyTx1);
-  addTransaction(manyTx2);
-  addTransaction(manyTx3);
-  addTransaction(manyTx4);
-  addTransaction(useChange);
+  addTransaction(txs.manyTx1);
+  addTransaction(txs.manyTx2);
+  addTransaction(txs.manyTx3);
+  addTransaction(txs.manyTx4);
+  addTransaction(txs.useChange);
   // failed-single-tx
-  addTransaction(failedTx);
+  addTransaction(txs.failedTx);
 }
 
 // =========================

--- a/features/step_definitions/transactions-steps.js
+++ b/features/step_definitions/transactions-steps.js
@@ -4,7 +4,7 @@ import { Given, When, Then } from 'cucumber';
 import { By } from 'selenium-webdriver';
 import { expect } from 'chai';
 import i18n from '../support/helpers/i18n-helpers';
-import { addTransaction, postLaunchSuccessfulTx, postLaunchPendingTx } from '../mock-chain/mockImporter';
+import { addTransaction, generateTransction, } from '../mock-chain/mockImporter';
 
 Given(/^I have a wallet with funds$/, async function () {
   const amountWithCurrency = await this.driver.findElements(By.xpath("//div[@class='WalletTopbarTitle_walletAmount']"));
@@ -119,11 +119,13 @@ Then(/^I should see an incorrect wallet password error message$/, async function
 });
 
 Then(/^A successful tx gets sent from my wallet from another client$/, () => {
-  addTransaction(postLaunchSuccessfulTx);
+  const txs = generateTransction();
+  addTransaction(txs.postLaunchSuccessfulTx);
 });
 
 Then(/^A pending tx gets sent from my wallet from another client$/, () => {
-  addTransaction(postLaunchPendingTx);
+  const txs = generateTransction();
+  addTransaction(txs.postLaunchPendingTx);
 });
 
 Then(/^I should see a warning block$/, async function () {

--- a/features/step_definitions/tx-history-steps.js
+++ b/features/step_definitions/tx-history-steps.js
@@ -182,7 +182,7 @@ const displayInfo = {
     txStatus: 'FAILED',
     txFrom: ['Ae2tdPwUPEYw8ScZrAvKbxai1TzG7BGC4n8PoF9JzE1abgHc3gBfkkDNBNv'],
     txTo: [
-      'Ae2tdPwUPEZCvDkc6R9oNE7Qh1yFLDyu4mpVbGhqUHkNsoVjd2UPiWGoVes',
+      'Ae2tdPwUPEZCdSLM7bHhoC6xptW9SRW155PFFf4WYCKnpX4JrxJPmFzi6G2',
       'Ae2tdPwUPEZCqWsJkibw8BK2SgbmJ1rRG142Ru1CjSnRvKwDWbL4UYPN3eU',
     ],
     txId: 'fc6a5f086c0810de3048651ddd9075e6e5543bf59cdfe5e0c73bf1ed9dcec1ab',


### PR DESCRIPTION
To be able to run the mockchain with Shelley addresses it's easiest to enable WASM usage for the mockchain generation.

I don't enable anything Shelley-specific in this PR. Just legacy mockchain generated with wasm instead of constant strings