### PR TITLE
Fix spinner condition for delegation page

### DIFF
--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -106,9 +106,9 @@ export default class StakingDashboardPage extends Component<Props, State> {
       : errorIfPresent;
 
     const showRewardAmount = delegationStore.getCurrentDelegation.wasExecuted &&
-      delegationStore.getCurrentDelegation.result != null &&
       delegationStore.getDelegatedBalance.wasExecuted &&
       errorIfPresent == null;
+
     const { getThemeVars } = this.props.stores.profile;
     return (
       <StakingDashboard


### PR DESCRIPTION
This bug made that if you have never delegated to a pool, you would permanently get a spinner for the "total delegated" in the dashboard page instead of `0 ADA`

![image](https://user-images.githubusercontent.com/2608559/71772878-9800a380-2f96-11ea-8587-e6b0e688a22d.png)
