### PR TITLE
Detect server error in account state

### DIFF
--- a/app/components/wallet/staking/dashboard/StakingDashboard.js
+++ b/app/components/wallet/staking/dashboard/StakingDashboard.js
@@ -11,6 +11,9 @@ import WarningBox from '../../../widgets/WarningBox';
 import InformativeError from '../../../widgets/InformativeError';
 import LoadingSpinner from '../../../widgets/LoadingSpinner';
 import VerticallyCenteredLayout from '../../../layout/VerticallyCenteredLayout';
+import LocalizableError from '../../../../i18n/LocalizableError';
+import InvalidURIImg from '../../../../assets/images/uri/invalid-uri.inline.svg';
+import ErrorBlock from '../../../widgets/ErrorBlock';
 
 const messages = defineMessages({
   positionsLabel: {
@@ -42,7 +45,7 @@ type Props = {|
   themeVars: Object,
   totalGraphData: Array<Object>,
   positionsGraphData: Array<Object>,
-  stakePools: null | Array<Node>,
+  stakePools: {| error: LocalizableError, |} | {| pools: null | Array<Node> |},
   epochProgress: Node,
   userSummary: Node,
   rewardPopup: void | Node,
@@ -121,14 +124,24 @@ export default class StakingDashboard extends Component<Props> {
 
   displayStakePools: void => Node = () => {
     const { intl } = this.context;
-    if (this.props.stakePools == null) {
+    if (this.props.stakePools.error) {
+      return (
+        <div className={styles.poolError}>
+          <center><InvalidURIImg /></center>
+          <ErrorBlock
+            error={this.props.stakePools.error}
+          />
+        </div>
+      );
+    }
+    if (this.props.stakePools.pools === null) {
       return (
         <VerticallyCenteredLayout>
           <LoadingSpinner />
         </VerticallyCenteredLayout>
       );
     }
-    if (this.props.stakePools.length === 0) {
+    if (this.props.stakePools.pools.length === 0) {
       return (
         <InformativeError
           title={intl.formatMessage(emptyDashboardMessages.title)}
@@ -139,7 +152,7 @@ export default class StakingDashboard extends Component<Props> {
     return (
       <div className={styles.bodyWrapper}>
         <div className={styles.stakePool}>
-          {this.props.stakePools}
+          {this.props.stakePools.pools}
         </div>
       </div>
     );

--- a/app/components/wallet/staking/dashboard/StakingDashboard.scss
+++ b/app/components/wallet/staking/dashboard/StakingDashboard.scss
@@ -17,6 +17,10 @@
   flex: 1;
 }
 
+.poolError {
+  margin-top: 42px;
+}
+
 .rewards {
   min-width: 420px;
   align-self: flex-end;

--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -105,6 +105,10 @@ export default class StakingDashboardPage extends Component<Props, State> {
       ? this.getStakePools()
       : errorIfPresent;
 
+    const showRewardAmount = delegationStore.getCurrentDelegation.wasExecuted &&
+      delegationStore.getCurrentDelegation.result != null &&
+      delegationStore.getDelegatedBalance.wasExecuted &&
+      errorIfPresent == null;
     const { getThemeVars } = this.props.stores.profile;
     return (
       <StakingDashboard
@@ -118,7 +122,7 @@ export default class StakingDashboardPage extends Component<Props, State> {
             : hideOrFormat(publicDeriver.amount)
           }
           totalRewards={
-            delegationStore.getDelegatedBalance.result == null || errorIfPresent != null
+            !showRewardAmount || delegationStore.getDelegatedBalance.result == null
               ? undefined
               : hideOrFormat(
                 delegationStore.getDelegatedBalance.result
@@ -127,7 +131,7 @@ export default class StakingDashboardPage extends Component<Props, State> {
               )
           }
           totalDelegated={
-            delegationStore.getDelegatedBalance.result == null || errorIfPresent != null
+            !showRewardAmount || delegationStore.getDelegatedBalance.result == null
               ? undefined
               : hideOrFormat(
                 delegationStore.getDelegatedBalance.result.utxoPart.plus(

--- a/app/stores/ada/DelegationStore.js
+++ b/app/stores/ada/DelegationStore.js
@@ -19,6 +19,7 @@ import type {
   AccountStateSuccess,
   RemotePoolMetaSuccess,
 } from '../../api/ada/lib/state-fetch/types';
+import LocalizableError from '../../i18n/LocalizableError';
 
 export default class DelegationStore extends Store {
 
@@ -27,6 +28,8 @@ export default class DelegationStore extends Store {
 
   @observable getCurrentDelegation: LocalizedRequest<GetCurrentDelegationFunc>
     = new LocalizedRequest<GetCurrentDelegationFunc>(getCurrentDelegation);
+
+  @observable error: LocalizableError | any;
 
   @observable stakingKeyState: void | {|
     state: AccountStateSuccess,
@@ -59,72 +62,79 @@ export default class DelegationStore extends Store {
       ],
       // $FlowFixMe error in mobx types
       async () => {
-        this.getDelegatedBalance.reset();
-        this.getCurrentDelegation.reset();
-        runInAction(() => {
-          this.stakingKeyState = undefined;
-        });
-
-        const publicDeriver = this.stores.substores.ada.wallets.selected;
-        if (publicDeriver == null) {
-          throw new Error(`${nameof(this._startWatch)} no public deriver selected`);
-        }
-        const withStakingKey = asGetAllAccounting(publicDeriver.self);
-        if (withStakingKey == null) {
-          throw new Error(`${nameof(this._startWatch)} missing staking key functionality`);
-        }
-
-        const stakingKeyResp = await withStakingKey.getStakingKey();
-
-        const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
-        const accountStateResp = await stateFetcher.getAccountState({
-          addresses: [stakingKeyResp.addr.Hash],
-        });
-        const stateForStakingKey = accountStateResp[stakingKeyResp.addr.Hash];
-
-        if (!stateForStakingKey.delegation) {
-          return runInAction(() => {
+        try {
+          this.getDelegatedBalance.reset();
+          this.getCurrentDelegation.reset();
+          runInAction(() => {
+            this.error = undefined;
             this.stakingKeyState = undefined;
-            throw new Error(`${nameof(this._startWatch)} stake key invalid - ${stateForStakingKey.comment}`);
           });
-        }
-        const poolInfoResp = await stateFetcher.getPoolInfo({
-          ids: stateForStakingKey.delegation.pools.map(delegation => delegation[0]),
-        });
-        const meta = new Map(stateForStakingKey.delegation.pools.map(delegation => {
-          const info = poolInfoResp[delegation[0]];
-          if (!info.history) {
+
+          const publicDeriver = this.stores.substores.ada.wallets.selected;
+          if (publicDeriver == null) {
+            throw new Error(`${nameof(this._startWatch)} no public deriver selected`);
+          }
+          const withStakingKey = asGetAllAccounting(publicDeriver.self);
+          if (withStakingKey == null) {
+            throw new Error(`${nameof(this._startWatch)} missing staking key functionality`);
+          }
+
+          const stakingKeyResp = await withStakingKey.getStakingKey();
+
+          const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
+          const accountStateResp = await stateFetcher.getAccountState({
+            addresses: [stakingKeyResp.addr.Hash],
+          });
+          const stateForStakingKey = accountStateResp[stakingKeyResp.addr.Hash];
+
+          if (!stateForStakingKey.delegation) {
             return runInAction(() => {
               this.stakingKeyState = undefined;
-              throw new Error(`${nameof(this._startWatch)} pool info missing ${info.error}`);
+              throw new Error(`${nameof(this._startWatch)} stake key invalid - ${stateForStakingKey.comment}`);
             });
           }
-          return [delegation[0], info];
-        }));
-        runInAction(() => {
-          this.stakingKeyState = {
-            state: stateForStakingKey,
-            poolInfo: meta,
-          };
-        });
+          const poolInfoResp = await stateFetcher.getPoolInfo({
+            ids: stateForStakingKey.delegation.pools.map(delegation => delegation[0]),
+          });
+          const meta = new Map(stateForStakingKey.delegation.pools.map(delegation => {
+            const info = poolInfoResp[delegation[0]];
+            if (!info.history) {
+              return runInAction(() => {
+                this.stakingKeyState = undefined;
+                throw new Error(`${nameof(this._startWatch)} pool info missing ${info.error}`);
+              });
+            }
+            return [delegation[0], info];
+          }));
+          runInAction(() => {
+            this.stakingKeyState = {
+              state: stateForStakingKey,
+              poolInfo: meta,
+            };
+          });
 
-        const delegatedBalance = this.getDelegatedBalance.execute({
-          publicDeriver: withStakingKey,
-          accountState: stateForStakingKey,
-          stakingPubKey: stakingKeyResp.addr.Hash,
-        }).promise;
-        if (delegatedBalance == null) throw new Error('Should never happen');
+          const delegatedBalance = this.getDelegatedBalance.execute({
+            publicDeriver: withStakingKey,
+            accountState: stateForStakingKey,
+            stakingPubKey: stakingKeyResp.addr.Hash,
+          }).promise;
+          if (delegatedBalance == null) throw new Error('Should never happen');
 
-        const currentDelegation = this.getCurrentDelegation.execute({
-          publicDeriver: withStakingKey,
-          stakingKeyAddressId: stakingKeyResp.addr.AddressId,
-        }).promise;
-        if (currentDelegation == null) throw new Error('Should never happen');
+          const currentDelegation = this.getCurrentDelegation.execute({
+            publicDeriver: withStakingKey,
+            stakingKeyAddressId: stakingKeyResp.addr.AddressId,
+          }).promise;
+          if (currentDelegation == null) throw new Error('Should never happen');
 
-        await Promise.all([
-          delegatedBalance,
-          currentDelegation,
-        ]);
+          await Promise.all([
+            delegatedBalance,
+            currentDelegation,
+          ]);
+        } catch (e) {
+          runInAction(() => {
+            this.error = e;
+          });
+        }
       },
     );
   }
@@ -136,5 +146,6 @@ export default class DelegationStore extends Store {
     this.getDelegatedBalance.reset();
     this.getCurrentDelegation.reset();
     this.stakingKeyState = undefined;
+    this.error = undefined;
   }
 }

--- a/chrome/constants.js
+++ b/chrome/constants.js
@@ -8,7 +8,7 @@ import {
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 
 export const Version = {
-  Shelley: '2.2.1',
+  Shelley: '2.2.2',
   Byron: '1.10.0',
 };
 


### PR DESCRIPTION
Due to instability of the node, sometimes the server is down or the account state endpoint returns the wrong result. To avoid users panicking, I try and detect these errors client-side and report an error in the UI

Notably
1) Show an error message to the user instead of saying their ADA is not delegated
2) Show the "total rewards" and "total delegated" as spinners instead of 0 ADA

![image](https://user-images.githubusercontent.com/2608559/71236834-470c7080-2343-11ea-8fea-7c55a7bddb76.png)
![image](https://user-images.githubusercontent.com/2608559/71236839-496eca80-2343-11ea-97ec-7e29e15c410b.png)
