### PR TITLE
Attempt to fix transaction-screen check on Firefox

### DIFF
--- a/features/step_definitions/main-ui-steps.js
+++ b/features/step_definitions/main-ui-steps.js
@@ -22,7 +22,7 @@ When(/^I go to the main screen$/, async function () {
 });
 
 Then(/^I should see the transactions screen$/, async function () {
-  await this.waitForElement("//div[@class='WalletSummary_numberOfTransactions']", By.xpath);
+  await this.waitForElement("//div[@class='WalletSummary_component']", By.xpath);
 });
 
 Then(/^I click on "copy to clipboard" button$/, async function () {


### PR DESCRIPTION
Currently E2E tests on Firefox seem to always fail on this line with 

```
 NoSuchElementError: Unable to locate element: //div[@class='WalletSummary_numberOfTransactions']
```

This error happens reliably but I'm not sure why since visually it looks fine. Switching to checking the root component seems to fix it though.