### PR TITLE
Fix transaction assurance calculation

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -733,7 +733,7 @@ export default class AdaApi {
         return WalletTransaction.fromAnnotatedTx({
           tx,
           addressLookupMap: fetchedTxs.addressLookupMap,
-          lastBlockNumber: lastSyncInfo.SlotNum,
+          lastBlockNumber: lastSyncInfo.Height,
         });
       });
       return {
@@ -761,7 +761,7 @@ export default class AdaApi {
         return WalletTransaction.fromAnnotatedTx({
           tx,
           addressLookupMap: fetchedTxs.addressLookupMap,
-          lastBlockNumber: lastSyncInfo.SlotNum,
+          lastBlockNumber: lastSyncInfo.Height,
         });
       });
       return mappedTransactions;

--- a/app/api/ada/lib/storage/database/primitives/api/read.js
+++ b/app/api/ada/lib/storage/database/primitives/api/read.js
@@ -740,6 +740,7 @@ export class GetTxAndBlock {
         )
       )
       .orderBy(blockTable[Tables.BlockSchema.properties.SlotNum], lf.Order.DESC)
+      .orderBy(txTable[Tables.TransactionSchema.properties.Ordinal], lf.Order.DESC)
       .where(op.and(
         blockTable[Tables.BlockSchema.properties.SlotNum].lt(request.slot),
         txTable[Tables.TransactionSchema.properties.TransactionId].in(request.txIds),
@@ -905,7 +906,8 @@ export class GetCertificates {
       .where(certAddrTable[certAddrSchema.properties.AddressId].in(
         request.addressIds
       ))
-      .orderBy(blockTable[Tables.BlockSchema.properties.SlotNum], lf.Order.DESC);
+      .orderBy(blockTable[Tables.BlockSchema.properties.SlotNum], lf.Order.DESC)
+      .orderBy(txTable[Tables.TransactionSchema.properties.Ordinal], lf.Order.DESC);
 
     const queryResult: $ReadOnlyArray<{|
       CertificateAddress: $ReadOnly<CertificateAddressRow>,

--- a/app/domain/WalletTransaction.js
+++ b/app/domain/WalletTransaction.js
@@ -91,7 +91,7 @@ export default class WalletTransaction {
         ? tx.block.BlockTime
         : new Date(tx.transaction.LastUpdateTime),
       numberOfConfirmations: request.lastBlockNumber != null && tx.block != null
-        ? request.lastBlockNumber - tx.block.SlotNum
+        ? request.lastBlockNumber - tx.block.Height
         : 0,
       addresses: {
         from: [


### PR DESCRIPTION
The code for transaction assurance ("low", "medium", "high" assurance your transaction won't be rolled back) used to be calculated by slot number instead of block height. This made transactions go to "high" assurance basically right away for Jormungandr since every block can increase the slot number by 10-30.

With this change, a transaction took me
~2 minutes to get to medium assurance
~5 minutes to get to high assurance

which seems more aligned with expectations.