### PR TITLE
Refresh wallet as part of tx sending

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -322,12 +322,12 @@ export type CreateWalletFunc = (
 
 // signAndBroadcast
 
-export type SignAndBroadcastRequest = {
+export type SignAndBroadcastRequest = {|
   publicDeriver: IPublicDeriver<ConceptualWallet & IHasLevels> & IGetSigningKey,
   signRequest: BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput>,
   password: string,
   sendTx: SendFunc,
-};
+|};
 export type SignAndBroadcastResponse = SignedResponse;
 export type SignAndBroadcastFunc = (
   request: SignAndBroadcastRequest
@@ -349,10 +349,10 @@ export type CreateTrezorSignTxDataFunc = (
 
 // broadcastTrezorSignedTx
 
-export type BroadcastTrezorSignedTxRequest = {
+export type BroadcastTrezorSignedTxRequest = {|
   signedTxRequest: SignedRequest,
   sendTx: SendFunc,
-};
+|};
 export type BroadcastTrezorSignedTxResponse = SignedResponse;
 export type BroadcastTrezorSignedTxFunc = (
   request: BroadcastTrezorSignedTxRequest
@@ -373,13 +373,13 @@ export type CreateLedgerSignTxDataFunc = (
 
 // prepareAndBroadcastLedgerSignedTx
 
-export type PrepareAndBroadcastLedgerSignedTxRequest = {
+export type PrepareAndBroadcastLedgerSignedTxRequest = {|
   getPublicKey: () => Promise<IGetPublicResponse>,
   keyLevel: number,
   ledgerSignTxResp: LedgerSignTxResponse,
   unsignedTx: RustModule.WalletV2.Transaction,
   sendTx: SendFunc,
-};
+|};
 export type PrepareAndBroadcastLedgerSignedTxResponse = SignedResponse;
 export type PrepareAndBroadcastLedgerSignedTxFunc = (
   request: PrepareAndBroadcastLedgerSignedTxRequest
@@ -425,12 +425,12 @@ export type CreateDelegationTxFunc = (
 
 // signAndBroadcastDelegationTx
 
-export type SignAndBroadcastDelegationTxRequest = {
+export type SignAndBroadcastDelegationTxRequest = {|
   publicDeriver: IPublicDeriver<ConceptualWallet & IHasLevels> & IGetSigningKey & IGetStakingKey,
   signRequest: BaseSignRequest<RustModule.WalletV3.InputOutput>,
   password: string,
   sendTx: SendFunc,
-};
+|};
 export type SignAndBroadcastDelegationTxResponse = SignedResponse;
 
 export type SignAndBroadcastDelegationTxFunc = (


### PR DESCRIPTION
Historically the flow has been as follows:

1) Send a transaction
2) Route user to transaction page
3) Refresh transaction history

This causes a problem in step (2) since the user is left wondering if their tx actually got sent. In mainnet it's not a big deal since the time between (2) and (3) is very small. However in the Shelley testnet (for a variety of reasons), the time between (2) and (3) can be very large.

To fix this, we group (1) and (3) into a single action and only do (2) once it's done. That way when they see the tx history page, they know for sure it's gone through.