### PR TITLE
Async trigger

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -41,3 +41,4 @@ module.name_mapper.extension='jpg' -> '<PROJECT_ROOT>/flow/mappers/WebpackAsset.
 module.name_mapper.extension='svg' -> '<PROJECT_ROOT>/flow/mappers/WebpackAsset.js.flow'
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
+suppress_comment=\\(.\\|\n\\)*\\$FlowDisable

--- a/app/actions/ada/addresses-actions.js
+++ b/app/actions/ada/addresses-actions.js
@@ -1,9 +1,9 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 
 // ======= ADDRESSES ACTIONS =======
 
 export default class AddressesActions {
-  createAddress: Action<void> = new Action();
+  createAddress: AsyncAction<void> = new AsyncAction();
   resetErrors: Action<void> = new Action();
 }

--- a/app/actions/ada/daedalus-transfer-actions.js
+++ b/app/actions/ada/daedalus-transfer-actions.js
@@ -1,23 +1,23 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 
 export default class DaedalusTranferActions {
   startTransferFunds: Action<void> = new Action();
   startTransferPaperFunds: Action<void> = new Action();
   startTransferMasterKey: Action<void> = new Action();
-  setupTransferFundsWithMnemonic: Action<{
+  setupTransferFundsWithMnemonic: AsyncAction<{
     recoveryPhrase: string,
     publicDeriver: PublicDeriverWithCachedMeta,
-  }> = new Action();
-  setupTransferFundsWithMasterKey: Action<{
+  }> = new AsyncAction();
+  setupTransferFundsWithMasterKey: AsyncAction<{
     masterKey: string,
     publicDeriver: PublicDeriverWithCachedMeta,
-  }> = new Action();
+  }> = new AsyncAction();
   backToUninitialized: Action<void> = new Action();
-  transferFunds: Action<{|
+  transferFunds: AsyncAction<{|
     next: () => void,
     publicDeriver: PublicDeriverWithCachedMeta,
-  |}> = new Action();
+  |}> = new AsyncAction();
   cancelTransferFunds: Action<void> = new Action();
 }

--- a/app/actions/ada/delegation-transaction-actions.js
+++ b/app/actions/ada/delegation-transaction-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 
 export type PoolRequest =
   void |
@@ -10,8 +10,8 @@ export type PoolRequest =
   |}>;
 
 export default class DelegationTransactionActions {
-  createTransaction: Action<PoolRequest> = new Action();
-  signTransaction: Action<{| password: string |}> = new Action();
-  complete: Action<void> = new Action();
+  createTransaction: AsyncAction<PoolRequest> = new AsyncAction();
+  signTransaction: AsyncAction<{| password: string |}> = new AsyncAction();
+  complete: AsyncAction<void> = new AsyncAction();
   reset: Action<void> = new Action();
 }

--- a/app/actions/ada/hw-connect-actions.js
+++ b/app/actions/ada/hw-connect-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 
 // ======= HARDWARE WALLET CONNECT ACTIONS =======
 
@@ -8,6 +8,6 @@ export default class HWConnectActions {
   cancel: Action<void> = new Action();
   submitCheck: Action<void> = new Action();
   goBackToCheck: Action<void> = new Action();
-  submitConnect: Action<void> = new Action();
-  submitSave: Action<string> = new Action();
+  submitConnect: AsyncAction<void> = new AsyncAction();
+  submitSave: AsyncAction<string> = new AsyncAction();
 }

