### PR TITLE
Improve wallet upgrade debugging

### DIFF
--- a/app/api/ada/transactions/byron/daedalusTransfer.js
+++ b/app/api/ada/transactions/byron/daedalusTransfer.js
@@ -10,8 +10,9 @@ import {
 } from '../../../../utils/logging';
 import { LOVELACES_PER_ADA } from '../../../../config/numbersConfig';
 import {
-  GenerateTransferTxError
+  GenerateTransferTxError,
 } from '../../errors';
+import LocalizableError from '../../../../i18n/LocalizableError';
 import {
   sendAllUnsignedTxFromUtxo,
 } from './transactionsV2';
@@ -72,6 +73,9 @@ export async function buildDaedalusTransferTx(payload: {
     };
   } catch (error) {
     Logger.error(`daedalusTransfer::buildTransferTx ${stringifyError(error)}`);
+    if (error instanceof LocalizableError) {
+      throw error;
+    }
     throw new GenerateTransferTxError();
   }
 }

--- a/app/api/ada/transactions/byron/yoroiTransfer.js
+++ b/app/api/ada/transactions/byron/yoroiTransfer.js
@@ -11,6 +11,7 @@ import { LOVELACES_PER_ADA } from '../../../../config/numbersConfig';
 import {
   GenerateTransferTxError
 } from '../../errors';
+import LocalizableError from '../../../../i18n/LocalizableError';
 import {
   sendAllUnsignedTx,
   signTransaction,
@@ -74,6 +75,9 @@ export async function buildYoroiTransferTx(payload: {
     };
   } catch (error) {
     Logger.error(`transfer::buildTransferTx ${stringifyError(error)}`);
+    if (error instanceof LocalizableError) {
+      throw error;
+    }
     throw new GenerateTransferTxError();
   }
 }

--- a/app/api/ada/transactions/shelley/daedalusTransfer.js
+++ b/app/api/ada/transactions/shelley/daedalusTransfer.js
@@ -13,6 +13,7 @@ import { Bech32Prefix } from '../../../../config/stringConfig';
 import {
   GenerateTransferTxError
 } from '../../errors';
+import LocalizableError from '../../../../i18n/LocalizableError';
 import {
   sendAllUnsignedTxFromUtxo,
 } from './utxoTransactions';
@@ -79,6 +80,9 @@ export async function buildDaedalusTransferTx(payload: {|
     };
   } catch (error) {
     Logger.error(`daedalusTransfer::buildTransferTx ${stringifyError(error)}`);
+    if (error instanceof LocalizableError) {
+      throw error;
+    }
     throw new GenerateTransferTxError();
   }
 }

--- a/app/api/ada/transactions/shelley/yoroiTransfer.js
+++ b/app/api/ada/transactions/shelley/yoroiTransfer.js
@@ -12,6 +12,7 @@ import { addressToDisplayString } from '../../lib/storage/bridge/utils';
 import {
   GenerateTransferTxError
 } from '../../errors';
+import LocalizableError from '../../../../i18n/LocalizableError';
 import {
   sendAllUnsignedTx,
   signTransaction,
@@ -72,6 +73,9 @@ export async function buildYoroiTransferTx(payload: {|
     };
   } catch (error) {
     Logger.error(`transfer::buildTransferTx ${stringifyError(error)}`);
+    if (error instanceof LocalizableError) {
+      throw error;
+    }
     throw new GenerateTransferTxError();
   }
 }

