### PR TITLE
Decouple discriminant from network name

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -578,9 +578,7 @@ export default class AdaApi {
       words.join(' '),
       0, // paper wallets always use account 0
       request.numAddresses != null ? request.numAddresses : DEFAULT_ADDRESSES_PER_PAPER,
-      environment.isMainnet()
-        ? RustModule.WalletV3.AddressDiscrimination.Production
-        : RustModule.WalletV3.AddressDiscrimination.Test,
+      environment.getDiscriminant(),
       request.legacy,
     );
     return { addresses, scrambledWords, accountPlate };

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -1193,9 +1193,7 @@ export default class AdaApi {
       if (environment.isShelley()) {
         const wallet = await createStandardCip1852Wallet({
           db: request.db,
-          discrimination: environment.isMainnet()
-            ? RustModule.WalletV3.AddressDiscrimination.Production
-            : RustModule.WalletV3.AddressDiscrimination.Test,
+          discrimination: environment.getDiscriminant(),
           rootPk,
           password: walletPassword,
           accountIndex,

--- a/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1231,9 +1231,7 @@ async function certificateToDb(
   const accountToId = async (account: RustModule.WalletV3.Account): Promise<number> => {
     const address = account.to_address(
       // TODO: should come from the public deriver, not environment
-      environment.isMainnet()
-        ? RustModule.WalletV3.AddressDiscrimination.Production
-        : RustModule.WalletV3.AddressDiscrimination.Test,
+      environment.getDiscriminant(),
     );
     const hash = Buffer.from(address.as_bytes()).toString('hex');
     const idMap = await request.hashToIds({

--- a/app/api/ada/restoration/shelley/scan.js
+++ b/app/api/ada/restoration/shelley/scan.js
@@ -154,9 +154,7 @@ export async function scanCip1852Account(request: {
   const key = RustModule.WalletV3.Bip32PublicKey.from_bytes(
     Buffer.from(request.accountPublicKey, 'hex'),
   );
-  const discrimination = environment.isMainnet()
-    ? RustModule.WalletV3.AddressDiscrimination.Production
-    : RustModule.WalletV3.AddressDiscrimination.Test;
+  const discrimination = environment.getDiscriminant();
 
   const insert = await scanAccount({
     generateInternalAddresses: genSingleAddressBatchFunc(

--- a/app/components/settings/categories/general-setting/AboutYoroiSettingsBlock.js
+++ b/app/components/settings/categories/general-setting/AboutYoroiSettingsBlock.js
@@ -147,7 +147,7 @@ export default class AboutYoroiSettingsBlock extends Component<{}> {
             </RawHash>
           </ExplorableHash>
         </div>
-        {!environment.isMainnet() &&
+        {!environment.isProduction() &&
           <div className={styles.aboutLine}>
             <strong>{intl.formatMessage(messages.branchLabel)}</strong>&nbsp;
             <ExplorableHash

--- a/app/components/topbar/banners/TestnetWarningBanner.js
+++ b/app/components/topbar/banners/TestnetWarningBanner.js
@@ -31,7 +31,7 @@ export default class TestnetWarningBanner extends Component<Props> {
   };
 
   render() {
-    if (environment.isMainnet()) {
+    if (environment.isProduction() && !environment.isShelley()) {
       // banner will not shown in Mainnet
       return (null);
     }

--- a/app/containers/transfer/YoroiPlatePage.js
+++ b/app/containers/transfer/YoroiPlatePage.js
@@ -45,9 +45,7 @@ export default class YoroiPlatePage extends Component<Props, WalletRestoreDialog
       yoroiTransfer.recoveryPhrase,
       0, // show addresses for account #0
       numAddresses,
-      environment.isMainnet()
-        ? RustModule.WalletV3.AddressDiscrimination.Production
-        : RustModule.WalletV3.AddressDiscrimination.Test,
+      environment.getDiscriminant(),
       true,
     );
     const shelleyPlate = yoroiTransfer.transferKind === TransferKind.PAPER
@@ -56,9 +54,7 @@ export default class YoroiPlatePage extends Component<Props, WalletRestoreDialog
         yoroiTransfer.recoveryPhrase,
         0, // show addresses for account #0
         numAddresses,
-        environment.isMainnet()
-          ? RustModule.WalletV3.AddressDiscrimination.Production
-          : RustModule.WalletV3.AddressDiscrimination.Test,
+        environment.getDiscriminant(),
         false,
       );
     return {

--- a/app/environment.js
+++ b/app/environment.js
@@ -4,6 +4,8 @@ import type { ConfigType, Network } from '../config/config-types';
 import { NetworkType } from '../config/config-types';
 import type { UserAgentInfo } from './utils/userAgentInfo';
 import userAgentInfo from './utils/userAgentInfo';
+import type { AddressDiscriminationType } from '@emurgo/js-chain-libs/js_chain_libs';
+import { RustModule } from './api/ada/lib/cardanoCrypto/rustLoader';
 
 // populated by ConfigWebpackPlugin
 declare var CONFIG: ConfigType;
@@ -37,11 +39,17 @@ export const environment = ((
     },
     isShelley: () => {
       return CONFIG.network.name === NetworkType.SHELLEY_DEV ||
-        CONFIG.network.name === NetworkType.SHELLEY_TESTNET;
+        CONFIG.network.name === NetworkType.SHELLEY_TESTNET ||
+        CONFIG.network.name === NetworkType.TEST;
     },
     isTest: () => CONFIG.network.name === NetworkType.TEST,
-    isMainnet: () => environment.NETWORK === NetworkType.MAINNET ||
-      CONFIG.network.name === NetworkType.TEST,
+    isMainnet: () => environment.NETWORK === NetworkType.MAINNET,
+    isProduction: () => environment.NETWORK === NetworkType.MAINNET ||
+      CONFIG.network.name === NetworkType.SHELLEY_TESTNET,
+    getDiscriminant: () => {
+      // currently all networks use test discrimination
+      return RustModule.WalletV3.AddressDiscrimination.Test;
+    },
     isAdaApi: () => environment.API === 'ada',
     walletRefreshInterval: CONFIG.app.walletRefreshInterval,
     serverStatusRefreshInterval: CONFIG.app.serverStatusRefreshInterval,
@@ -60,7 +68,9 @@ export const environment = ((
   isShelley: void => boolean,
   isTest: void => boolean,
   isMainnet: void => boolean,
+  isProduction: void => boolean,
   isAdaApi: void => boolean,
+  getDiscriminant: void => AddressDiscriminationType,
   walletRefreshInterval: number,
   serverStatusRefreshInterval: number,
   userAgentInfo: UserAgentInfo

--- a/app/environment.js
+++ b/app/environment.js
@@ -39,15 +39,16 @@ export const environment = ((
     },
     isShelley: () => {
       return CONFIG.network.name === NetworkType.SHELLEY_DEV ||
-        CONFIG.network.name === NetworkType.SHELLEY_TESTNET ||
-        CONFIG.network.name === NetworkType.TEST;
+        CONFIG.network.name === NetworkType.SHELLEY_TESTNET;
     },
     isTest: () => CONFIG.network.name === NetworkType.TEST,
     isMainnet: () => environment.NETWORK === NetworkType.MAINNET,
     isProduction: () => environment.NETWORK === NetworkType.MAINNET ||
       CONFIG.network.name === NetworkType.SHELLEY_TESTNET,
     getDiscriminant: () => {
-      // currently all networks use test discrimination
+      if (CONFIG.network.name === NetworkType.TEST || process.env.NODE_ENV === 'jest') {
+        return RustModule.WalletV3.AddressDiscrimination.Production;
+      }
       return RustModule.WalletV3.AddressDiscrimination.Test;
     },
     isAdaApi: () => environment.API === 'ada',

--- a/app/stores/ada/WalletRestoreStore.js
+++ b/app/stores/ada/WalletRestoreStore.js
@@ -104,9 +104,7 @@ export default class WalletRestoreStore extends Store {
     const internalAddr = RustModule.WalletV3.Address.delegation_from_public_key(
       internalKey,
       stakingKey,
-      environment.isMainnet()
-        ? RustModule.WalletV3.AddressDiscrimination.Production
-        : RustModule.WalletV3.AddressDiscrimination.Test,
+      environment.getDiscriminant(),
     );
     const internalAddrHash = Buffer.from(internalAddr.as_bytes()).toString('hex');
     return internalAddrHash;
@@ -177,9 +175,7 @@ export default class WalletRestoreStore extends Store {
       this.mode === RestoreMode.PAPER
         ? NUMBER_OF_VERIFIED_ADDRESSES_PAPER
         : NUMBER_OF_VERIFIED_ADDRESSES,
-      environment.isMainnet()
-        ? RustModule.WalletV3.AddressDiscrimination.Production
-        : RustModule.WalletV3.AddressDiscrimination.Test,
+      environment.getDiscriminant(),
       true,
     );
     // TODO: we disable shelley restoration information for paper wallet restoration
@@ -193,9 +189,7 @@ export default class WalletRestoreStore extends Store {
         this.mode === RestoreMode.PAPER
           ? NUMBER_OF_VERIFIED_ADDRESSES_PAPER
           : NUMBER_OF_VERIFIED_ADDRESSES,
-        environment.isMainnet()
-          ? RustModule.WalletV3.AddressDiscrimination.Production
-          : RustModule.WalletV3.AddressDiscrimination.Test,
+        environment.getDiscriminant(),
         false,
       );
 

--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -21,7 +21,7 @@ export default class ProfileStore extends Store {
 
   LANGUAGE_OPTIONS = [
     ...LANGUAGES,
-    ...(!environment.isMainnet()
+    ...(!environment.isProduction()
       ? [
         // add any language that's mid-translation here
       ]

--- a/app/stores/toplevel/WalletBackupStore.js
+++ b/app/stores/toplevel/WalletBackupStore.js
@@ -68,7 +68,7 @@ class WalletBackupStore extends Store {
     this.isEntering = false;
     this.isTermDeviceAccepted = false;
     this.isTermRecoveryAccepted = false;
-    this.countdownRemaining = !environment.isMainnet() ? 0 : 10;
+    this.countdownRemaining = !environment.isProduction() ? 0 : 10;
     clearInterval(this.countdownTimerInterval);
     this.countdownTimerInterval = setInterval(() => {
       if (this.countdownRemaining > 0) {


### PR DESCRIPTION
We used to couple the discriminant to the network name but that's not really accurate and it caused issues because `isMainnet` wouldn't trigger on ITN builds. I instead split this into two settings: `isProduction` and `getDiscriminant`