### PR TITLE
Set Yoroi's total amount to Seiza's userADA [ch2339]

### DIFF
--- a/app/containers/wallet/staking/StakingPage.js
+++ b/app/containers/wallet/staking/StakingPage.js
@@ -5,6 +5,7 @@ import { defineMessages, intlShape } from 'react-intl';
 import SeizaFetcher from './SeizaFetcher';
 import InformativeError from '../../../components/widgets/InformativeError';
 import VerticallyCenteredLayout from '../../../components/layout/VerticallyCenteredLayout';
+import { formattedAmountWithoutLovelace } from '../../../utils/formatters';
 
 import type { InjectedProps } from '../../../types/injectedPropsType';
 
@@ -30,6 +31,19 @@ export default class StakingPage extends Component<Props> {
     intl: intlShape.isRequired,
   };
 
+  prepareStakingURL(): string {
+    let finalURL = this.props.stakingUrl;
+
+    // Add userAda
+    const publicDeriver = this.props.stores.substores.ada.wallets.selected;
+    if (publicDeriver) {
+      // Seiza does not understand decimal places, so removing all Lovelaces
+      finalURL += `&userAda=${formattedAmountWithoutLovelace(publicDeriver.amount)}`;
+    }
+
+    return finalURL;
+  }
+
   render() {
     const { stores } = this.props;
     const { intl } = this.context;
@@ -43,6 +57,6 @@ export default class StakingPage extends Component<Props> {
           />
         </VerticallyCenteredLayout>
       )
-      : (<SeizaFetcher {...this.props} stores={stores} stakingUrl={this.props.stakingUrl} />);
+      : (<SeizaFetcher {...this.props} stores={stores} stakingUrl={this.prepareStakingURL()} />);
   }
 }

--- a/app/utils/formatters.js
+++ b/app/utils/formatters.js
@@ -6,6 +6,15 @@ export const formattedWalletAmount = (amount: BigNumber): string => (
   amount.toFormat(DECIMAL_PLACES_IN_ADA)
 );
 
+/**
+ * Just removes all Lovelaces, without decimal place (does not round off)
+ * e.g 3657.9345 => 3657
+ * @param {*} amount
+ */
+export const formattedAmountWithoutLovelace = (amount: BigNumber): string => (
+  amount.decimalPlaces(0, 3).toString() // 3 = ROUND_FLOOR
+);
+
 /** removes commas */
 export const formattedAmountToBigNumber = (amount: string) => {
   const cleanedAmount = amount.replace(/,/g, '');


### PR DESCRIPTION
Adds **userAda** param in Seiza's URL for Yoroi:
http://localhost:3001/staking/list?sortBy=REVENUE&searchText=&performance[]=0&performance[]=100&source=chrome&userAda=220

Note:
Seiza does not supports amount in decimal places so needed to format before passing.