--- a/app/api/ada/transactions/transfer/legacyDaedalus.test.js
+++ b/app/api/ada/transactions/transfer/legacyDaedalus.test.js
@@ -10,7 +10,7 @@ import {
   buildDaedalusTransferTx,
 } from './legacyDaedalus';
 import {
-  GenerateTransferTxError,
+  NotEnoughMoneyToSendError,
 } from '../../errors';
 import {
   silenceLogsForTesting,
@@ -128,7 +128,7 @@ describe('Byron era tx format tests', () => {
       getUTXOsForAddresses: (_addresses) => Promise.resolve([utxo]),
       outputAddr: outAddress,
       legacy: true,
-    })).rejects.toThrow(GenerateTransferTxError);
+    })).rejects.toThrow(NotEnoughMoneyToSendError);
   });
 
   test('Daedalus transfer from many UTXO', async () => {
@@ -280,7 +280,7 @@ describe('Shelley era tx format tests', () => {
       getUTXOsForAddresses: (_addresses) => Promise.resolve([utxo]),
       outputAddr: outAddress,
       legacy: false,
-    })).rejects.toThrow(GenerateTransferTxError);
+    })).rejects.toThrow(NotEnoughMoneyToSendError);
   });
 
   test('Daedalus transfer from many UTXO', async () => {

--- a/app/components/transfer/TransferSummaryPage.js
+++ b/app/components/transfer/TransferSummaryPage.js
@@ -12,6 +12,7 @@ import LocalizableError from '../../i18n/LocalizableError';
 import RawHash from '../widgets/hashWrappers/RawHash';
 import ExplorableHashContainer from '../../containers/widgets/ExplorableHashContainer';
 import type { ExplorerType } from '../../domain/Explorer';
+import globalMessages from '../../i18n/global-messages';
 
 const messages = defineMessages({
   addressFromLabel: {
@@ -140,6 +141,22 @@ export default class TransferSummaryPage extends Component<Props> {
           >
             <RawHash light>
               <span className={styles.address}>{receiver}</span>
+            </RawHash>
+          </ExplorableHashContainer>
+        </div>
+
+        <div className={styles.addressLabelWrapper}>
+          <div className={styles.addressLabel}>
+            {intl.formatMessage(globalMessages.transactionId)}
+          </div>
+          <ExplorableHashContainer
+            selectedExplorer={this.props.selectedExplorer}
+            light
+            hash={transferTx.id}
+            linkType="transaction"
+          >
+            <RawHash light>
+              <span className={styles.address}>{transferTx.id}</span>
             </RawHash>
           </ExplorableHashContainer>
         </div>

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -12,7 +12,7 @@ import { uniq } from 'lodash';
 import styles from './Transaction.scss';
 import AdaSymbol from '../../../assets/images/ada-symbol.inline.svg';
 import WalletTransaction from '../../../domain/WalletTransaction';
-import { environmentSpecificMessages } from '../../../i18n/global-messages';
+import globalMessages, { environmentSpecificMessages } from '../../../i18n/global-messages';
 import type { TransactionDirectionType, } from '../../../api/ada/transactions/types';
 import { transactionTypes } from '../../../api/ada/transactions/types';
 import type { AssuranceLevel } from '../../../types/transactionAssuranceTypes';
@@ -44,10 +44,6 @@ const messages = defineMessages({
   confirmations: {
     id: 'wallet.transaction.confirmations',
     defaultMessage: '!!!confirmations',
-  },
-  transactionId: {
-    id: 'wallet.transaction.transactionId',
-    defaultMessage: '!!!Transaction ID',
   },
   conversionRate: {
     id: 'wallet.transaction.conversion.rate',
@@ -377,7 +373,7 @@ export default class Transaction extends Component<Props, State> {
                 </div>
               ) : null}
 
-              <h2>{intl.formatMessage(messages.transactionId)}</h2>
+              <h2>{intl.formatMessage(globalMessages.transactionId)}</h2>
               <ExplorableHashContainer
                 selectedExplorer={this.props.selectedExplorer}
                 hash={data.id}

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -233,7 +233,7 @@ export default class WalletRestoreDialogContainer
         );
       case TransferStatus.READY_TO_TRANSFER: {
         if (yoroiTransfer.transferTx == null) {
-          return null; // TODO: throw error? Shoudln't happen
+          return null; // TODO: throw error? Shouldn't happen
         }
         return (<TransferSummaryPage
           formattedWalletAmount={formattedWalletAmount}

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -437,6 +437,10 @@ const globalMessages = defineMessages({
     id: 'wallet.delegation.transaction.generation',
     defaultMessage: '!!!Generating transaction',
   },
+  transactionId: {
+    id: 'wallet.transaction.transactionId',
+    defaultMessage: '!!!Transaction ID',
+  },
   epochLabel: {
     id: 'global.labels.epoch',
     defaultMessage: '!!!Epoch',


### PR DESCRIPTION
PR improves on two things:

# 1) Add expected transaction ID to the wallet upgrade page

This allows us to ask users for their transaction ID if the wallet upgrade is failing

![image](https://user-images.githubusercontent.com/2608559/72614682-4385fc80-3976-11ea-8f20-c393a9a908e5.png)

![image](https://user-images.githubusercontent.com/2608559/72614695-484ab080-3976-11ea-9df7-088b688860e8.png)

# 2) Show proper error message if wallet upgrade is failing

Before
![image](https://user-images.githubusercontent.com/2608559/72614718-5698cc80-3976-11ea-968b-91ca132b8e4d.png)

After
![image](https://user-images.githubusercontent.com/2608559/72614725-5a2c5380-3976-11ea-9605-538b48d2184a.png)
