### PR TITLE
Split reward history graph into two tabs

### DIFF
--- a/app/components/wallet/staking/dashboard/GraphWrapper.scss
+++ b/app/components/wallet/staking/dashboard/GraphWrapper.scss
@@ -13,6 +13,13 @@
 
 .tabsWrapper {
     margin-bottom: 16px;
+    display: flex;
+    flex-wrap: wrap;
+
+    li {
+        margin-right: 14px;
+        width: max-content;
+    }
 }
 
 .tab {

--- a/app/components/wallet/staking/dashboard/GraphWrapper.scss
+++ b/app/components/wallet/staking/dashboard/GraphWrapper.scss
@@ -17,7 +17,7 @@
     flex-wrap: wrap;
 
     li {
-        margin-right: 14px;
+        margin-right: 20px;
         width: max-content;
     }
 }

--- a/app/components/wallet/staking/dashboard/StakingDashboard.js
+++ b/app/components/wallet/staking/dashboard/StakingDashboard.js
@@ -46,12 +46,15 @@ const emptyDashboardMessages = defineMessages({
   }
 });
 
-export type SingleGraphData = {|
-  +items: ?Array<GraphItems>,
+export type RewardsGraphData = {|
+  +items: ?{|
+    totalRewards: Array<GraphItems>,
+    perEpochRewards: Array<GraphItems>,
+  |},
   +error: ?LocalizableError,
 |};
 export type GraphData = {|
-  +rewardsGraphData: SingleGraphData,
+  +rewardsGraphData: RewardsGraphData,
 |};
 
 type Props = {|
@@ -148,7 +151,7 @@ export default class StakingDashboard extends Component<Props> {
     );
   }
 
-  _displayGraph: SingleGraphData => Node = (graphData) => {
+  _displayGraph: RewardsGraphData => Node = (graphData) => {
     const { intl } = this.context;
     if (graphData.error) {
       return (
@@ -167,19 +170,25 @@ export default class StakingDashboard extends Component<Props> {
         </VerticallyCenteredLayout>
       );
     }
+    const items = graphData.items;
     return (
       <GraphWrapper
-        data={graphData.items}
         themeVars={this.props.themeVars}
         tabs={[
-          // intl.formatMessage(globalMessages.totalAdaLabel),
+          {
+            tabName: intl.formatMessage(globalMessages.totalAdaLabel),
+            data: items.totalRewards,
+            primaryBarLabel: intl.formatMessage(globalMessages.totalAdaLabel),
+            yAxisLabel: intl.formatMessage(globalMessages.rewardsLabel),
+          },
+          {
+            tabName: intl.formatMessage(globalMessages.rewardsLabel),
+            data: items.perEpochRewards,
+            primaryBarLabel: intl.formatMessage(globalMessages.rewardsLabel),
+            yAxisLabel: intl.formatMessage(globalMessages.rewardsLabel),
+          }
           // intl.formatMessage(globalMessages.marginsLabel),
-          intl.formatMessage(globalMessages.rewardsLabel),
         ]}
-        primaryBarLabel={intl.formatMessage(globalMessages.rewardsLabel)}
-        secondaryBarLabel={intl.formatMessage(globalMessages.totalAdaLabel)}
-        yAxisLabel={intl.formatMessage(globalMessages.rewardsLabel)}
-        graphName="total"
         epochLength={this.props.epochLength}
       />
     );

--- a/app/components/wallet/staking/dashboard/StakingDashboard.js
+++ b/app/components/wallet/staking/dashboard/StakingDashboard.js
@@ -176,17 +176,17 @@ export default class StakingDashboard extends Component<Props> {
         themeVars={this.props.themeVars}
         tabs={[
           {
-            tabName: intl.formatMessage(globalMessages.totalAdaLabel),
-            data: items.totalRewards,
-            primaryBarLabel: intl.formatMessage(globalMessages.totalAdaLabel),
-            yAxisLabel: intl.formatMessage(globalMessages.rewardsLabel),
-          },
-          {
             tabName: intl.formatMessage(globalMessages.rewardsLabel),
             data: items.perEpochRewards,
             primaryBarLabel: intl.formatMessage(globalMessages.rewardsLabel),
             yAxisLabel: intl.formatMessage(globalMessages.rewardsLabel),
-          }
+          },
+          {
+            tabName: intl.formatMessage(globalMessages.totalRewardsLabel),
+            data: items.totalRewards,
+            primaryBarLabel: intl.formatMessage(globalMessages.totalRewardsLabel),
+            yAxisLabel: intl.formatMessage(globalMessages.rewardsLabel),
+          },
           // intl.formatMessage(globalMessages.marginsLabel),
         ]}
         epochLength={this.props.epochLength}

--- a/app/components/wallet/staking/dashboard/UserSummary.js
+++ b/app/components/wallet/staking/dashboard/UserSummary.js
@@ -23,10 +23,6 @@ const messages = defineMessages({
     id: 'wallet.dashboard.summary.title',
     defaultMessage: '!!!Your Summary',
   },
-  rewardsLabel: {
-    id: 'wallet.dashboard.summary.rewardsTitle',
-    defaultMessage: '!!!Total Rewards',
-  },
   delegatedLabel: {
     id: 'wallet.dashboard.summary.delegatedTitle',
     defaultMessage: '!!!Total Delegated',
@@ -124,7 +120,7 @@ export default class UserSummary extends Component<Props, State> {
           </div>
         </div>
         <h3 className={styles.label}>
-          {intl.formatMessage(messages.rewardsLabel)}:
+          {intl.formatMessage(globalMessages.totalRewardsLabel)}:
         </h3>
         {this.props.totalRewards != null
           ? (

--- a/app/components/widgets/PageSelect.scss
+++ b/app/components/widgets/PageSelect.scss
@@ -1,6 +1,7 @@
 .component {
   width: 315px;
   height: 34px;
+  white-space: nowrap;
 }
 
 .content {

--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -608,7 +608,10 @@ export default class StakingDashboardPage extends Component<Props, State> {
   _generateRewardGraphData: {|
     delegationRequests: DelegationRequests,
     currentEpoch: number,
-  |} => (?Array<GraphItems>) = (
+  |} => (?{|
+    totalRewards: Array<GraphItems>,
+    perEpochRewards: Array<GraphItems>,
+  |}) = (
     request
   ) => {
     const history = request.delegationRequests.rewardHistory.result;
@@ -622,7 +625,8 @@ export default class StakingDashboardPage extends Component<Props, State> {
 
     // the reward history endpoint doesn't contain entries when the reward was 0
     // so we need to insert these manually
-    const result: Array<GraphItems> = [];
+    const totalRewards: Array<GraphItems> = [];
+    const perEpochRewards: Array<GraphItems> = [];
     let adaSum = new BigNumber(0);
     // note: reward history includes the current epoch
     // since it tells you the reward you got at slot 0 of the new epoch
@@ -631,22 +635,31 @@ export default class StakingDashboardPage extends Component<Props, State> {
         // exists a reward for this epoch
         const nextReward = history[historyIterator][1];
         adaSum = adaSum.plus(nextReward);
-        result.push({
+        totalRewards.push({
           name: i,
-          secondary: adaSum.dividedBy(LOVELACES_PER_ADA).toNumber(),
+          primary: adaSum.dividedBy(LOVELACES_PER_ADA).toNumber(),
+        });
+        perEpochRewards.push({
+          name: i,
           primary: nextReward / LOVELACES_PER_ADA.toNumber(),
         });
         historyIterator++;
       } else {
         // no reward for this epoch
-        result.push({
+        totalRewards.push({
           name: i,
-          secondary: adaSum.dividedBy(LOVELACES_PER_ADA).toNumber(),
+          primary: adaSum.dividedBy(LOVELACES_PER_ADA).toNumber(),
+        });
+        perEpochRewards.push({
+          name: i,
           primary: 0,
         });
       }
     }
-    return result;
+    return {
+      totalRewards,
+      perEpochRewards,
+    };
   }
 
   _generateGraphData: {|

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -397,6 +397,10 @@ const globalMessages = defineMessages({
     id: 'wallet.restore.dialog.form.errors.invalidRecoveryPhrase',
     defaultMessage: '!!!Invalid recovery phrase',
   },
+  totalRewardsLabel: {
+    id: 'wallet.dashboard.summary.rewardsTitle',
+    defaultMessage: '!!!Total Rewards',
+  },
   skipLabel: {
     id: 'profile.uriPrompt.form.skipLabel',
     defaultMessage: '!!!Skip',

--- a/app/stores/ada/DelegationStore.js
+++ b/app/stores/ada/DelegationStore.js
@@ -253,6 +253,10 @@ export default class DelegationStore extends Store {
         this.stores.substores.ada.time.currentTime?.currentEpoch,
       ],
       async () => {
+        if (!this.stores.substores.ada.serverConnectionStore.checkAdaServerStatus) {
+          // don't re-query when server goes offline -- only when it comes back online
+          return;
+        }
         const selected = this.stores.substores.ada.wallets.selected;
         if (selected == null) return;
         await this.refreshDelegation(selected);

--- a/app/themes/prebuilt/YoroiModern.js
+++ b/app/themes/prebuilt/YoroiModern.js
@@ -449,7 +449,7 @@ const YoroiModern = {
   '--theme-dashboard-percentage-stake-base': '#FFEDF2',
   '--theme-dashboard-percentage-stake-circle': '#FF1755',
   '--theme-dashboard-graph-tab-color': '#ADAEB6',
-  '--theme-dashboard-graph-active-tab-color': '#38393D', // temporary since we have one tab. For multi-tab use #3D60CD
+  '--theme-dashboard-graph-active-tab-color': '#3D60CD',
   '--theme-dashboard-graph-radio-color': '#93979C',
   '--theme-dashboard-graph-active-radio-color': '#17D1AA',
   '--theme-dashboard-graph-axis-tick-color': '#ADAEB6',

--- a/chrome/constants.js
+++ b/chrome/constants.js
@@ -8,7 +8,7 @@ import {
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 
 export const Version = {
-  Shelley: '2.5.1',
+  Shelley: '2.5.2',
   Byron: '1.10.0',
 };
 


### PR DESCRIPTION
In response to our reward history graph, a lot of people have said they want the "total earned" and the per-epoch rewards to be separate graphs. This PR enables tabs on the graph to enable this

![graphs2](https://user-images.githubusercontent.com/2608559/73826426-17f18600-4841-11ea-8c38-3e861eee46c8.gif)
