### PR TITLE
Approximate rewards UI properly compounds rewards

### DIFF
--- a/app/actions/ada/delegation-transaction-actions.js
+++ b/app/actions/ada/delegation-transaction-actions.js
@@ -1,16 +1,13 @@
 // @flow
 import { AsyncAction, Action } from '../lib/Action';
-
-export type PoolRequest =
-  void |
-  {| id: string |} |
-  Array<{|
-    id: string,
-    part: number,
-  |}>;
+import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
+import type { PoolRequest } from '../../api/ada/lib/storage/bridge/delegationUtils';
 
 export default class DelegationTransactionActions {
-  createTransaction: AsyncAction<PoolRequest> = new AsyncAction();
+  createTransaction: AsyncAction<{|
+    publicDeriver: PublicDeriverWithCachedMeta,
+    poolRequest: PoolRequest,
+  |}> = new AsyncAction();
   signTransaction: AsyncAction<{| password: string |}> = new AsyncAction();
   complete: AsyncAction<void> = new AsyncAction();
   reset: Action<void> = new Action();

--- a/app/components/wallet/staking/dashboard/StakingDashboard.js
+++ b/app/components/wallet/staking/dashboard/StakingDashboard.js
@@ -76,9 +76,11 @@ export default class StakingDashboard extends Component<Props> {
 
     const pendingTxWarningComponent = this.props.hasAnyPending
       ? (
-        <WarningBox>
-          {this.context.intl.formatMessage(messages.pendingTxWarning)}
-        </WarningBox>
+        <div className={styles.warningBox}>
+          <WarningBox>
+            {this.context.intl.formatMessage(messages.pendingTxWarning)}
+          </WarningBox>
+        </div>
       )
       : (null);
 

--- a/app/components/wallet/staking/dashboard/StakingDashboard.scss
+++ b/app/components/wallet/staking/dashboard/StakingDashboard.scss
@@ -8,6 +8,10 @@
   flex-direction: column;
 }
 
+.warningBox {
+  margin-bottom: 16px;
+}
+
 .contentWrap {
   max-width: 1178px;
   width: 100%;

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -142,7 +142,7 @@ export default class WalletTransactionsList extends Component<Props> {
           </div>
         ))}
         {loadingSpinner}
