### PR TITLE
Cancel fee calculation on input

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -32,6 +32,6 @@ export default {
     }
   },
   forms: {
-    FORM_VALIDATION_DEBOUNCE_WAIT: 250
+    FORM_VALIDATION_DEBOUNCE_WAIT: 500
   },
 };


### PR DESCRIPTION
This should fix two issues with the send screen "amount" field:

1) The debounce was too short and sometimes started calculating the tx fee while you were still typing in numbers. `500` seemed to do much better

2) Instead of awaiting for the current fee calculation to end before starting the next one, I just cancel the request. The "cancel" feature doesn't actually cancel the request -- is just indicates that the result should be discarded whenever it's done. This is much easier than actually making it cancelable.