### PR TITLE
Fix semver import

### DIFF
--- a/app/api/ada/lib/storage/adaMigration.js
+++ b/app/api/ada/lib/storage/adaMigration.js
@@ -16,9 +16,7 @@ import LocalStorageApi from '../../../localStorage/index';
 import {
   Logger,
 } from '../../../../utils/logging';
-import {
-  satisfies,
-} from 'semver';
+import satisfies from 'semver/functions/satisfies';
 import {
   OPEN_TAB_ID_KEY,
 } from '../../../../utils/tabManager';


### PR DESCRIPTION
This version bump: https://github.com/Emurgo/yoroi-frontend/pull/1272

Actually broke the import but Webpack just made the call silently fail. This PR fixes it