### PR TITLE
Use per-certificate fee

### DIFF
--- a/app/api/ada/lib/test-config.js
+++ b/app/api/ada/lib/test-config.js
@@ -28,7 +28,11 @@ const CONFIG: ConfigType = {
     linearFee: {
       constant: '155381',
       coefficient: '1',
-      certificate: '4'
+      certificate: '4',
+      per_certificate_fees: {
+        certificate_pool_registration: '5',
+        certificate_stake_delegation: '6',
+      },
     },
     genesisHash: 'adbdd5ede31637f6c9bad5c271eec0bc3d0cb9efb86a5b913bb55cba549d0770',
   }

--- a/app/api/ada/transactions/shelley/accountingTransactions.js
+++ b/app/api/ada/transactions/shelley/accountingTransactions.js
@@ -6,7 +6,7 @@ import {
 import type { ConfigType } from '../../../../../config/config-types';
 import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
 import BigNumber from 'bignumber.js';
-import { generateAuthData } from './utils';
+import { generateAuthData, generateFee, } from './utils';
 
 declare var CONFIG: ConfigType;
 
@@ -36,11 +36,7 @@ export function buildUnsignedAccountTx(
     : RustModule.WalletV3.Payload.no_payload();
   const sourceAccount = RustModule.WalletV3.Account.single_from_public_key(sender);
 
-  const feeAlgorithm = RustModule.WalletV3.Fee.linear_fee(
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.constant),
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.coefficient),
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.certificate),
-  );
+  const feeAlgorithm = generateFee();
 
   let fee;
   {

--- a/app/api/ada/transactions/shelley/utxoTransactions.js
+++ b/app/api/ada/transactions/shelley/utxoTransactions.js
@@ -20,7 +20,7 @@ import type {
   Address, Value, Addressing,
   IGetAllUtxosResponse
 } from '../../lib/storage/models/PublicDeriver/interfaces';
-import { generateAuthData, normalizeKey, } from './utils';
+import { generateAuthData, normalizeKey, generateFee, } from './utils';
 
 declare var CONFIG: ConfigType;
 
@@ -83,11 +83,7 @@ export function sendAllUnsignedTxFromUtxo(
     throw new NotEnoughMoneyToSendError();
   }
 
-  const feeAlgorithm = RustModule.WalletV3.Fee.linear_fee(
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.constant),
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.coefficient),
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.certificate),
-  );
+  const feeAlgorithm = generateFee();
   let fee;
   {
     // firts build a transaction to see what the cost would be
@@ -181,11 +177,7 @@ export function newAdaUnsignedTxFromUtxo(
   allUtxos: Array<RemoteUnspentOutput>,
   certificate: void | RustModule.WalletV3.Certificate,
 ): V3UnsignedTxUtxoResponse {
-  const feeAlgorithm = RustModule.WalletV3.Fee.linear_fee(
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.constant),
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.coefficient),
-    RustModule.WalletV3.Value.from_str(CONFIG.genesis.linearFee.certificate),
-  );
+  const feeAlgorithm = generateFee();
 
   const ioBuilder = RustModule.WalletV3.InputOutputBuilder.empty();
   for (const output of outputs) {

--- a/app/api/ada/transactions/shelley/utxoTransactions.test.js
+++ b/app/api/ada/transactions/shelley/utxoTransactions.test.js
@@ -349,6 +349,22 @@ describe('Create signed transactions', () => {
   });
 
   it('Transaction with a certificate and output is also valid', () => {
+    const accountPrivateKey = RustModule.WalletV3.Bip32PrivateKey.from_bytes(
+      Buffer.from(
+        '408a1cb637d615c49e8696c30dd54883302a20a7b9b8a9d1c307d2ed3cd50758c9402acd000461a8fc0f25728666e6d3b86d031b8eea8d2f69b21e8aa6ba2b153e3ec212cc8a36ed9860579dfe1e3ef4d6de778c5dbdd981623b48727cd96247',
+        'hex',
+      ),
+    );
+    const stakingKey = accountPrivateKey.derive(2).derive(STAKING_KEY_INDEX).to_raw_key();
+    const certificate = RustModule.WalletV3.Certificate.stake_delegation(
+      RustModule.WalletV3.StakeDelegation.new(
+        RustModule.WalletV3.DelegationType.full(
+          RustModule.WalletV3.PoolId.from_hex('312e3d449038372ba2fc3300cfedf1b152ae739201b3e5da47ab3f933a421b62')
+        ),
+        stakingKey.to_public()
+      )
+    );
+
     const unsignedTxResponse = newAdaUnsignedTx(
       [{
         address: Buffer.from(RustModule.WalletV3.Address.from_string(
@@ -378,23 +394,9 @@ describe('Create signed transactions', () => {
           startLevel: Bip44DerivationLevels.CHAIN.level,
         },
       }],
+      certificate,
     );
 
-    const accountPrivateKey = RustModule.WalletV3.Bip32PrivateKey.from_bytes(
-      Buffer.from(
-        '408a1cb637d615c49e8696c30dd54883302a20a7b9b8a9d1c307d2ed3cd50758c9402acd000461a8fc0f25728666e6d3b86d031b8eea8d2f69b21e8aa6ba2b153e3ec212cc8a36ed9860579dfe1e3ef4d6de778c5dbdd981623b48727cd96247',
-        'hex',
-      ),
-    );
-    const stakingKey = accountPrivateKey.derive(2).derive(STAKING_KEY_INDEX).to_raw_key();
-    const certificate = RustModule.WalletV3.Certificate.stake_delegation(
-      RustModule.WalletV3.StakeDelegation.new(
-        RustModule.WalletV3.DelegationType.full(
-          RustModule.WalletV3.PoolId.from_hex('312e3d449038372ba2fc3300cfedf1b152ae739201b3e5da47ab3f933a421b62')
-        ),
-        stakingKey.to_public()
-      )
-    );
     const fragment = signTransaction(
       unsignedTxResponse,
       Bip44DerivationLevels.ACCOUNT.level,
@@ -418,19 +420,35 @@ describe('Create signed transactions', () => {
     expect(outputs.size()).toEqual(2);
     const change = outputs.get(1);
     expect(change.address().to_string(Bech32Prefix.ADDRESS)).toEqual('addr1s5quq8utjkrfntnkngjxa9u9mdd8pcprjal2fwzkm7k0y0prx3k276qm0j8');
-    expect(change.value().to_str()).toEqual('1839616');
+    expect(change.value().to_str()).toEqual('1839610');
 
-    expect(Buffer.from(fragment.id().as_bytes()).toString('hex')).toEqual('c3ef21699ee8937527b83942980b0739353ddd133f627d40832b98d3ef416a6d');
-    expect(Buffer.from(fragment.get_transaction().id().as_bytes()).toString('hex')).toEqual('314ea630977b20d21cc2dc8f861dc9bcfa2013dcbc32c75288d7a5067274662d');
+    expect(Buffer.from(fragment.id().as_bytes()).toString('hex')).toEqual('368f5b1b46c661b57e2d2c2e1715dea470900918f4f6e82e6060a0d91915985d');
+    expect(Buffer.from(fragment.get_transaction().id().as_bytes()).toString('hex')).toEqual('e48d9ae0957ebf9c6deb9eae861366e268522db78ae6077f688e4bb9f4791f85');
 
     const witnesses = signedTx.witnesses();
     expect(witnesses.size()).toEqual(1);
     expect(witnesses.get(0).to_bech32()).toEqual(
-      'witness1q89jcq78wt4u773vrrjjwuqg8908wpyuv5j3sdj0mcs4dpe667f97yfc0k48dae9u29r07nkms764js84tgwxr09ah6e948s2u6ye8cgyzhd4j'
+      'witness1q8m9yyyhx4dp3v220v4h7gtm3yv69x0u9amy3yllksphnhgeufj0s6ayncn33krpjp2vccv78d20nx20wd4upd9gtv0vum5c5v9f7qcplf5phl'
     );
   });
 
   it('Transaction with a certificate without output is also valid', () => {
+    const accountPrivateKey = RustModule.WalletV3.Bip32PrivateKey.from_bytes(
+      Buffer.from(
+        '408a1cb637d615c49e8696c30dd54883302a20a7b9b8a9d1c307d2ed3cd50758c9402acd000461a8fc0f25728666e6d3b86d031b8eea8d2f69b21e8aa6ba2b153e3ec212cc8a36ed9860579dfe1e3ef4d6de778c5dbdd981623b48727cd96247',
+        'hex',
+      ),
+    );
+    const stakingKey = accountPrivateKey.derive(2).derive(STAKING_KEY_INDEX).to_raw_key();
+    const certificate = RustModule.WalletV3.Certificate.stake_delegation(
+      RustModule.WalletV3.StakeDelegation.new(
+        RustModule.WalletV3.DelegationType.full(
+          RustModule.WalletV3.PoolId.from_hex('312e3d449038372ba2fc3300cfedf1b152ae739201b3e5da47ab3f933a421b62')
+        ),
+        stakingKey.to_public()
+      )
+    );
+
     const unsignedTxResponse = newAdaUnsignedTx(
       [],
       [{
@@ -455,23 +473,9 @@ describe('Create signed transactions', () => {
           startLevel: Bip44DerivationLevels.CHAIN.level,
         },
       }],
+      certificate,
     );
 
-    const accountPrivateKey = RustModule.WalletV3.Bip32PrivateKey.from_bytes(
-      Buffer.from(
-        '408a1cb637d615c49e8696c30dd54883302a20a7b9b8a9d1c307d2ed3cd50758c9402acd000461a8fc0f25728666e6d3b86d031b8eea8d2f69b21e8aa6ba2b153e3ec212cc8a36ed9860579dfe1e3ef4d6de778c5dbdd981623b48727cd96247',
-        'hex',
-      ),
-    );
-    const stakingKey = accountPrivateKey.derive(2).derive(STAKING_KEY_INDEX).to_raw_key();
-    const certificate = RustModule.WalletV3.Certificate.stake_delegation(
-      RustModule.WalletV3.StakeDelegation.new(
-        RustModule.WalletV3.DelegationType.full(
-          RustModule.WalletV3.PoolId.from_hex('312e3d449038372ba2fc3300cfedf1b152ae739201b3e5da47ab3f933a421b62')
-        ),
-        stakingKey.to_public()
-      )
-    );
     const fragment = signTransaction(
       unsignedTxResponse,
       Bip44DerivationLevels.ACCOUNT.level,
@@ -495,15 +499,15 @@ describe('Create signed transactions', () => {
     expect(outputs.size()).toEqual(1);
     const change = outputs.get(0);
     expect(change.address().to_string(Bech32Prefix.ADDRESS)).toEqual('addr1s5quq8utjkrfntnkngjxa9u9mdd8pcprjal2fwzkm7k0y0prx3k276qm0j8');
-    expect(change.value().to_str()).toEqual('1844617');
+    expect(change.value().to_str()).toEqual('1844611');
 
-    expect(Buffer.from(fragment.id().as_bytes()).toString('hex')).toEqual('fdbb1fe40618b8ded1300483c99cd3c4f1b2c2745f86c01b1018e593d2710951');
-    expect(Buffer.from(fragment.get_transaction().id().as_bytes()).toString('hex')).toEqual('433c14a1f1bb654e569c381e45e49c97738ecc4e0064e04daaf284b531d56e22');
+    expect(Buffer.from(fragment.id().as_bytes()).toString('hex')).toEqual('3b0ecc3c301b413d768f44c791ee1b2cb4f6763d4573699c87c7d39b1d81e607');
+    expect(Buffer.from(fragment.get_transaction().id().as_bytes()).toString('hex')).toEqual('86654959226b6316f5210c80fdf95ac3bea41aafcc0fc93558f3093821a20a0c');
 
     const witnesses = signedTx.witnesses();
     expect(witnesses.size()).toEqual(1);
     expect(witnesses.get(0).to_bech32()).toEqual(
-      'witness1q9ukepgn8dchhvc4ynnz3he0ymf9ax5jggfvz2602tqqu62sym0cpfdc5qe7x7v6skf03mv3h8huqgna7x495t4e85r3wg6m5rg25ms9sqh95g'
+      'witness1q9dt42g3h5qqz7fyrlfsvcmp27vvlzwnp747kt9wujm8tyy6hv5ugh6kv44lkcra2k4ugjt96q0u3z0r62w48ww4nz93n780e0n0ajsy8term5'
     );
   });
 });

--- a/config/config-types.js
+++ b/config/config-types.js
@@ -36,6 +36,11 @@ export type GenesisConfigType = {|
     constant: string,
     coefficient: string,
     certificate: string,
+    per_certificate_fees?: {|
+      certificate_pool_registration?: string,
+      certificate_stake_delegation?: string,
+      certificate_owner_stake_delegation?: string,
+    |},
   |},
   /**
    * Reward for a single epoch

--- a/config/shelley-testnet.json
+++ b/config/shelley-testnet.json
@@ -25,7 +25,11 @@
     "linearFee": {
       "constant": "200000",
       "coefficient": "100000",
-      "certificate": "400000"
+      "certificate": "400000",
+      "per_certificate_fees": {
+        "certificate_pool_registration": "500000000",
+        "certificate_stake_delegation": "400000"
+      }
     },
     "genesisHash": "8e4d2a343f3dcf9330ad9035b3e8d168e6728904262f2c434a4f8f934ec7b676"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2793,11 +2793,11 @@
       "dev": true
     },
     "@emurgo/js-chain-libs": {
-      "version": "git+https://github.com/SebastienGllmt/js-chain-libs-pkg.git#69701be6644927b324d380df6a9510c0fa2d4e1a",
+      "version": "git+https://github.com/SebastienGllmt/js-chain-libs-pkg.git#9917e654f67d955c46f9b1b8782d8dfe3198a3ec",
       "from": "git+https://github.com/SebastienGllmt/js-chain-libs-pkg.git"
     },
     "@emurgo/js-chain-libs-node": {
-      "version": "git+https://github.com/SebastienGllmt/js-chain-libs-node-pkg.git#2b6bf15bf90727bfd6062ceba9dba1336e514c73",
+      "version": "git+https://github.com/SebastienGllmt/js-chain-libs-node-pkg.git#e29e73895ee36c21febac915e83972ba0be5b4c0",
       "from": "git+https://github.com/SebastienGllmt/js-chain-libs-node-pkg.git",
       "dev": true
     },


### PR DESCRIPTION
For the first release of Yoroi we had a hack where we made the certificate base fee be equal to the per-certificate fee of a delegation certificate. This PR implements the proper fix so that now transaction fees should be accurate with any certificate type