-        {hasMoreToLoad &&
+        {!isLoadingTransactions && hasMoreToLoad &&
           <Button
             disabled={isLoadingTransactions}
             className={buttonClasses}

--- a/app/containers/wallet/staking/SeizaFetcher.js
+++ b/app/containers/wallet/staking/SeizaFetcher.js
@@ -45,9 +45,14 @@ export default class SeizaFetcher extends Component<Props> {
     if (event.origin !== process.env.SEIZA_FOR_YOROI_URL) return;
     const pools: Array<SelectedPool> = JSON.parse(decodeURI(event.data));
 
+    const selectedWallet = this.props.stores.substores[environment.API].wallets.selected;
+    if (selectedWallet == null) {
+      return;
+    }
     const delegationTxActions = this.props.actions[environment.API].delegationTransaction;
     await delegationTxActions.createTransaction.trigger({
-      id: pools[0].poolHash,
+      poolRequest: { id: pools[0].poolHash },
+      publicDeriver: selectedWallet,
     });
     runInAction(() => { this.selectedPools = pools; });
   }
@@ -151,9 +156,9 @@ export default class SeizaFetcher extends Component<Props> {
             staleTx={delegationTxStore.isStale}
             poolName={this.selectedPools[0].name}
             poolHash={this.selectedPools[0].poolHash}
-            transactionFee={getShelleyTxFee(delegationTx.IOs, true)}
-            amountToDelegate={delegationTxStore.amountToDelegate}
-            approximateReward={approximateReward(delegationTxStore.amountToDelegate)}
+            transactionFee={getShelleyTxFee(delegationTx.unsignedTx.IOs, true)}
+            amountToDelegate={delegationTx.totalAmountToDelegate}
+            approximateReward={approximateReward(delegationTx.totalAmountToDelegate)}
             isSubmitting={
               delegationTxStore.signAndBroadcastDelegationTx.isExecuting
             }

--- a/app/stores/ada/DelegationTransactionStore.js
+++ b/app/stores/ada/DelegationTransactionStore.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { observable, action, reaction, runInAction } from 'mobx';
+import { observable, action, reaction } from 'mobx';
 import BigNumber from 'bignumber.js';
 import Store from '../base/Store';
 import LocalizedRequest from '../lib/LocalizedRequest';
@@ -11,22 +11,14 @@ import type {
 } from '../../api/ada';
 import { buildRoute } from '../../utils/routing';
 import { ROUTES } from '../../routes-config';
-import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 import {
   asGetAllUtxos, asHasUtxoChains, asGetAllAccounting, asGetSigningKey,
 } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
 import {
   PublicDeriver,
 } from '../../api/ada/lib/storage/models/PublicDeriver/index';
-import type {
-  IGetAllUtxosResponse
-} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
-import type { PoolRequest } from '../../actions/ada/delegation-transaction-actions';
-import {
-  filterAddressesByStakingKey,
-  groupAddrContainsAccountKey,
-} from '../../api/ada/lib/storage/bridge/utils';
-import type { V3UnsignedTxAddressedUtxoResponse } from '../../api/ada/transactions/types';
+import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
+import type { PoolRequest } from '../../api/ada/lib/storage/bridge/delegationUtils';
 
 export default class DelegationTransactionStore extends Store {
 
@@ -37,8 +29,6 @@ export default class DelegationTransactionStore extends Store {
     = new LocalizedRequest<SignAndBroadcastDelegationTxFunc>(
       this.api.ada.signAndBroadcastDelegationTx
     );
-
-  @observable amountToDelegate: BigNumber;
 
   /** tracks if wallet balance changed during confirmation screen */
   @observable isStale: boolean = false;
@@ -74,12 +64,11 @@ export default class DelegationTransactionStore extends Store {
   }
 
   @action
-  _createTransaction: PoolRequest => Promise<void> = async (request) => {
-    const publicDeriver = this.stores.substores.ada.wallets.selected;
-    if (publicDeriver == null) {
-      throw new Error(`${nameof(this._createTransaction)} no public deriver selected`);
-    }
-    const withUtxos = asGetAllUtxos(publicDeriver.self);
+  _createTransaction: {|
+    publicDeriver: PublicDeriverWithCachedMeta,
+    poolRequest: PoolRequest,
+  |} => Promise<void> = async (request) => {
+    const withUtxos = asGetAllUtxos(request.publicDeriver.self);
     if (withUtxos == null) {
       throw new Error(`${nameof(this._createTransaction)} missing utxo functionality`);
     }
@@ -93,50 +82,15 @@ export default class DelegationTransactionStore extends Store {
     }
     const basePubDeriver = withStakingKey;
 
-    let stakingKey;
-    {
-      const stakingKeyResp = await basePubDeriver.getStakingKey();
-      const accountAddress = RustModule.WalletV3.Address.from_bytes(
-        Buffer.from(stakingKeyResp.addr.Hash, 'hex')
-      ).to_account_address();
-      if (accountAddress == null) {
-        throw new Error(`${nameof(this._createTransaction)} staking key invalid`);
-      }
-      stakingKey = accountAddress.get_account_key();
-    }
-
-    const certificate = createCertificate(stakingKey, request);
-
     const delegationTxPromise = this.createDelegationTx.execute({
       publicDeriver: basePubDeriver,
-      certificate: RustModule.WalletV3.Certificate.stake_delegation(certificate),
+      poolRequest: request.poolRequest,
+      valueInAccount: this.stores.substores.ada.delegation.stakingKeyState?.state.value ?? 0
     }).promise;
     if (delegationTxPromise == null) {
       throw new Error(`${nameof(this._createTransaction)} should never happen`);
     }
-    const delegationTx = await delegationTxPromise;
-
-    {
-      const allUtxo = await basePubDeriver.getAllUtxos();
-      const allUtxosForKey = filterAddressesByStakingKey(
-        stakingKey,
-        allUtxo
-      );
-      const utxoSum = allUtxosForKey.reduce(
-        (sum, utxo) => sum.plus(new BigNumber(utxo.output.UtxoTransactionOutput.Amount)),
-        new BigNumber(0)
-      );
-
-      const differenceAfterTx = getDifferenceAfterTx(
-        delegationTx,
-        allUtxo,
-        stakingKey
-      );
-
-      // we substract any part of the fee that comes from UTXO of the staking key
-      const total = utxoSum.plus(differenceAfterTx);
-      runInAction(() => { this.amountToDelegate = total; });
-    }
+    await delegationTxPromise;
 
     this.markStale(false);
   }
@@ -166,10 +120,10 @@ export default class DelegationTransactionStore extends Store {
     await this.signAndBroadcastDelegationTx.execute({
       publicDeriver: basePubDeriver,
       signRequest: {
-        certificate: result.certificate,
-        changeAddr: result.changeAddr,
-        senderUtxos: result.senderUtxos,
-        unsignedTx: result.IOs,
+        certificate: result.unsignedTx.certificate,
+        changeAddr: result.unsignedTx.changeAddr,
+        senderUtxos: result.unsignedTx.senderUtxos,
+        unsignedTx: result.unsignedTx.IOs,
       },
       password: request.password,
       sendTx: this.stores.substores.ada.stateFetchStore.fetcher.sendTx,
@@ -200,95 +154,5 @@ export default class DelegationTransactionStore extends Store {
     this.signAndBroadcastDelegationTx.reset();
     this.createDelegationTx.reset();
     this.isStale = false;
-    this.amountToDelegate = new BigNumber(0);
   }
-}
-
-function createCertificate(
-  stakingKey: RustModule.WalletV3.PublicKey,
-  poolRequest: PoolRequest,
-): RustModule.WalletV3.StakeDelegation {
-  if (poolRequest == null) {
-    return RustModule.WalletV3.StakeDelegation.new(
-      RustModule.WalletV3.DelegationType.non_delegated(),
-      stakingKey
-    );
-  }
-  if (Array.isArray(poolRequest)) {
-    const partsTotal = poolRequest.reduce((sum, pool) => sum + pool.part, 0);
-    const ratios = RustModule.WalletV3.PoolDelegationRatios.new();
-    for (const pool of poolRequest) {
-      ratios.add(RustModule.WalletV3.PoolDelegationRatio.new(
-        RustModule.WalletV3.PoolId.from_hex(pool.id),
-        pool.part
-      ));
-    }
-    const delegationRatio = RustModule.WalletV3.DelegationRatio.new(
-      partsTotal,
-      ratios,
-    );
-    if (delegationRatio == null) {
-      throw new Error(`${nameof(createCertificate)} invalid ratio`);
-    }
-    return RustModule.WalletV3.StakeDelegation.new(
-      RustModule.WalletV3.DelegationType.ratio(delegationRatio),
-      stakingKey
-    );
-  }
-  return RustModule.WalletV3.StakeDelegation.new(
-    RustModule.WalletV3.DelegationType.full(
-      RustModule.WalletV3.PoolId.from_hex(poolRequest.id)
-    ),
-    stakingKey
-  );
-}
-
-/**
- * Sending the transaction may affect the amount delegated in a few ways:
- * 1) The transaction fee for the transaction
- *  - may be paid with UTXO that either does or doesn't belong to our staking key.
- * 2) The change for the transaction
- *  - may get turned into a group address for our staking key
- */
-function getDifferenceAfterTx(
-  utxoResponse: V3UnsignedTxAddressedUtxoResponse,
-  allUtxos: IGetAllUtxosResponse,
-  stakingKey: RustModule.WalletV3.PublicKey,
-): BigNumber {
-  const stakingKeyString = Buffer.from(stakingKey.as_bytes()).toString('hex');
-
-  let sumInForKey = new BigNumber(0);
-  {
-    // note senderUtxos.length is approximately 1
-    // since it's just to cover transaction fees
-    // so this for loop is faster than building a map
-    for (const senderUtxo of utxoResponse.senderUtxos) {
-      const match = allUtxos.find(utxo => (
-        utxo.output.Transaction.Hash === senderUtxo.tx_hash &&
-        utxo.output.UtxoTransactionOutput.OutputIndex === senderUtxo.tx_index
-      ));
-      if (match == null) {
-        throw new Error(`${nameof(getDifferenceAfterTx)} utxo not found. Should not happen`);
-      }
-      const address = match.address;
-      if (groupAddrContainsAccountKey(address, stakingKeyString)) {
-        sumInForKey = sumInForKey.plus(new BigNumber(senderUtxo.amount));
-      }
-    }
-  }
-
-  let sumOutForKey = new BigNumber(0);
-  {
-    const outputs = utxoResponse.IOs.outputs();
-    for (let i = 0; i < outputs.size(); i++) {
-      const output = outputs.get(i);
-      const address = Buffer.from(output.address().as_bytes()).toString('hex');
-      if (groupAddrContainsAccountKey(address, stakingKeyString)) {
-        const value = new BigNumber(output.value().to_str());
-        sumOutForKey = sumOutForKey.plus(value);
-      }
-    }
-  }
-
-  return sumOutForKey.minus(sumInForKey);
 }


### PR DESCRIPTION
The approximate reward when choosing a stake pool used to only take into account the UTXO balance. Now it properly includes the rewards you've earned so far also.

AKA the "total delegated" in the first screenshot is now what is used instead of "total ADA"

![image](https://user-images.githubusercontent.com/2608559/72691895-07b48800-3b6c-11ea-9ee2-416a947e954b.png)

![image](https://user-images.githubusercontent.com/2608559/72691888-ff5c4d00-3b6b-11ea-963d-915d6527990a.png)