--- a/app/actions/ada/hw-verify-address-actions.js
+++ b/app/actions/ada/hw-verify-address-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 
 import type {
   BIP32Path
@@ -10,6 +10,6 @@ import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/in
 
 export default class HWVerifyAddressActions {
   closeAddressDetailDialog: Action<void> = new Action();
-  selectAddress: Action<{| address: string, path: BIP32Path |}> = new Action();
-  verifyAddress: Action<PublicDeriver<>> = new Action();
+  selectAddress: AsyncAction<{| address: string, path: BIP32Path |}> = new AsyncAction();
+  verifyAddress: AsyncAction<PublicDeriver<>> = new AsyncAction();
 }

--- a/app/actions/ada/ledger-send-actions.js
+++ b/app/actions/ada/ledger-send-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
@@ -12,5 +12,5 @@ export type SendUsingLedgerParams = {|
 export default class LedgerSendActions {
   init: Action<void> = new Action();
   cancel: Action<void> = new Action();
-  sendUsingLedger: Action<SendUsingLedgerParams> = new Action();
+  sendUsingLedger: AsyncAction<SendUsingLedgerParams> = new AsyncAction();
 }

--- a/app/actions/ada/paper-wallets-actions.js
+++ b/app/actions/ada/paper-wallets-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from '../lib/Action';
+import { Action, AsyncAction, } from '../lib/Action';
 import type { PdfGenStepType } from '../../api/ada/paperWallet/paperWalletPdf';
 
 // ======= PAPER WALLET ACTIONS =======
@@ -9,14 +9,14 @@ export default class PaperWalletsActions {
     numAddresses: number,
     printAccountPlate: boolean,
   }> = new Action();
-  submitUserPassword: Action<{| userPassword: string |}> = new Action();
+  submitUserPassword: AsyncAction<{| userPassword: string |}> = new AsyncAction();
   submitCreate: Action<void> = new Action();
   backToCreate: Action<void> = new Action();
   submitVerify: Action<void> = new Action();
   createPaperWallet: Action<void>= new Action();
-  createPdfDocument: Action<void>= new Action();
-  setPdfRenderStatus: Action<{ status: PdfGenStepType }> = new Action();
-  setPdf: Action<{ pdf: Blob }> = new Action();
+  createPdfDocument: AsyncAction<void>= new AsyncAction();
+  setPdfRenderStatus: Action<{| status: PdfGenStepType |}> = new Action();
+  setPdf: Action<{| pdf: Blob |}> = new Action();
   downloadPaperWallet: Action<void> = new Action();
   cancel: Action<void>= new Action();
 }

--- a/app/actions/ada/transactions-actions.js
+++ b/app/actions/ada/transactions-actions.js
@@ -1,12 +1,12 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 
 // ======= TRANSACTIONS ACTIONS =======
 
 export type TransactionRowsToExportRequest = void;
 
 export default class TransactionsActions {
-  loadMoreTransactions: Action<void> = new Action();
-  exportTransactionsToFile: Action<TransactionRowsToExportRequest> = new Action();
+  loadMoreTransactions: AsyncAction<void> = new AsyncAction();
+  exportTransactionsToFile: AsyncAction<TransactionRowsToExportRequest> = new AsyncAction();
   closeExportTransactionDialog: Action<void> = new Action();
 }

--- a/app/actions/ada/trezor-send-actions.js
+++ b/app/actions/ada/trezor-send-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
@@ -11,5 +11,5 @@ export type SendUsingTrezorParams = {
 
 export default class TrezorSendActions {
   cancel: Action<void> = new Action();
-  sendUsingTrezor: Action<SendUsingTrezorParams> = new Action();
+  sendUsingTrezor: AsyncAction<SendUsingTrezorParams> = new AsyncAction();
 }

--- a/app/actions/ada/tx-builder-actions.js
+++ b/app/actions/ada/tx-builder-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from '../lib/Action';
+import { Action } from '../lib/Action';
 
 export default class WalletSettingsActions {
   updateReceiver: Action<void | string> = new Action();

--- a/app/actions/ada/wallet-restore-actions.js
+++ b/app/actions/ada/wallet-restore-actions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 
 export type WalletRestoreMeta = {|
   recoveryPhrase: string,
@@ -18,10 +18,10 @@ export type RestoreModeType = $Values<typeof RestoreMode>;
 
 export default class WalletRestoreActions {
   submitFields: Action<WalletRestoreMeta> = new Action();
-  startRestore: Action<void> = new Action();
-  verifyMnemonic: Action<void> = new Action();
-  startCheck: Action<void> = new Action();
-  transferFromLegacy: Action<void> = new Action();
+  startRestore: AsyncAction<void> = new AsyncAction();
+  verifyMnemonic: AsyncAction<void> = new AsyncAction();
+  startCheck: AsyncAction<void> = new AsyncAction();
+  transferFromLegacy: AsyncAction<void> = new AsyncAction();
   setMode: Action<RestoreModeType> = new Action();
   reset: Action<void> = new Action();
   back: Action<void> = new Action();

--- a/app/actions/ada/wallet-settings-actions.js
+++ b/app/actions/ada/wallet-settings-actions.js
@@ -1,16 +1,16 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 
 export default class WalletSettingsActions {
   cancelEditingWalletField: Action<void> = new Action();
   startEditingWalletField: Action<{| field: string |}> = new Action();
   stopEditingWalletField: Action<void> = new Action();
-  renamePublicDeriver: Action<{| newName: string |}> = new Action();
-  renameConceptualWallet: Action<{| newName: string |}> = new Action();
-  updateSigningPassword: Action<{
+  renamePublicDeriver: AsyncAction<{| newName: string |}> = new AsyncAction();
+  renameConceptualWallet: AsyncAction<{| newName: string |}> = new AsyncAction();
+  updateSigningPassword: AsyncAction<{
     publicDeriver: PublicDeriverWithCachedMeta,
     oldPassword: string,
     newPassword: string
-  }> = new Action();
+  }> = new AsyncAction();
 }

--- a/app/actions/ada/wallets-actions.js
+++ b/app/actions/ada/wallets-actions.js
@@ -1,6 +1,6 @@
 // @flow
 import BigNumber from 'bignumber.js';
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 import type {
@@ -10,16 +10,16 @@ import type {
 // ======= WALLET ACTIONS =======
 
 export default class WalletsActions {
-  createWallet: Action<{| name: string, password: string |}> = new Action();
-  restoreWallet: Action<{|
+  createWallet: AsyncAction<{| name: string, password: string |}> = new AsyncAction();
+  restoreWallet: AsyncAction<{|
     recoveryPhrase: string,
     walletName: string,
     walletPassword: string
-  |}> = new Action();
-  sendMoney: Action<{|
+  |}> = new AsyncAction();
+  sendMoney: AsyncAction<{|
     signRequest: BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput>,
     password: string,
-  |}> = new Action();
+  |}> = new AsyncAction();
   updateBalance: Action<BigNumber> = new Action();
   updateLastSync: Action<IGetLastSyncInfoResponse> = new Action();
 }

--- a/app/actions/ada/yoroi-transfer-actions.js
+++ b/app/actions/ada/yoroi-transfer-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from '../lib/Action';
+import { AsyncAction, Action } from '../lib/Action';
 import type { TransferSourceType, TransferKindType, } from '../../types/TransferTypes';
 
 export default class YoroiTranferActions {
@@ -18,14 +18,14 @@ export default class YoroiTranferActions {
     recoveryPhrase: string,
     paperPassword: string,
   |}> = new Action();
-  checkAddresses: Action<{|
+  checkAddresses: AsyncAction<{|
     getDestinationAddress: void => Promise<string>,
-  |}> = new Action();
+  |}> = new AsyncAction();
   backToUninitialized: Action<void> = new Action();
-  transferFunds: Action<{|
+  transferFunds: AsyncAction<{|
     next: void => Promise<void>,
     getDestinationAddress: void => Promise<string>,
     rebuildTx: boolean,
-  |}> = new Action();
+  |}> = new AsyncAction();
   cancelTransferFunds: Action<void> = new Action();
 }

--- a/app/actions/dialogs-actions.js
+++ b/app/actions/dialogs-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from './lib/Action';
+import { Action } from './lib/Action';
 
 // ======= DIALOGS ACTIONS =======
 

--- a/app/actions/notice-board-actions.js
+++ b/app/actions/notice-board-actions.js
@@ -1,8 +1,8 @@
 // @flow
-import Action from './lib/Action';
+import { AsyncAction } from './lib/Action';
 
 // ======= NOTICE-BOARD ACTIONS =======
 
 export default class NoticeBoardActions {
-  loadMore: Action<void> = new Action();
+  loadMore: AsyncAction<void> = new AsyncAction();
 }

--- a/app/actions/notifications-actions.js
+++ b/app/actions/notifications-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from './lib/Action';
+import { Action } from './lib/Action';
 import type { Notification } from '../types/notificationType';
 
 // ======= NOTIFICATIONS ACTIONS =======

--- a/app/actions/profile-actions.js
+++ b/app/actions/profile-actions.js
@@ -1,17 +1,17 @@
 // @flow
-import Action from './lib/Action';
+import { AsyncAction, Action } from './lib/Action';
 import type { ExplorerType } from '../domain/Explorer';
 
 // ======= PROFILE ACTIONS =======
 
 export default class ProfileActions {
-  acceptTermsOfUse: Action<void> = new Action();
-  acceptUriScheme: Action<void> = new Action();
+  acceptTermsOfUse: AsyncAction<void> = new AsyncAction();
+  acceptUriScheme: AsyncAction<void> = new AsyncAction();
   updateTentativeLocale: Action<{| locale: string |}> = new Action();
-  updateLocale: Action<{| locale: string |}> = new Action();
-  updateSelectedExplorer: Action<{| explorer: ExplorerType |}> = new Action();
-  updateTheme: Action<{| theme: string |}> = new Action();
-  exportTheme: Action<void> = new Action();
-  commitLocaleToStorage: Action<void> = new Action();
-  updateHideBalance: Action<void> = new Action();
+  updateLocale: AsyncAction<{| locale: string |}> = new AsyncAction();
+  updateSelectedExplorer: AsyncAction<{| explorer: ExplorerType |}> = new AsyncAction();
+  updateTheme: AsyncAction<{| theme: string |}> = new AsyncAction();
+  exportTheme: AsyncAction<void> = new AsyncAction();
+  commitLocaleToStorage: AsyncAction<void> = new AsyncAction();
+  updateHideBalance: AsyncAction<void> = new AsyncAction();
 }

--- a/app/actions/router-actions.js
+++ b/app/actions/router-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from './lib/Action';
+import { Action } from './lib/Action';
 
 // ======= ROUTER ACTIONS =======
 

--- a/app/actions/topbar-actions.js
+++ b/app/actions/topbar-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from './lib/Action';
+import { Action } from './lib/Action';
 
 export default class TopbarActions {
   activateTopbarCategory: Action<{ category: string, showSubMenu?: boolean }> = new Action();

--- a/app/actions/wallet-backup-actions.js
+++ b/app/actions/wallet-backup-actions.js
@@ -1,5 +1,5 @@
 // @flow
-import Action from './lib/Action';
+import { AsyncAction, Action } from './lib/Action';
 
 // ======= WALLET BACKUP ACTIONS =======
 
@@ -19,6 +19,6 @@ export default class WalletBackupActions {
   acceptWalletBackupTermRecovery: Action<void> = new Action();
   restartWalletBackup: Action<void> = new Action();
   cancelWalletBackup: Action<void> = new Action();
-  finishWalletBackup: Action<void> = new Action();
+  finishWalletBackup: AsyncAction<void> = new AsyncAction();
   removeOneMnemonicWord: Action<void> = new Action();
 }

--- a/app/components/profile/language-selection/LanguageSelectionForm.js
+++ b/app/components/profile/language-selection/LanguageSelectionForm.js
@@ -25,7 +25,7 @@ const messages = defineMessages({
 type Props = {|
   +onSelectLanguage: {| locale: string |} => void,
   +languages: Array<{ value: string, label: MessageDescriptor, svg: string }>,
-  +onSubmit: {| locale: string |} => void,
+  +onSubmit: {| locale: string |} => PossiblyAsync<void>,
   +isSubmitting: boolean,
   +currentLocale: string,
   +error?: ?LocalizableError,
@@ -41,15 +41,15 @@ export default class LanguageSelectionForm extends Component<Props> {
     intl: intlShape.isRequired,
   };
 
-  selectLanguage = (locale: string) => {
+  selectLanguage: string => void = (locale) => {
     this.props.onSelectLanguage({ locale });
   };
 
-  submit = () => {
+  submit: void => void = () => {
     this.form.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         const { languageId } = form.values();
-        this.props.onSubmit({ locale: languageId });
+        await this.props.onSubmit({ locale: languageId });
       },
       onError: () => {}
     });

--- a/app/components/profile/terms-of-use/TermsOfUseForm.js
+++ b/app/components/profile/terms-of-use/TermsOfUseForm.js
@@ -21,7 +21,7 @@ const messages = defineMessages({
 
 type Props = {|
   +localizedTermsOfUse: string,
-  +onSubmit: void => void,
+  +onSubmit: void => PossiblyAsync<void>,
   +isSubmitting: boolean,
   +error?: ?LocalizableError,
 |};
@@ -47,10 +47,6 @@ export default class TermsOfUseForm extends Component<Props, State> {
   toggleAcceptance() {
     this.setState(prevState => ({ areTermsOfUseAccepted: !prevState.areTermsOfUseAccepted }));
   }
-
-  submit = () => {
-    this.props.onSubmit();
-  };
 
   render() {
     const { intl } = this.context;
@@ -80,7 +76,7 @@ export default class TermsOfUseForm extends Component<Props, State> {
             <Button
               className={buttonClasses}
               label={intl.formatMessage(globalMessages.continue)}
-              onMouseUp={this.submit}
+              onMouseUp={this.props.onSubmit}
               disabled={!areTermsOfUseAccepted}
               skin={ButtonSkin}
             />

--- a/app/components/profile/uri-prompt/UriAccept.js
+++ b/app/components/profile/uri-prompt/UriAccept.js
@@ -17,7 +17,7 @@ const messages = defineMessages({
 });
 
 type Props = {|
-  +onConfirm: void => void,
+  +onConfirm: void => PossiblyAsync<void>,
   +onBack: void => void,
   +classicTheme: boolean
 |};

--- a/app/components/profile/uri-prompt/UriSkip.js
+++ b/app/components/profile/uri-prompt/UriSkip.js
@@ -23,7 +23,7 @@ const messages = defineMessages({
 });
 
 type Props = {|
-  +onConfirm: void => void,
+  +onConfirm: void => PossiblyAsync<void>,
   +onBack: void => void,
   +classicTheme: boolean,
 |};

--- a/app/components/settings/categories/general-setting/ExplorerSettings.js
+++ b/app/components/settings/categories/general-setting/ExplorerSettings.js
@@ -15,7 +15,7 @@ import type { ExplorerType } from '../../../../domain/Explorer';
 type Props = {|
   +explorers: Array<{| value: ExplorerType, label: string |}>,
   +selectedExplorer: ExplorerType,
-  +onSelectExplorer: {| explorer: ExplorerType |} => void,
+  +onSelectExplorer: {| explorer: ExplorerType |} => PossiblyAsync<void>,
   +isSubmitting: boolean,
   +error?: ?LocalizableError,
 |};
@@ -30,8 +30,8 @@ export default class ExplorerSettings extends Component<Props> {
     intl: intlShape.isRequired,
   };
 
-  selectExplorer = (explorer: ExplorerType) => {
-    this.props.onSelectExplorer({ explorer });
+  selectExplorer: ExplorerType => Promise<void> = async (explorer) => {
+    await this.props.onSelectExplorer({ explorer });
   };
 
   form = new ReactToolboxMobxForm({

--- a/app/components/settings/categories/general-setting/GeneralSettings.js
+++ b/app/components/settings/categories/general-setting/GeneralSettings.js
@@ -16,7 +16,7 @@ import globalMessages, { listOfTranslators } from '../../../../i18n/global-messa
 type Props = {|
   +languages: Array<{ value: string, label: MessageDescriptor, svg: string }>,
   +currentLocale: string,
-  +onSelectLanguage: {| locale: string |} => void,
+  +onSelectLanguage: {| locale: string |} => PossiblyAsync<void>,
   +isSubmitting: boolean,
   +error?: ?LocalizableError,
 |};
@@ -31,8 +31,8 @@ export default class GeneralSettings extends Component<Props> {
     intl: intlShape.isRequired,
   };
 
-  selectLanguage = (locale: string) => {
-    this.props.onSelectLanguage({ locale });
+  selectLanguage: string => Promise<void> = async (locale) => {
+    await this.props.onSelectLanguage({ locale });
   };
 
   form = new ReactToolboxMobxForm({

--- a/app/components/settings/categories/general-setting/ThemeSettingsBlock.js
+++ b/app/components/settings/categories/general-setting/ThemeSettingsBlock.js
@@ -51,8 +51,8 @@ const messages = defineMessages({
 
 type Props = {|
   +currentTheme: Theme,
-  +selectTheme: {| theme: string |} => void,
-  +exportTheme: void => void,
+  +selectTheme: {| theme: string |} => PossiblyAsync<void>,
+  +exportTheme: void => PossiblyAsync<void>,
   +getThemeVars: {| theme: string |} => { [key: string]: string },
   +hasCustomTheme: void => boolean,
   +onExternalLinkClick: MouseEvent => void,

--- a/app/components/topbar/WalletTopbarTitle.js
+++ b/app/components/topbar/WalletTopbarTitle.js
@@ -30,7 +30,7 @@ type Props = {|
   +themeProperties?: {|
     identiconSaturationFactor: number,
   |},
-  +onUpdateHideBalance: void => void,
+  +onUpdateHideBalance: void => PossiblyAsync<void>,
   +shouldHideBalance: boolean,
 |};
 

--- a/app/components/transfer/TransferSummaryPage.js
+++ b/app/components/transfer/TransferSummaryPage.js
@@ -52,7 +52,7 @@ type Props = {|
   +formattedWalletAmount: BigNumber => string,
   +selectedExplorer: ExplorerType,
   +transferTx: TransferTx,
-  +onSubmit: void => void,
+  +onSubmit: void => PossiblyAsync<void>,
   +isSubmitting: boolean,
   +onCancel: void => void,
   +error: ?LocalizableError,

--- a/app/components/wallet/WalletBackupDialog.js
+++ b/app/components/wallet/WalletBackupDialog.js
@@ -26,7 +26,7 @@ type Props = {|
   +onAcceptTermRecovery: void => void,
   +onAddWord: {| index: number, word: string |} => void,
   +onClear: void => void,
-  +onFinishBackup: void => void,
+  +onFinishBackup: void => PossiblyAsync<void>,
   +onRestartBackup: void => void,
   +removeWord: void => void,
   +hasWord: boolean,

--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -42,7 +42,7 @@ const messages = defineMessages({
 });
 
 type Props = {|
-  +onSubmit: {| name: string, password: string |} => void,
+  +onSubmit: {| name: string, password: string |} => PossiblyAsync<void>,
   +onCancel: void => void,
   +classicTheme: boolean
 |};
@@ -126,14 +126,14 @@ export default class WalletCreateDialog extends Component<Props, State> {
 
   submit = () => {
     this.form.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         this.setState({ isSubmitting: true });
         const { walletName, walletPassword } = form.values();
         const walletData = {
           name: walletName,
           password: walletPassword,
         };
-        this.props.onSubmit(walletData);
+        await this.props.onSubmit(walletData);
       },
       onError: () => {
         this.setState({ isSubmitting: false });

--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -47,9 +47,9 @@ type Props = {|
   +classicTheme: boolean
 |};
 
-type State = {
+type State = {|
   isSubmitting: boolean,
-};
+|};
 
 @observer
 export default class WalletCreateDialog extends Component<Props, State> {

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -67,10 +67,10 @@ type Props = {|
   +selectedExplorer: ExplorerType,
   +isWalletAddressUsed: boolean,
   +walletAddresses: Array<StandardAddress>,
-  +onGenerateAddress: void => void,
+  +onGenerateAddress: void => Promise<void>,
   +onCopyAddressTooltip: (string, string) => void,
   +notification: ?Notification,
-  +onVerifyAddress: {| address: string, path: BIP32Path |} => void,
+  +onVerifyAddress: {| address: string, path: BIP32Path |} => Promise<void>,
   +onGeneratePaymentURI: string => void,
   +isSubmitting: boolean,
   +error?: ?LocalizableError,
@@ -98,8 +98,8 @@ export default class WalletReceive extends Component<Props, State> {
     this.setState(prevState => ({ showUsed: !prevState.showUsed }));
   };
 
-  submit = () => {
-    this.props.onGenerateAddress();
+  submit: void => Promise<void> = async () => {
+    await this.props.onGenerateAddress();
   }
 
   loadingSpinner: ?LoadingSpinner;

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -68,9 +68,9 @@ export type WalletRestoreDialogValues = {|
 |};
 
 type Props = {|
-  +onSubmit: WalletRestoreDialogValues => void,
-  +onCancel: void => void,
-  +onBack?: void => void,
+  +onSubmit: WalletRestoreDialogValues => PossiblyAsync<void>,
+  +onCancel: void => PossiblyAsync<void>,
+  +onBack?: void => PossiblyAsync<void>,
   +mnemonicValidator: string => boolean,
   +passwordValidator?: string => boolean,
   +numberOfMnemonics: number,
@@ -216,7 +216,7 @@ export default class WalletRestoreDialog extends Component<Props> {
 
   submit = () => {
     this.form.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         const { recoveryPhrase, walletName, walletPassword, paperPassword } = form.values();
         const walletData: WalletRestoreDialogValues = {
           recoveryPhrase: join(recoveryPhrase, ' '),
@@ -224,7 +224,7 @@ export default class WalletRestoreDialog extends Component<Props> {
           walletPassword,
           paperPassword,
         };
-        this.props.onSubmit(walletData);
+        await this.props.onSubmit(walletData);
       },
       onError: () => {}
     });

--- a/app/components/wallet/WalletRestoreVerifyDialog.js
+++ b/app/components/wallet/WalletRestoreVerifyDialog.js
@@ -73,7 +73,7 @@ type Props = {|
   +selectedExplorer: ExplorerType,
   +onCopyAddressTooltip: (string, string) => void,
   +notification: ?Notification,
-  +onNext: void => void,
+  +onNext: void => PossiblyAsync<void>,
   +onCancel: void => void,
   +isSubmitting: boolean,
   +classicTheme: boolean,

--- a/app/components/wallet/WalletSettings.js
+++ b/app/components/wallet/WalletSettings.js
@@ -33,7 +33,7 @@ type Props = {|
   +openDialogAction: {| dialog: any, params?: any |} => void,
   +isDialogOpen: any => boolean,
   +dialog: Node,
-  +onFieldValueChange: (string, string) => void,
+  +onFieldValueChange: (string, string) => PossiblyAsync<void>,
   +onStartEditing: string => void,
   +onStopEditing: void => void,
   +onCancelEditing: void => void,
@@ -91,7 +91,7 @@ export default class WalletSettings extends Component<Props> {
           onStartEditing={() => onStartEditing('name')}
           onStopEditing={onStopEditing}
           onCancelEditing={onCancelEditing}
-          onSubmit={(value) => onFieldValueChange('name', value)}
+          onSubmit={async (value) => onFieldValueChange('name', value)}
           isValid={nameValidator}
           validationErrorMessage={intl.formatMessage(globalMessages.invalidWalletName)}
           successfullyUpdated={!isSubmitting && lastUpdatedField === 'name' && !isInvalid}

--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
@@ -55,7 +55,7 @@ type Props = {|
   +onAcceptTermRecovery: void => void,
   +onRestartBackup: void => void,
   +onCancelBackup: void => void,
-  +onFinishBackup: void => void,
+  +onFinishBackup: void => PossiblyAsync<void>,
   +removeWord: void => void,
   +hasWord: boolean,
   +classicTheme: boolean,

--- a/app/components/wallet/export/ExportTransactionDialog.js
+++ b/app/components/wallet/export/ExportTransactionDialog.js
@@ -30,7 +30,7 @@ const messages = defineMessages({
 type Props = {|
   +isActionProcessing: ?boolean,
   +error: ?LocalizableError,
-  +submit: void => void,
+  +submit: void => PossiblyAsync<void>,
   +cancel: void => void,
   +classicTheme: boolean,
 |};

--- a/app/components/wallet/hwConnect/ledger/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/ledger/ConnectDialog.js
@@ -48,7 +48,7 @@ type Props = {|
   +error: ?LocalizableError,
   +onExternalLinkClick: MouseEvent => void,
   +goBack: void => void,
-  +submit: void => void,
+  +submit: void => PossiblyAsync<void>,
   +cancel: void => void,
   +classicTheme: boolean,
 |};

--- a/app/components/wallet/hwConnect/ledger/SaveDialog.js
+++ b/app/components/wallet/hwConnect/ledger/SaveDialog.js
@@ -52,7 +52,7 @@ type Props = {|
   +isActionProcessing: boolean,
   +defaultWalletName: string,
   +onExternalLinkClick: MouseEvent => void,
-  +submit: string => void,
+  +submit: string => PossiblyAsync<void>,
   +cancel: void => void,
   +classicTheme: boolean,
 |};
@@ -208,7 +208,7 @@ export default class SaveDialog extends Component<Props> {
     this.form.submit({
       onSuccess: async (form) => {
         const { walletName } = form.values();
-        this.props.submit(walletName);
+        await this.props.submit(walletName);
       }
     });
   }

--- a/app/components/wallet/hwConnect/trezor/ConnectDialog.js
+++ b/app/components/wallet/hwConnect/trezor/ConnectDialog.js
@@ -48,7 +48,7 @@ type Props = {|
   +error: ?LocalizableError,
   +onExternalLinkClick: MouseEvent => void,
   +goBack: void => void,
-  +submit: void => void,
+  +submit: void => PossiblyAsync<void>,
   +cancel: void => void,
   +classicTheme: boolean
 |};

--- a/app/components/wallet/hwConnect/trezor/SaveDialog.js
+++ b/app/components/wallet/hwConnect/trezor/SaveDialog.js
@@ -52,7 +52,7 @@ type Props = {|
   +isActionProcessing: boolean,
   +defaultWalletName: string,
   +onExternalLinkClick: MouseEvent => void,
-  +submit: string => void,
+  +submit: string => PossiblyAsync<void>,
   +cancel: void => void,
   +classicTheme: boolean
 |};
@@ -207,7 +207,7 @@ export default class SaveDialog extends Component<Props> {
     this.form.submit({
       onSuccess: async (form) => {
         const { walletName } = form.values();
-        this.props.submit(walletName);
+        await this.props.submit(walletName);
       }
     });
   }

--- a/app/components/wallet/receive/VerifyAddressDialog.js
+++ b/app/components/wallet/receive/VerifyAddressDialog.js
@@ -46,7 +46,7 @@ const messages = defineMessages({
 type Props = {|
   +isActionProcessing: boolean,
   +error: ?LocalizableError,
-  +verify: void => void,
+  +verify: void => PossiblyAsync<void>,
   +cancel: void => void,
   +selectedExplorer: ExplorerType,
   +isHardware: boolean,

--- a/app/components/wallet/restore/LegacyExplanation.js
+++ b/app/components/wallet/restore/LegacyExplanation.js
@@ -26,8 +26,8 @@ const messages = defineMessages({
 type Props = {|
   +onBack: void => void,
   +onClose: void => void,
-  +onSkip: void => void,
-  +onCheck: void => void,
+  +onSkip: void => PossiblyAsync<void>,
+  +onCheck: void => PossiblyAsync<void>,
   +classicTheme: boolean
 |};
 

--- a/app/components/wallet/send/HWSendConfirmationDialog.js
+++ b/app/components/wallet/send/HWSendConfirmationDialog.js
@@ -36,7 +36,7 @@ type Props = {|
   +messages: ExpectedMessages,
   +isSubmitting: boolean,
   +error: ?LocalizableError,
-  +onSubmit: void => void,
+  +onSubmit: void => PossiblyAsync<void>,
   +onCancel: void => void,
   +classicTheme: boolean,
 |};

--- a/app/components/wallet/send/WalletSendConfirmationDialog.js
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.js
@@ -30,7 +30,7 @@ type Props = {|
   +receivers: Array<string>,
   +totalAmount: string,
   +transactionFee: string,
-  +onSubmit: ({| password: string |}) => void,
+  +onSubmit: ({| password: string |}) => PossiblyAsync<void>,
   +amountToNaturalUnits: (amountWithFractions: string) => string,
   +onCancel: void => void,
   +isSubmitting: boolean,
@@ -74,12 +74,12 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
 
   submit() {
     this.form.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         const { walletPassword } = form.values();
         const transactionData = {
           password: walletPassword,
         };
-        this.props.onSubmit(transactionData);
+        await this.props.onSubmit(transactionData);
       },
       onError: () => {}
     });

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.js
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.js
@@ -34,7 +34,7 @@ type Props = {|
   +currentPasswordValue: string,
   +newPasswordValue: string,
   +repeatedPasswordValue: string,
-  +onSave: {| oldPassword: string, newPassword: string |} => void,
+  +onSave: {| oldPassword: string, newPassword: string |} => PossiblyAsync<void>,
   +onCancel: void => void,
   +onDataChange: { [key: string]: any } => void,
   +onPasswordSwitchToggle: void => void,
@@ -103,13 +103,13 @@ export default class ChangeWalletPasswordDialog extends Component<Props> {
 
   submit = () => {
     this.form.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         const { currentPassword, walletPassword } = form.values();
         const passwordData = {
           oldPassword: currentPassword || null,
           newPassword: walletPassword,
         };
-        this.props.onSave(passwordData);
+        await this.props.onSave(passwordData);
       },
       onError: () => {},
     });

--- a/app/components/wallet/settings/paper-wallets/CreatePaperDialog.js
+++ b/app/components/wallet/settings/paper-wallets/CreatePaperDialog.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component } from 'react';
+import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import { defineMessages, intlShape } from 'react-intl';
@@ -60,6 +61,7 @@ type Props = {|
   +onCancel: void => PossiblyAsync<void>,
   +onDownload: void => PossiblyAsync<void>,
   +onDataChange: { [key: string]: any } => void,
+  +loadingGif: Node,
   +classicTheme: boolean,
 |};
 
@@ -165,7 +167,7 @@ export default class CreatePaperDialog extends Component<Props> {
         classicTheme={classicTheme}
       >
         <div className={styles.walletLoaderWrapper}>
-          <div className={styles.walletLoader} />
+          {this.props.loadingGif}
           <div className={styles.walletLoaderTitle}>
             {this.context.intl.formatMessage(messages.progressTitleCreatePaperWallet)}
           </div>

--- a/app/components/wallet/settings/paper-wallets/CreatePaperDialog.js
+++ b/app/components/wallet/settings/paper-wallets/CreatePaperDialog.js
@@ -56,9 +56,9 @@ const messages = defineMessages({
 type Props = {|
   +renderStatus: ?PdfGenStepType,
   +paperFile: ?Blob,
-  +onNext: void => void,
-  +onCancel: void => void,
-  +onDownload: void => void,
+  +onNext: void => PossiblyAsync<void>,
+  +onCancel: void => PossiblyAsync<void>,
+  +onDownload: void => PossiblyAsync<void>,
   +onDataChange: { [key: string]: any } => void,
   +classicTheme: boolean,
 |};

--- a/app/components/wallet/settings/paper-wallets/CreatePaperDialog.scss
+++ b/app/components/wallet/settings/paper-wallets/CreatePaperDialog.scss
@@ -32,18 +32,7 @@
     color: var(--cmn-default-color-grey-3);
   }
   
-  .walletLoaderWrapper {
-    .walletLoader {
-      display: inline-block;
-      background-repeat: no-repeat;
-      background-size: contain;
-      background-position: center center;
-      margin-top: 10px;
-      margin-bottom: 20px;
-      width: 170px;
-      height: 190px;
-    }    
-  
+  .walletLoaderWrapper { 
     .walletLoaderTitle {
       word-break: break-all;
       font-size: 16px;
@@ -60,10 +49,6 @@
 
 :global(.YoroiClassic) {
   .component {
-    .walletLoader {
-      background-image: url("../../../../assets/images/paper-wallet/create-paper-wallet-loader-classic.gif");
-    }
-
     .downloadIcon {
       background-image: url("../../../../assets/images/paper-wallet/download-certificate-classic.inline.svg");
     }
@@ -72,10 +57,6 @@
 
 :global(.YoroiModern) {
   .component {
-    .walletLoader {
-      background-image: url("../../../../assets/images/paper-wallet/create-paper-wallet-loader-modern.gif");
-    }
-
     .downloadIcon {
       background-image: url("../../../../assets/images/paper-wallet/download-certificate-modern.inline.svg");
     }    

--- a/app/components/wallet/settings/paper-wallets/FinalizeDialog.js
+++ b/app/components/wallet/settings/paper-wallets/FinalizeDialog.js
@@ -48,9 +48,9 @@ type Props = {|
   +notification: ?Notification,
   +selectedExplorer: ExplorerType,
   +paper: AdaPaper,
-  +onNext: void => void,
-  +onCancel: void => void,
-  +onBack?: void => void,
+  +onNext: void => PossiblyAsync<void>,
+  +onCancel: void => PossiblyAsync<void>,
+  +onBack?: void => PossiblyAsync<void>,
   +classicTheme: boolean,
 |};
 

--- a/app/components/wallet/settings/paper-wallets/LoadingGif.js
+++ b/app/components/wallet/settings/paper-wallets/LoadingGif.js
@@ -1,0 +1,50 @@
+// @flow
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import styles from './LoadingGif.scss';
+
+function getBgUrl(el) {
+  let bg = '';
+  // $FlowDisable flow doesn't work that well for HTML access
+  if (el.currentStyle != null) { // IE
+    bg = el.currentStyle.backgroundImage;
+  } else if (document.defaultView && document.defaultView.getComputedStyle) { // Firefox
+    bg = document.defaultView.getComputedStyle(el, '').backgroundImage;
+  } else { // try and get inline style
+    bg = el.style.backgroundImage;
+  }
+  return bg.replace(/url\(['"]?(.*?)['"]?\)/i, '$1');
+}
+
+type State = {|
+  isLoaded: boolean,
+  image: HTMLImageElement,
+|};
+
+@observer
+export default class LoadingGif extends Component<{||}, State> {
+  state = {
+    isLoaded: false,
+    image: document.createElement('img'),
+  };
+
+  componentDidMount() {
+    const loadingImg = getBgUrl(document.getElementsByClassName(styles.component)[0]);
+    this.state.image.src = loadingImg;
+    this.state.image.onload = () => {
+      this.setState({ isLoaded: true, });
+    };
+  }
+
+  componentWillUnmount() {
+    this.state.image.onload = null;
+  }
+
+  render() {
+    return (
+      <div className={styles.component}>
+        {!this.state.isLoaded && <div className={styles.spinner} />}
+      </div>
+    );
+  }
+}

--- a/app/components/wallet/settings/paper-wallets/LoadingGif.scss
+++ b/app/components/wallet/settings/paper-wallets/LoadingGif.scss
@@ -1,0 +1,29 @@
+
+@import '../../../../themes/mixins/loading-spinner';
+
+.component {
+  display: inline-block;
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center center;
+  margin-top: 10px;
+  margin-bottom: 20px;
+  width: 170px;
+  height: 190px;
+}
+
+.spinner {
+  @include loading-spinner("../../../../assets/images/spinner-dark.svg");
+}
+
+:global(.YoroiClassic) {
+  .component {
+    background-image: url("../../../../assets/images/paper-wallet/create-paper-wallet-loader-classic.gif");
+  }
+}
+
+:global(.YoroiModern) {
+  .component {
+    background-image: url("../../../../assets/images/paper-wallet/create-paper-wallet-loader-modern.gif");
+  }
+}

--- a/app/components/wallet/settings/paper-wallets/UserPasswordDialog.js
+++ b/app/components/wallet/settings/paper-wallets/UserPasswordDialog.js
@@ -53,8 +53,8 @@ const messages = defineMessages({
 type Props = {|
   +passwordValue: string,
   +repeatedPasswordValue: string,
-  +onNext: {| userPassword: string |} => void,
-  +onCancel: void => void,
+  +onNext: {| userPassword: string |} => PossiblyAsync<void>,
+  +onCancel: void => PossiblyAsync<void>,
   +onDataChange: { [key: string]: any } => void,
   +classicTheme: boolean,
 |};
@@ -112,9 +112,9 @@ export default class UserPasswordDialog extends Component<Props> {
 
   submit = () => {
     this.form.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         const { paperPassword } = form.values();
-        this.props.onNext({ userPassword: paperPassword });
+        await this.props.onNext({ userPassword: paperPassword });
       },
       onError: () => {},
     });

--- a/app/components/wallet/staking/DelegationSuccessDialog.js
+++ b/app/components/wallet/staking/DelegationSuccessDialog.js
@@ -24,7 +24,7 @@ const messages = defineMessages({
 });
 
 type Props = {|
-  +onClose: void => void;
+  +onClose: void => PossiblyAsync<void>;
   +classicTheme: boolean,
 |};
 

--- a/app/components/wallet/staking/DelegationTxDialog.js
+++ b/app/components/wallet/staking/DelegationTxDialog.js
@@ -67,7 +67,7 @@ type Props = {|
   +approximateReward: BigNumber,
   +isSubmitting: boolean,
   +onCancel: void => void,
-  +onSubmit: ({| password: string |}) => void,
+  +onSubmit: ({| password: string |}) => PossiblyAsync<void>,
   +classicTheme: boolean,
   +error: ?LocalizableError,
 |};
@@ -107,12 +107,12 @@ export default class DelegationTxDialog extends Component<Props> {
 
   submit() {
     this.form.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         const { walletPassword } = form.values();
         const transactionData = {
           password: walletPassword,
         };
-        this.props.onSubmit(transactionData);
+        await this.props.onSubmit(transactionData);
       },
       onError: () => {}
     });

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -33,7 +33,7 @@ type Props = {|
   +assuranceMode: AssuranceMode,
   +walletId: string,
   +formattedWalletAmount: BigNumber => string,
-  +onLoadMore: void => void,
+  +onLoadMore: void => PossiblyAsync<void>,
 |};
 
 @observer

--- a/app/components/widgets/Dialog.js
+++ b/app/components/widgets/Dialog.js
@@ -12,7 +12,7 @@ import styles from './Dialog.scss';
 
 type ActionType = {
   +label: string,
-  +onClick: void => void,
+  +onClick: void => PossiblyAsync<void>,
   +primary?: boolean,
   +disabled?: boolean,
   +className?: ?string
@@ -26,7 +26,7 @@ type Props = {|
   +backButton?: Node,
   +className?: string,
   +styleOveride?: {},
-  +onClose?: ?(void => void),
+  +onClose?: ?(void => PossiblyAsync<void>),
   +closeOnOverlayClick?: boolean,
   +classicTheme: boolean
 |};

--- a/app/components/widgets/DialogBackButton.js
+++ b/app/components/widgets/DialogBackButton.js
@@ -4,7 +4,7 @@ import BackArrow from '../../assets/images/back-arrow-ic.inline.svg';
 import styles from './DialogBackButton.scss';
 
 type Props = {|
-  +onBack: void => void
+  +onBack: void => PossiblyAsync<void>
 |};
 
 export default class DialogBackButton extends Component<Props> {

--- a/app/components/widgets/DialogCloseButton.js
+++ b/app/components/widgets/DialogCloseButton.js
@@ -4,7 +4,7 @@ import CloseCross from '../../assets/images/close-cross.inline.svg';
 import styles from './DialogCloseButton.scss';
 
 type Props = {|
-  +onClose?: void => void,
+  +onClose?: void => PossiblyAsync<void>,
   +icon?: ?string,
 |};
 

--- a/app/components/widgets/forms/InlineEditingInput.js
+++ b/app/components/widgets/forms/InlineEditingInput.js
@@ -33,7 +33,7 @@ type Props = {|
   +onStartEditing: void => void,
   +onStopEditing: void => void,
   +onCancelEditing: void => void,
-  +onSubmit: string => void,
+  +onSubmit: string => PossiblyAsync<void>,
   +isValid: string => boolean,
   +validationErrorMessage: string,
   +successfullyUpdated: boolean,
@@ -82,10 +82,10 @@ export default class InlineEditingInput extends Component<Props, State> {
 
   submit = () => {
     this.validator.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         const { inputField } = form.values();
         if (inputField !== this.props.inputFieldValue) {
-          this.props.onSubmit(inputField);
+          await this.props.onSubmit(inputField);
           this.props.onStopEditing();
         } else {
           this.props.onCancelEditing();

--- a/app/containers/TopBarContainer.js
+++ b/app/containers/TopBarContainer.js
@@ -13,8 +13,8 @@ type Props = InjectedProps;
 @observer
 export default class TopBarContainer extends Component<Props> {
 
-  updateHideBalance = () => {
-    this.props.actions.profile.updateHideBalance.trigger();
+  updateHideBalance = async (): Promise<void> => {
+    await this.props.actions.profile.updateHideBalance.trigger();
   }
 
   render() {

--- a/app/containers/profile/LanguageSelectionPage.js
+++ b/app/containers/profile/LanguageSelectionPage.js
@@ -48,8 +48,8 @@ export default class LanguageSelectionPage extends Component<InjectedProps> {
     this.props.actions.profile.updateTentativeLocale.trigger(values);
   };
 
-  onSubmit = (_values: {| locale: string |}) => {
-    this.props.actions.profile.commitLocaleToStorage.trigger();
+  onSubmit = async (_values: {| locale: string |}): Promise<void> => {
+    await this.props.actions.profile.commitLocaleToStorage.trigger();
   };
 
   renderByron() {

--- a/app/containers/profile/TermsOfUsePage.js
+++ b/app/containers/profile/TermsOfUsePage.js
@@ -25,10 +25,6 @@ export default class TermsOfUsePage extends Component<InjectedProps> {
     intl: intlShape.isRequired,
   };
 
-  onSubmit = () => {
-    this.props.actions.profile.acceptTermsOfUse.trigger();
-  };
-
   render() {
     const { setTermsOfUseAcceptanceRequest, termsOfUse } = this.props.stores.profile;
     const isSubmitting = setTermsOfUseAcceptanceRequest.isExecuting;
@@ -51,7 +47,7 @@ export default class TermsOfUsePage extends Component<InjectedProps> {
       >
         <TermsOfUseForm
           localizedTermsOfUse={termsOfUse}
-          onSubmit={this.onSubmit}
+          onSubmit={this.props.actions.profile.acceptTermsOfUse.trigger}
           isSubmitting={isSubmitting}
           error={setTermsOfUseAcceptanceRequest.error}
         />

--- a/app/containers/profile/UriPromptPage.js
+++ b/app/containers/profile/UriPromptPage.js
@@ -53,10 +53,6 @@ export default class UriPromptPage extends Component<InjectedProps> {
     });
   };
 
-  onFinalSubmit = () => {
-    this.props.actions.profile.acceptUriScheme.trigger();
-  };
-
   _getContent = () => {
     const { profile } = this.props.stores;
     switch (this.selectedChoice) {
@@ -68,13 +64,13 @@ export default class UriPromptPage extends Component<InjectedProps> {
         />;
       case Choices.ACCEPT:
         return <UriAccept
-          onConfirm={this.onFinalSubmit}
+          onConfirm={this.props.actions.profile.acceptUriScheme.trigger}
           onBack={this.onBack}
           classicTheme={profile.isClassicTheme}
         />;
       case Choices.SKIP:
         return <UriSkip
-          onConfirm={this.onFinalSubmit}
+          onConfirm={this.props.actions.profile.acceptUriScheme.trigger}
           onBack={this.onBack}
           classicTheme={profile.isClassicTheme}
         />;

--- a/app/containers/settings/categories/GeneralSettingsPage.js
+++ b/app/containers/settings/categories/GeneralSettingsPage.js
@@ -10,35 +10,11 @@ import UriSettingsBlock from '../../../components/settings/categories/general-se
 import registerProtocols from '../../../uri-protocols';
 import environment from '../../../environment';
 import AboutYoroiSettingsBlock from '../../../components/settings/categories/general-setting/AboutYoroiSettingsBlock';
-import type { ExplorerType } from '../../../domain/Explorer';
 import { getExplorers } from '../../../domain/Explorer';
 
 @observer
 export default class GeneralSettingsPage extends Component<InjectedProps> {
 
-  onSelectLanguage = (values: {| locale: string |}) => {
-    this.props.actions.profile.updateLocale.trigger(values);
-  };
-
-  onSelecExplorer = (values: {| explorer: ExplorerType |}) => {
-    this.props.actions.profile.updateSelectedExplorer.trigger(values);
-  };
-
-  selectTheme = (values: {| theme: string |}) => {
-    this.props.actions.profile.updateTheme.trigger(values);
-  };
-
-  exportTheme = () => {
-    this.props.actions.profile.exportTheme.trigger();
-  };
-
-  getThemeVars = (theme: {| theme: string |}) => (
-    this.props.stores.profile.getThemeVars(theme)
-  )
-
-  hasCustomTheme = (): boolean => (
-    this.props.stores.profile.hasCustomTheme()
-  )
 
   render() {
     const {
@@ -66,14 +42,14 @@ export default class GeneralSettingsPage extends Component<InjectedProps> {
     return (
       <div>
         <GeneralSettings
-          onSelectLanguage={this.onSelectLanguage}
+          onSelectLanguage={this.props.actions.profile.updateLocale.trigger}
           isSubmitting={isSubmittingLocale}
           languages={LANGUAGE_OPTIONS}
           currentLocale={currentLocale}
           error={setProfileLocaleRequest.error}
         />
         <ExplorerSettings
-          onSelectExplorer={this.onSelecExplorer}
+          onSelectExplorer={this.props.actions.profile.updateSelectedExplorer.trigger}
           isSubmitting={isSubmittingExplorer}
           explorers={explorerOptions}
           selectedExplorer={selectedExplorer}
@@ -83,10 +59,10 @@ export default class GeneralSettingsPage extends Component<InjectedProps> {
         {!environment.isShelley() &&
           <ThemeSettingsBlock
             currentTheme={currentTheme}
-            selectTheme={this.selectTheme}
-            getThemeVars={this.getThemeVars}
-            exportTheme={this.exportTheme}
-            hasCustomTheme={this.hasCustomTheme}
+            selectTheme={this.props.actions.profile.updateTheme.trigger}
+            getThemeVars={this.props.stores.profile.getThemeVars}
+            exportTheme={this.props.actions.profile.exportTheme.trigger}
+            hasCustomTheme={this.props.stores.profile.hasCustomTheme}
             onExternalLinkClick={handleExternalLinkClick}
           />
         }

--- a/app/containers/settings/categories/WalletSettingsPage.js
+++ b/app/containers/settings/categories/WalletSettingsPage.js
@@ -56,9 +56,9 @@ export default class WalletSettingsPage extends Component<Props> {
           renameModelRequest.result === false
         }
         lastUpdatedField={lastUpdatedWalletField}
-        onFieldValueChange={(field, value) => {
+        onFieldValueChange={async (field, value) => {
           if (field === 'name') {
-            renameConceptualWallet.trigger({ newName: value });
+            await renameConceptualWallet.trigger({ newName: value });
           }
         }}
         onStartEditing={field => startEditingWalletField.trigger({ field })}

--- a/app/containers/transfer/DaedalusTransferFormPage.js
+++ b/app/containers/transfer/DaedalusTransferFormPage.js
@@ -21,7 +21,7 @@ const messages = defineMessages({
 });
 
 type Props = {|
-  +onSubmit: {| recoveryPhrase: string |} => void,
+  +onSubmit: {| recoveryPhrase: string |} => PossiblyAsync<void>,
   +onBack: void => void,
   +mnemonicValidator: string => boolean,
   +validWords: Array<string>,
@@ -52,12 +52,12 @@ export default class DaedalusTransferFormPage extends Component<Props> {
       throw new Error('DaedalusTransferFormPage form not set');
     }
     this.mnemonicForm.submit({
-      onSuccess: (form) => {
+      onSuccess: async (form) => {
         const { recoveryPhrase } = form.values();
         const payload = {
           recoveryPhrase: join(recoveryPhrase, ' '),
         };
-        this.props.onSubmit(payload);
+        await this.props.onSubmit(payload);
       },
       onError: () => {}
     });

--- a/app/containers/transfer/DaedalusTransferMasterKeyFormPage.js
+++ b/app/containers/transfer/DaedalusTransferMasterKeyFormPage.js
@@ -15,7 +15,7 @@ const messages = defineMessages({
 });
 
 type Props = {|
-  +onSubmit: { masterKey: string, } => void,
+  +onSubmit: {| masterKey: string, |} => PossiblyAsync<void>,
   +onBack: void => void,
   +classicTheme: boolean,
 |};
@@ -39,8 +39,8 @@ export default class DaedalusTransferMasterKeyFormPage extends Component<Props> 
       throw new Error('DaedalusTransferMasterKeyFormPage form not set');
     }
     this.masterKeyForm.submit({
-      onSuccess: (form) => {
-        this.props.onSubmit(form.values());
+      onSuccess: async (form) => {
+        await this.props.onSubmit(form.values());
       },
       onError: () => {}
     });

--- a/app/containers/transfer/DaedalusTransferPage.js
+++ b/app/containers/transfer/DaedalusTransferPage.js
@@ -44,43 +44,43 @@ export default class DaedalusTransferPage extends Component<InjectedProps> {
     this._getDaedalusTransferActions().startTransferMasterKey.trigger();
   }
 
-  setupTransferFundsWithMnemonic = (payload: {
+  setupTransferFundsWithMnemonic: {|
     recoveryPhrase: string,
-  }): void => {
+  |} => Promise<void> = async (payload) => {
     const walletsStore = this._getWalletsStore();
     const publicDeriver = walletsStore.selected;
     if (publicDeriver == null) {
       throw new Error('tranferFunds no wallet selected');
     }
-    this._getDaedalusTransferActions().setupTransferFundsWithMnemonic.trigger({
+    await this._getDaedalusTransferActions().setupTransferFundsWithMnemonic.trigger({
       ...payload,
       publicDeriver
     });
   };
 
-  setupTransferFundsWithMasterKey = (payload: {
+  setupTransferFundsWithMasterKey: {|
     masterKey: string,
-  }): void => {
+  |} => Promise<void> = async (payload) => {
     const walletsStore = this._getWalletsStore();
     const publicDeriver = walletsStore.selected;
     if (publicDeriver == null) {
       throw new Error('tranferFunds no wallet selected');
     }
-    this._getDaedalusTransferActions().setupTransferFundsWithMasterKey.trigger({
+    await this._getDaedalusTransferActions().setupTransferFundsWithMasterKey.trigger({
       ...payload,
       publicDeriver
     });
   };
 
   /** Broadcast the transfer transaction if one exists and return to wallet page */
-  tranferFunds = () => {
+  tranferFunds: void => Promise<void> = async () => {
     const walletsStore = this._getWalletsStore();
     const publicDeriver = walletsStore.selected;
     if (publicDeriver == null) {
       throw new Error('tranferFunds no wallet selected');
     }
     // broadcast transfer transaction then call continuation
-    this._getDaedalusTransferActions().transferFunds.trigger({
+    await this._getDaedalusTransferActions().transferFunds.trigger({
       next: () => {
         walletsStore.refreshWallet(publicDeriver);
         if (walletsStore.activeWalletRoute != null) {

--- a/app/containers/transfer/YoroiPlatePage.js
+++ b/app/containers/transfer/YoroiPlatePage.js
@@ -19,7 +19,7 @@ import { TransferKind } from '../../types/TransferTypes';
 
 type Props = {|
   ...InjectedProps,
-  +onNext: void => void,
+  +onNext: void => PossiblyAsync<void>,
   +selectedExplorer: ExplorerType,
   +onCancel: void => void,
   +recoveryPhrase: string,

--- a/app/containers/transfer/YoroiTransferPage.js
+++ b/app/containers/transfer/YoroiTransferPage.js
@@ -89,20 +89,20 @@ export default class YoroiTransferPage extends Component<InjectedProps> {
     });
   };
 
-  checkAddresses: void => void = () => {
+  checkAddresses: void => Promise<void> = async () => {
     const walletsStore = this._getWalletsStore();
     const yoroiTransfer = this._getYoroiTransferStore();
     const publicDeriver = walletsStore.selected;
     if (publicDeriver == null) {
       throw new Error(`${nameof(this.checkAddresses)} no wallet selected`);
     }
-    this._getYoroiTransferActions().checkAddresses.trigger({
+    await this._getYoroiTransferActions().checkAddresses.trigger({
       getDestinationAddress: yoroiTransfer.nextInternalAddress(publicDeriver),
     });
   };
 
   /** Broadcast the transfer transaction if one exists and return to wallet page */
-  tranferFunds: void => void = () => {
+  tranferFunds: void => Promise<void> = async () => {
     // broadcast transfer transaction then call continuation
     const walletsStore = this._getWalletsStore();
     const yoroiTransfer = this._getYoroiTransferStore();
@@ -110,7 +110,7 @@ export default class YoroiTransferPage extends Component<InjectedProps> {
     if (publicDeriver == null) {
       throw new Error(`${nameof(this.tranferFunds)} no wallet selected`);
     }
-    this._getYoroiTransferActions().transferFunds.trigger({
+    await this._getYoroiTransferActions().transferFunds.trigger({
       next: () => new Promise(resolve => {
         walletsStore.refreshWallet(publicDeriver);
         setTimeout(() => {

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -37,11 +37,11 @@ export default class WalletReceivePage extends Component<Props, State> {
     this.resetErrors();
   }
 
-  handleGenerateAddress = () => {
+  handleGenerateAddress: void => Promise<void> = async () => {
     const { wallets } = this.props.stores.substores.ada;
     const publicDeriver = wallets.selected;
     if (publicDeriver != null) {
-      this.props.actions.ada.addresses.createAddress.trigger();
+      await this.props.actions.ada.addresses.createAddress.trigger();
     }
   };
 
@@ -114,8 +114,8 @@ export default class WalletReceivePage extends Component<Props, State> {
           notification={uiNotifications.getTooltipActiveNotification(
             this.state.notificationElementId
           )}
-          onVerifyAddress={({ address, path }) => {
-            actions.ada.hwVerifyAddress.selectAddress.trigger({ address, path });
+          onVerifyAddress={async ({ address, path }) => {
+            await actions.ada.hwVerifyAddress.selectAddress.trigger({ address, path });
             this.openVerifyAddressDialog();
           }}
           onGeneratePaymentURI={(address) => {

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -74,7 +74,7 @@ export default class WalletSummaryPage extends Component<Props> {
             selectedExplorer={this.props.stores.profile.selectedExplorer}
             isLoadingTransactions={isLoadingTx}
             hasMoreToLoad={totalAvailable > limit}
-            onLoadMore={() => actions.ada.transactions.loadMoreTransactions.trigger()}
+            onLoadMore={actions.ada.transactions.loadMoreTransactions.trigger}
             assuranceMode={publicDeriver.assuranceMode}
             walletId={publicDeriver.self.getPublicDeriverId().toString()}
             formattedWalletAmount={formattedWalletAmount}

--- a/app/containers/wallet/dialogs/ChangeWalletPasswordDialogContainer.js
+++ b/app/containers/wallet/dialogs/ChangeWalletPasswordDialogContainer.js
@@ -24,9 +24,9 @@ export default class ChangeWalletPasswordDialogContainer extends Component<Injec
         currentPasswordValue={dialogData.currentPasswordValue}
         newPasswordValue={dialogData.newPasswordValue}
         repeatedPasswordValue={dialogData.repeatedPasswordValue}
-        onSave={(values) => {
+        onSave={async (values) => {
           const { oldPassword, newPassword } = values;
-          actions[environment.API].walletSettings.updateSigningPassword.trigger({
+          await actions[environment.API].walletSettings.updateSigningPassword.trigger({
             publicDeriver,
             oldPassword,
             newPassword

--- a/app/containers/wallet/dialogs/CreatePaperWalletDialogContainer.js
+++ b/app/containers/wallet/dialogs/CreatePaperWalletDialogContainer.js
@@ -9,6 +9,7 @@ import PaperWalletsActions from '../../../actions/ada/paper-wallets-actions';
 import PaperWalletCreateStore, { ProgressStep } from '../../../stores/ada/PaperWalletCreateStore';
 import { Logger } from '../../../utils/logging';
 import CreatePaperDialog from '../../../components/wallet/settings/paper-wallets/CreatePaperDialog';
+import LoadingGif from '../../../components/wallet/settings/paper-wallets/LoadingGif';
 import WalletRestoreDialog from '../../../components/wallet/WalletRestoreDialog';
 import validWords from 'bip39/src/wordlists/english.json';
 import FinalizeDialog from '../../../components/wallet/settings/paper-wallets/FinalizeDialog';
@@ -94,6 +95,7 @@ export default class CreatePaperWalletDialogContainer extends Component<Injected
             paperFile={paperStore.pdf}
             onNext={paperActions.submitCreate.trigger}
             onCancel={onCancel}
+            loadingGif={<LoadingGif />}
             onDownload={paperActions.downloadPaperWallet.trigger}
             onDataChange={data => {
               updateDataForActiveDialog.trigger({ data });

--- a/app/containers/wallet/dialogs/WalletBackupDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletBackupDialogContainer.js
@@ -70,9 +70,7 @@ export default class WalletBackupDialogContainer extends Component<Props> {
         onAcceptTermRecovery={acceptWalletBackupTermRecovery.trigger}
         onAddWord={addWordToWalletBackupVerification.trigger}
         onClear={clearEnteredRecoveryPhrase.trigger}
-        onFinishBackup={() => {
-          finishWalletBackup.trigger();
-        }}
+        onFinishBackup={finishWalletBackup.trigger}
         removeWord={() => {
           removeOneMnemonicWord.trigger();
         }}

--- a/app/containers/wallet/dialogs/WalletCreateDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletCreateDialogContainer.js
@@ -10,15 +10,11 @@ type Props = InjectedDialogContainerProps;
 @observer
 export default class WalletCreateDialogContainer extends Component<Props> {
 
-  onSubmit = (values: {| name: string, password: string |}) => {
-    this.props.actions[environment.API].wallets.createWallet.trigger(values);
-  };
-
   render() {
     return (
       <WalletCreateDialog
         classicTheme={this.props.classicTheme}
-        onSubmit={this.onSubmit}
+        onSubmit={this.props.actions[environment.API].wallets.createWallet.trigger}
         onCancel={this.props.onClose}
       />
     );

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -169,8 +169,8 @@ export default class WalletRestoreDialogContainer
           <LegacyExplanation
             onBack={() => walletRestoreActions.back.trigger()}
             onClose={this.onCancel}
-            onSkip={() => walletRestoreActions.startRestore.trigger()}
-            onCheck={() => walletRestoreActions.startCheck.trigger()}
+            onSkip={walletRestoreActions.startRestore.trigger}
+            onCheck={walletRestoreActions.startCheck.trigger}
             classicTheme={this.props.classicTheme}
           />
         );

--- a/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
@@ -55,9 +55,9 @@ export default class WalletSendConfirmationDialogContainer extends Component<Pro
         totalAmount={formattedWalletAmount(totalInput)}
         transactionFee={formattedWalletAmount(fee)}
         amountToNaturalUnits={formattedAmountToNaturalUnits}
-        onSubmit={({ password }) => {
+        onSubmit={async ({ password }) => {
           const copyRequest = copySignRequest(signRequest);
-          sendMoney.trigger({
+          await sendMoney.trigger({
             signRequest: copyRequest,
             password,
           });

--- a/app/stores/ada/DelegationStore.js
+++ b/app/stores/ada/DelegationStore.js
@@ -53,7 +53,7 @@ export default class DelegationStore extends Store {
   }
 
   @action.bound
-  _startWatch: void => Promise<void> = async () => {
+  _startWatch: void => void = () => {
     this._recalculateDelegationInfoDisposer = reaction(
       () => [
         this.stores.substores.ada.wallets.selected,

--- a/app/stores/ada/PaperWalletCreateStore.js
+++ b/app/stores/ada/PaperWalletCreateStore.js
@@ -58,7 +58,7 @@ export default class PaperWalletCreateStore extends Store {
     a.cancel.listen(this._cancel);
   }
 
-  @action _submitInit = async (
+  @action _submitInit = (
     {
       numAddresses,
       printAccountPlate
@@ -66,40 +66,37 @@ export default class PaperWalletCreateStore extends Store {
       numAddresses: number,
       printAccountPlate: boolean
     }
-  ): Promise<void> => {
+  ): void => {
     this.numAddresses = numAddresses;
     this.printAccountPlate = printAccountPlate;
     this.progressInfo = ProgressStep.USER_PASSWORD;
   };
 
-  @action _submitUserPassword = async ({ userPassword }: {| userPassword: string |}) => {
+  @action _submitUserPassword: {|
+    userPassword: string
+  |} => Promise<void> = async ({ userPassword }) => {
     if (this.userPassword != null) {
       throw new Error('User password is already initialized');
     }
     this.userPassword = userPassword;
     this.progressInfo = ProgressStep.CREATE;
     this.actions.ada.paperWallets.createPaperWallet.trigger();
-    // setTimeout is needed to fix:
-    // https://github.com/Emurgo/yoroi-frontend/pull/584#pullrequestreview-249311058
-    // createPdfDocument is heavyweight and blocking
-    setTimeout(() => {
-      this.actions.ada.paperWallets.createPdfDocument.trigger();
-    }, 0);
+    await this.actions.ada.paperWallets.createPdfDocument.trigger();
   };
 
-  @action _backToCreatePaper = async () => {
+  @action _backToCreatePaper = () => {
     this.progressInfo = ProgressStep.CREATE;
   };
 
-  @action _submitCreatePaper = async () => {
+  @action _submitCreatePaper = () => {
     this.progressInfo = ProgressStep.VERIFY;
   };
 
-  @action _submitVerifyPaper = async () => {
+  @action _submitVerifyPaper = () => {
     this.progressInfo = ProgressStep.FINALIZE;
   };
 
-  @action _createPaperWallet = async () => {
+  @action _createPaperWallet = () => {
     if (this.numAddresses != null && this.userPassword != null) {
       this.paper = this.api.ada.createAdaPaper({
         numAddresses: this.numAddresses,
@@ -128,19 +125,19 @@ export default class PaperWalletCreateStore extends Store {
     }
   };
 
-  @action _setPdfRenderStatus = async ({ status }: { status: PdfGenStepType }) => {
+  @action _setPdfRenderStatus = ({ status }: {| status: PdfGenStepType |}) => {
     this.pdfRenderStatus = status;
   };
 
-  @action _setPdf = async ({ pdf }: { pdf: Blob }) => {
+  @action _setPdf = ({ pdf }: {| pdf: Blob |}) => {
     this.pdf = pdf;
   };
 
-  @action _downloadPaperWallet = async () => {
+  @action _downloadPaperWallet = () => {
     fileSaver.saveAs(this.pdf, 'Yoroi-Paper-Wallet.pdf');
   };
 
-  @action _cancel = async () => {
+  @action _cancel = () => {
     this.teardown();
   };
 

--- a/app/stores/ada/WalletRestoreStore.js
+++ b/app/stores/ada/WalletRestoreStore.js
@@ -70,13 +70,13 @@ export default class WalletRestoreStore extends Store {
     actions.back.listen(this._back);
   }
 
-  _transferFromLegacy: void => void = () => {
+  _transferFromLegacy: void => Promise<void> = async () => {
     const phrase = this.recoveryResult?.phrase;
     if (phrase == null) {
       throw new Error(`${nameof(this._transferFromLegacy)} no recovery phrase set. Should never happen`);
     }
-    this.actions.ada.yoroiTransfer.transferFunds.trigger({
-      next: async () => { this._startRestore(); },
+    await this.actions.ada.yoroiTransfer.transferFunds.trigger({
+      next: async () => { await this._startRestore(); },
       getDestinationAddress: () => Promise.resolve(this._getFirstInternalAddr(phrase)),
       // funds in genesis block should be either entirely claimed or not claimed
       // so if another wallet instance claims the funds, it's not a big deal
@@ -111,7 +111,7 @@ export default class WalletRestoreStore extends Store {
   }
 
   @action
-  _startCheck: void => void = () => {
+  _startCheck: void => Promise<void> = async () => {
     const phrase = this.recoveryResult?.phrase;
     if (phrase == null) {
       throw new Error(`${nameof(this._startCheck)} no recovery phrase set. Should never happen`);
@@ -126,17 +126,17 @@ export default class WalletRestoreStore extends Store {
     runInAction(() => { this.step = RestoreSteps.TRANSFER_TX_GEN; });
 
     const internalAddrHash = this._getFirstInternalAddr(phrase);
-    this.actions.ada.yoroiTransfer.checkAddresses.trigger({
+    await this.actions.ada.yoroiTransfer.checkAddresses.trigger({
       getDestinationAddress: () => Promise.resolve(internalAddrHash),
     });
   }
 
   @action
-  _verifyMnemonic: void => void = () => {
+  _verifyMnemonic: void => Promise<void> = async () => {
     if (environment.isShelley()) {
       runInAction(() => { this.step = RestoreSteps.LEGACY_EXPLANATION; });
     } else {
-      this._startRestore();
+      await this._startRestore();
     }
   }
 
@@ -204,13 +204,13 @@ export default class WalletRestoreStore extends Store {
   }
 
   @action
-  _startRestore: void => void = () => {
+  _startRestore: void => Promise<void> = async () => {
     if (this.recoveryResult == null || this.walletRestoreMeta == null) {
       throw new Error(
         `${nameof(this._startRestore)} Cannot submit wallet restoration! No values are available in context!`
       );
     }
-    this.actions[environment.API].wallets.restoreWallet.trigger({
+    await this.actions[environment.API].wallets.restoreWallet.trigger({
       recoveryPhrase: this.recoveryResult.phrase,
       walletName: this.walletRestoreMeta.walletName,
       walletPassword: this.walletRestoreMeta.walletPassword

--- a/app/stores/base/TransactionsStore.js
+++ b/app/stores/base/TransactionsStore.js
@@ -53,7 +53,7 @@ export default class TransactionsStore extends Store {
     actions.loadMoreTransactions.listen(this._increaseSearchLimit);
   }
 
-  @action _increaseSearchLimit = () => {
+  @action _increaseSearchLimit = async (): Promise<void> => {
     if (this.searchOptions != null) {
       this.searchOptions.limit += this.SEARCH_LIMIT_INCREASE;
       const publicDeriver = this.stores.substores[environment.API].wallets.selected;
@@ -62,7 +62,7 @@ export default class TransactionsStore extends Store {
       if (hasLevels == null) {
         return;
       }
-      this.refreshLocal(hasLevels);
+      await this.refreshLocal(hasLevels);
     }
   };
 

--- a/chrome/extension/index.js
+++ b/chrome/extension/index.js
@@ -9,7 +9,7 @@ import { setupApi } from '../../app/api/index';
 import createStores from '../../app/stores/index';
 import { translations } from '../../app/i18n/translations';
 import actions from '../../app/actions/index';
-import Action from '../../app/actions/lib/Action';
+import { Action } from '../../app/actions/lib/Action';
 import App from '../../app/App';
 import '../../app/themes/index.global.scss';
 import BigNumber from 'bignumber.js';

--- a/flow/declarations/utils.js
+++ b/flow/declarations/utils.js
@@ -22,6 +22,8 @@ declare type ToSchemaProp = <K, V>(K, V) => K;
 declare type Nullable = <K>(K) => null | K;
 declare type WithNullableFields<T: {}> = $ObjMap<T, Nullable>;
 
+declare type PossiblyAsync<T> = T | Promise<T>;
+
 /* eslint-disable no-redeclare */
 declare function arguments<A>(() => any): []
 declare function arguments<A>((A) => any): [A]


### PR DESCRIPTION
The way we connect the UI to the stores in Yoroi is through firing events to listeners. Before this PR, there was no way to block until all listeners have fired. Although this has never caused a bug in production (as far as I know), I've seen it cause weirdness while developing features a few times.

This fix now makes that you can wait on AsyncActions. Should help with code reuse and it also finally makes the `trigger` function for listeners type-check correctly.

One thing I noticed is that this seems to have made the PDF loading screen worse (or maybe it's just worse than I remember it) so I made that if the GIF is still loading, it instead shows a spinner
![image](https://user-images.githubusercontent.com/2608559/72254271-d8bb8500-3646-11ea-95de-e0dd06849e21.png)

