### PR TITLE
Hide tx summary when balance is hidden

### DIFF
--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -146,7 +146,7 @@ type Props = {|
   +selectedExplorer: ExplorerType,
   +assuranceLevel: AssuranceLevel,
   +isLastInList: boolean,
-  +formattedWalletAmount: BigNumber => string,
+  +shouldHideBalance: boolean,
 |};
 
 type State = {|
@@ -212,10 +212,9 @@ export default class Transaction extends Component<Props, State> {
   }
 
   renderAmountDisplay: {|
-    shouldHideBalance: boolean,
     amount: BigNumber,
   |} => Node = (request) => {
-    if (request.shouldHideBalance) {
+    if (this.props.shouldHideBalance) {
       return (<span>******</span>);
     }
     const [beforeDecimalRewards, afterDecimalRewards] = splitAmount(request.amount);
@@ -234,11 +233,10 @@ export default class Transaction extends Component<Props, State> {
   }
 
   renderFeeDisplay: {|
-    shouldHideBalance: boolean,
     amount: BigNumber,
     type: TransactionDirectionType,
   |} => Node = (request) => {
-    if (request.shouldHideBalance) {
+    if (this.props.shouldHideBalance) {
       return (<span>******</span>);
     }
     if (request.type === transactionTypes.INCOME) {
@@ -319,14 +317,12 @@ export default class Transaction extends Component<Props, State> {
               <div className={classnames([styles.currency, styles.fee])}>
                 {this.renderFeeDisplay({
                   amount: data.fee,
-                  shouldHideBalance: false,
                   type: data.type,
                 })}
               </div>
               <div className={classnames([styles.currency, styles.amount])}>
                 {this.renderAmountDisplay({
                   amount: data.amount,
-                  shouldHideBalance: false,
                 })}
                 <span className={styles.currencySymbol}><AdaSymbol /></span>
               </div>

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component } from 'react';
-import BigNumber from 'bignumber.js';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import classnames from 'classnames';
@@ -33,8 +32,8 @@ type Props = {|
   +selectedExplorer: ExplorerType,
   +assuranceMode: AssuranceMode,
   +walletId: string,
-  +formattedWalletAmount: BigNumber => string,
   +onLoadMore: void => PossiblyAsync<void>,
+  +shouldHideBalance: boolean,
 |};
 
 @observer
@@ -107,7 +106,6 @@ export default class WalletTransactionsList extends Component<Props> {
       hasMoreToLoad,
       assuranceMode,
       walletId,
-      formattedWalletAmount,
       onLoadMore,
     } = this.props;
 
@@ -142,7 +140,7 @@ export default class WalletTransactionsList extends Component<Props> {
                   isLastInList={transactionIndex === group.transactions.length - 1}
                   state={transaction.state}
                   assuranceLevel={transaction.getAssuranceLevelForMode(assuranceMode)}
-                  formattedWalletAmount={formattedWalletAmount}
+                  shouldHideBalance={this.props.shouldHideBalance}
                 />
               ))}
             </div>

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -15,8 +15,6 @@ import VerticalFlexContainer from '../../components/layout/VerticalFlexContainer
 import ExportTransactionDialog from '../../components/wallet/export/ExportTransactionDialog';
 import { Logger } from '../../utils/logging';
 
-import { formattedWalletAmount } from '../../utils/formatters';
-
 type Props = InjectedProps
 
 const targetNotificationIds = [
@@ -77,7 +75,7 @@ export default class WalletSummaryPage extends Component<Props> {
             onLoadMore={actions.ada.transactions.loadMoreTransactions.trigger}
             assuranceMode={publicDeriver.assuranceMode}
             walletId={publicDeriver.self.getPublicDeriverId().toString()}
-            formattedWalletAmount={formattedWalletAmount}
+            shouldHideBalance={profile.shouldHideBalance}
           />
         );
       } else if (!hasAny) {

--- a/app/stores/ada/DelegationTransactionStore.js
+++ b/app/stores/ada/DelegationTransactionStore.js
@@ -141,9 +141,9 @@ export default class DelegationTransactionStore extends Store {
       throw new Error(`${nameof(this._complete)} no public deriver selected`);
     }
     this.actions.dialogs.closeActiveDialog.trigger();
+    this.goToDashboardRoute(publicDeriver.self);
     const { wallets } = this.stores.substores[environment.API];
     await wallets.refreshWallet(publicDeriver);
-    this.goToDashboardRoute(publicDeriver.self);
   }
 
   goToDashboardRoute(publicDeriver: PublicDeriver<>): void {


### PR DESCRIPTION
The tx history page never hid the amount of ADA involved in transactions but probably it should

![image](https://user-images.githubusercontent.com/2608559/73734944-cf26c800-4781-11ea-9b2f-e677f5ae0db6.png)
