### PR TITLE
Pass in selected wallet when possible

### DIFF
--- a/app/actions/ada/addresses-actions.js
+++ b/app/actions/ada/addresses-actions.js
@@ -1,9 +1,10 @@
 // @flow
 import { AsyncAction, Action } from '../lib/Action';
+import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 
 // ======= ADDRESSES ACTIONS =======
 
 export default class AddressesActions {
-  createAddress: AsyncAction<void> = new AsyncAction();
+  createAddress: AsyncAction<PublicDeriverWithCachedMeta> = new AsyncAction();
   resetErrors: Action<void> = new Action();
 }

--- a/app/actions/ada/delegation-transaction-actions.js
+++ b/app/actions/ada/delegation-transaction-actions.js
@@ -8,7 +8,10 @@ export default class DelegationTransactionActions {
     publicDeriver: PublicDeriverWithCachedMeta,
     poolRequest: PoolRequest,
   |}> = new AsyncAction();
-  signTransaction: AsyncAction<{| password: string |}> = new AsyncAction();
-  complete: AsyncAction<void> = new AsyncAction();
+  signTransaction: AsyncAction<{|
+    password: string,
+    publicDeriver: PublicDeriverWithCachedMeta,
+  |}> = new AsyncAction();
+  complete: Action<PublicDeriverWithCachedMeta> = new Action();
   reset: Action<void> = new Action();
 }

--- a/app/actions/ada/ledger-send-actions.js
+++ b/app/actions/ada/ledger-send-actions.js
@@ -2,6 +2,7 @@
 import { AsyncAction, Action } from '../lib/Action';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
+import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 
 export type SendUsingLedgerParams = {|
   signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
@@ -12,5 +13,8 @@ export type SendUsingLedgerParams = {|
 export default class LedgerSendActions {
   init: Action<void> = new Action();
   cancel: Action<void> = new Action();
-  sendUsingLedger: AsyncAction<SendUsingLedgerParams> = new AsyncAction();
+  sendUsingLedger: AsyncAction<{|
+    params: SendUsingLedgerParams,
+    publicDeriver: PublicDeriverWithCachedMeta,
+  |}> = new AsyncAction();
 }

--- a/app/actions/ada/transactions-actions.js
+++ b/app/actions/ada/transactions-actions.js
@@ -1,12 +1,16 @@
 // @flow
 import { AsyncAction, Action } from '../lib/Action';
+import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 
 // ======= TRANSACTIONS ACTIONS =======
 
 export type TransactionRowsToExportRequest = void;
 
 export default class TransactionsActions {
-  loadMoreTransactions: AsyncAction<void> = new AsyncAction();
-  exportTransactionsToFile: AsyncAction<TransactionRowsToExportRequest> = new AsyncAction();
+  loadMoreTransactions: AsyncAction<PublicDeriverWithCachedMeta> = new AsyncAction();
+  exportTransactionsToFile: AsyncAction<{|
+    publicDeriver: PublicDeriverWithCachedMeta,
+    exportRequest: TransactionRowsToExportRequest,
+  |}> = new AsyncAction();
   closeExportTransactionDialog: Action<void> = new Action();
 }

--- a/app/actions/ada/trezor-send-actions.js
+++ b/app/actions/ada/trezor-send-actions.js
@@ -2,14 +2,18 @@
 import { AsyncAction, Action } from '../lib/Action';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
+import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 
-export type SendUsingTrezorParams = {
+export type SendUsingTrezorParams = {|
   signRequest: BaseSignRequest<RustModule.WalletV2.Transaction>,
-};
+|};
 
 // ======= Sending ADA using Trezor ACTIONS =======
 
 export default class TrezorSendActions {
   cancel: Action<void> = new Action();
-  sendUsingTrezor: AsyncAction<SendUsingTrezorParams> = new AsyncAction();
+  sendUsingTrezor: AsyncAction<{|
+    params: SendUsingTrezorParams,
+    publicDeriver: PublicDeriverWithCachedMeta,
+  |}> = new AsyncAction();
 }

--- a/app/actions/ada/wallet-settings-actions.js
+++ b/app/actions/ada/wallet-settings-actions.js
@@ -6,8 +6,14 @@ export default class WalletSettingsActions {
   cancelEditingWalletField: Action<void> = new Action();
   startEditingWalletField: Action<{| field: string |}> = new Action();
   stopEditingWalletField: Action<void> = new Action();
-  renamePublicDeriver: AsyncAction<{| newName: string |}> = new AsyncAction();
-  renameConceptualWallet: AsyncAction<{| newName: string |}> = new AsyncAction();
+  renamePublicDeriver: AsyncAction<{|
+    publicDeriver: PublicDeriverWithCachedMeta,
+    newName: string,
+  |}> = new AsyncAction();
+  renameConceptualWallet: AsyncAction<{|
+    publicDeriver: PublicDeriverWithCachedMeta,
+    newName: string,
+  |}> = new AsyncAction();
   updateSigningPassword: AsyncAction<{|
     publicDeriver: PublicDeriverWithCachedMeta,
     oldPassword: string,

--- a/app/actions/ada/wallets-actions.js
+++ b/app/actions/ada/wallets-actions.js
@@ -6,6 +6,7 @@ import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 import type {
   IGetLastSyncInfoResponse,
 } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
+import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 
 // ======= WALLET ACTIONS =======
 
@@ -19,7 +20,14 @@ export default class WalletsActions {
   sendMoney: AsyncAction<{|
     signRequest: BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput>,
     password: string,
+    publicDeriver: PublicDeriverWithCachedMeta,
   |}> = new AsyncAction();
-  updateBalance: Action<BigNumber> = new Action();
-  updateLastSync: Action<IGetLastSyncInfoResponse> = new Action();
+  updateBalance: Action<{|
+    balance: BigNumber,
+    publicDeriver: PublicDeriverWithCachedMeta,
+  |}> = new Action();
+  updateLastSync: Action<{|
+    lastSync: IGetLastSyncInfoResponse,
+    publicDeriver: PublicDeriverWithCachedMeta,
+  |}> = new Action();
 }

--- a/app/containers/settings/categories/WalletSettingsPage.js
+++ b/app/containers/settings/categories/WalletSettingsPage.js
@@ -66,7 +66,7 @@ export default class WalletSettingsPage extends Component<Props> {
           lastUpdatedField={lastUpdatedWalletField}
           onFieldValueChange={async (field, value) => {
             if (field === 'name') {
-              await renameConceptualWallet.trigger({ newName: value });
+              await renameConceptualWallet.trigger({ publicDeriver, newName: value });
             }
           }}
           onStartEditing={field => startEditingWalletField.trigger({ field })}

--- a/app/containers/transfer/UnmangleTxDialogContainer.js
+++ b/app/containers/transfer/UnmangleTxDialogContainer.js
@@ -78,7 +78,11 @@ export default class UnmangleTxDialogContainer extends Component<Props> {
     this._getWalletsStore().sendMoneyRequest.reset();
   }
 
-  submit = async () => {
+  submit: void => Promise<void> = async () => {
+    const selected = this._getWalletsStore().selected;
+    if (selected == null) {
+      throw new Error(`${nameof(UnmangleTxDialogContainer)} no wallet selected`);
+    }
     if (this.spendingPasswordForm == null) {
       throw new Error(`${nameof(UnmangleTxDialogContainer)} form not set`);
     }
@@ -91,6 +95,7 @@ export default class UnmangleTxDialogContainer extends Component<Props> {
         this.props.actions.ada.wallets.sendMoney.trigger({
           signRequest: txBuilderStore.tentativeTx,
           password: walletPassword,
+          publicDeriver: selected,
         });
       },
       onError: () => {}

--- a/app/containers/wallet/Receive.js
+++ b/app/containers/wallet/Receive.js
@@ -8,10 +8,19 @@ import ReceiveWithNavigation from '../../components/wallet/layouts/ReceiveWithNa
 export default class Receive extends Component<InjectedContainerProps> {
 
   render() {
+    const publicDeriver = this.props.stores.substores.ada.wallets.selected;
+    if (publicDeriver == null) throw new Error(`${nameof(Receive)} no public deriver`);
+
     return (
       <ReceiveWithNavigation
-        isActiveTab={this.props.stores.substores.ada.addresses.isActiveTab}
-        onTabClick={this.props.stores.substores.ada.addresses.handleTabClick}
+        isActiveTab={(tab) => this.props.stores.substores.ada.addresses.isActiveTab(
+          tab,
+          publicDeriver
+        )}
+        onTabClick={(page) => this.props.stores.substores.ada.addresses.handleTabClick(
+          page,
+          publicDeriver
+        )}
         showMangled={this.props.stores.substores.ada.addresses.mangledAddressesForDisplay.hasAny}
       >
         {this.props.children}

--- a/app/containers/wallet/WalletSendPage.js
+++ b/app/containers/wallet/WalletSendPage.js
@@ -223,7 +223,8 @@ export default class WalletSendPage extends Component<Props> {
           error={ledgerSendStore.error}
           onSubmit={
             () => ledgerSendAction.sendUsingLedger.trigger({
-              signRequest: copySignRequest(v2Request)
+              params: { signRequest: copySignRequest(v2Request) },
+              publicDeriver,
             })
           }
           onCancel={ledgerSendAction.cancel.trigger}
@@ -246,7 +247,8 @@ export default class WalletSendPage extends Component<Props> {
           error={trezorSendStore.error}
           onSubmit={
             () => trezorSendAction.sendUsingTrezor.trigger({
-              signRequest: copySignRequest(v2Request)
+              params: { signRequest: copySignRequest(v2Request) },
+              publicDeriver,
             })
           }
           onCancel={trezorSendAction.cancel.trigger}

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -72,7 +72,7 @@ export default class WalletSummaryPage extends Component<Props> {
             selectedExplorer={this.props.stores.profile.selectedExplorer}
             isLoadingTransactions={isLoadingTx}
             hasMoreToLoad={totalAvailable > limit}
-            onLoadMore={actions.ada.transactions.loadMoreTransactions.trigger}
+            onLoadMore={() => actions.ada.transactions.loadMoreTransactions.trigger(publicDeriver)}
             assuranceMode={publicDeriver.assuranceMode}
             walletId={publicDeriver.self.getPublicDeriverId().toString()}
             shouldHideBalance={profile.shouldHideBalance}
@@ -113,7 +113,10 @@ export default class WalletSummaryPage extends Component<Props> {
           <ExportTransactionDialog
             isActionProcessing={isExporting}
             error={exportError}
-            submit={exportTransactionsToFile.trigger}
+            submit={exportRequest => exportTransactionsToFile.trigger({
+              exportRequest,
+              publicDeriver
+            })}
             cancel={closeExportTransactionDialog.trigger}
             classicTheme={profile.isClassicTheme}
           />

--- a/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
@@ -60,6 +60,7 @@ export default class WalletSendConfirmationDialogContainer extends Component<Pro
           await sendMoney.trigger({
             signRequest: copyRequest,
             password,
+            publicDeriver,
           });
         }}
         isSubmitting={sendMoneyRequest.isExecuting}

--- a/app/containers/wallet/staking/SeizaFetcher.js
+++ b/app/containers/wallet/staking/SeizaFetcher.js
@@ -101,6 +101,11 @@ export default class SeizaFetcher extends Component<Props> {
       throw new Error('Staking undefined SEIZA_FOR_YOROI_URL should never happen');
     }
 
+    const selectedWallet = this.props.stores.substores[environment.API].wallets.selected;
+    if (selectedWallet == null) {
+      return null;
+    }
+
     const dialogBackButton = [
       {
         label: intl.formatMessage(globalMessages.backButtonLabel),
@@ -174,7 +179,10 @@ export default class SeizaFetcher extends Component<Props> {
               delegationTxStore.signAndBroadcastDelegationTx.isExecuting
             }
             onCancel={this.cancel}
-            onSubmit={delegationTxActions.signTransaction.trigger}
+            onSubmit={({ password }) => delegationTxActions.signTransaction.trigger({
+              password,
+              publicDeriver: selectedWallet,
+            })}
             classicTheme={profile.isClassicTheme}
             error={delegationTxStore.signAndBroadcastDelegationTx.error}
             selectedExplorer={stores.profile.selectedExplorer}
@@ -182,7 +190,7 @@ export default class SeizaFetcher extends Component<Props> {
         }
         {delegationTx != null && !showSignDialog &&
           <DelegationSuccessDialog
-            onClose={delegationTxActions.complete.trigger}
+            onClose={() => delegationTxActions.complete.trigger(selectedWallet)}
             classicTheme={profile.isClassicTheme}
           />
         }

--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -147,7 +147,7 @@ export default class StakingDashboardPage extends Component<Props, State> {
       />
     );
 
-    const popup = this.generatePopupDialog();
+    const popup = this.generatePopupDialog(publicDeriver);
     return (
       <>
         {popup}
@@ -170,7 +170,7 @@ export default class StakingDashboardPage extends Component<Props, State> {
     return epochLengthInDays;
   }
 
-  generatePopupDialog: void => (null | Node) = () => {
+  generatePopupDialog: PublicDeriverWithCachedMeta => (null | Node) = (publicDeriver) => {
     const { uiDialogs } = this.props.stores;
     const delegationTxStore = this.props.stores.substores[environment.API].delegationTransaction;
 
@@ -220,7 +220,7 @@ export default class StakingDashboardPage extends Component<Props, State> {
         await this.props.actions[environment.API]
           .delegationTransaction
           .signTransaction
-          .trigger(request);
+          .trigger({ password: request.password, publicDeriver, });
         cancel();
       }}
       isSubmitting={delegationTxStore.signAndBroadcastDelegationTx.isExecuting}

--- a/app/stores/ada/AdaWalletSettingsStore.js
+++ b/app/stores/ada/AdaWalletSettingsStore.js
@@ -45,14 +45,14 @@ export default class AdaWalletSettingsStore extends WalletSettingsStore {
     a.resyncHistory.listen(this._resyncHistory);
   }
 
-  @action _changeSigningPassword = async (request: {
+  @action _changeSigningPassword: {|
     publicDeriver: PublicDeriverWithCachedMeta,
     oldPassword: string,
     newPassword: string
-  }): Promise<void> => {
+  |} => Promise<void> = async (request) => {
     const withSigningKey = asGetSigningKey(request.publicDeriver.self);
     if (withSigningKey == null) {
-      throw new Error('_changeSigningPassword missing signing functionality');
+      throw new Error(`${nameof(this._changeSigningPassword)} missing signing functionality`);
     }
     const newUpdateDate = new Date(Date.now());
     await this.changeSigningKeyRequest.execute({
@@ -71,34 +71,28 @@ export default class AdaWalletSettingsStore extends WalletSettingsStore {
     });
   };
 
-  @action _renamePublicDeriver = async (request: {
+  @action _renamePublicDeriver: {|
+    publicDeriver: PublicDeriverWithCachedMeta,
     newName: string
-  }): Promise<void> => {
-    // get public deriver
-    const publicDeriver = this.stores.substores.ada.wallets.selected;
-    if (!publicDeriver) return;
-
+  |} => Promise<void> = async (request) => {
     // update the meta-parameters in the internal wallet representation
     await this.renameModelRequest.execute({
-      func: publicDeriver.self.rename,
+      func: request.publicDeriver.self.rename,
       request: {
         newName: request.newName,
       },
     }).promise;
 
     runInAction(() => {
-      publicDeriver.publicDeriverName = request.newName;
+      request.publicDeriver.publicDeriverName = request.newName;
     });
   };
 
-  @action _renameConceptualWallet = async (request: {
+  @action _renameConceptualWallet: {|
+    publicDeriver: PublicDeriverWithCachedMeta,
     newName: string
-  }): Promise<void> => {
-    // get public deriver
-    const publicDeriver = this.stores.substores.ada.wallets.selected;
-    if (!publicDeriver) return;
-
-    const conceptualWallet = publicDeriver.self.getParent();
+  |} => Promise<void> = async (request) => {
+    const conceptualWallet = request.publicDeriver.self.getParent();
     // update the meta-parameters in the internal wallet representation
     await this.renameModelRequest.execute({
       func: conceptualWallet.rename,
@@ -108,13 +102,13 @@ export default class AdaWalletSettingsStore extends WalletSettingsStore {
     }).promise;
 
     runInAction(() => {
-      publicDeriver.conceptualWalletName = request.newName;
+      request.publicDeriver.conceptualWalletName = request.newName;
     });
   };
 
-  @action _resyncHistory = async (request: {|
+  @action _resyncHistory: {|
     publicDeriver: PublicDeriverWithCachedMeta,
-  |}): Promise<void> => {
+  |} => Promise<void> = async (request) => {
     const withLevels = asHasLevels<ConceptualWallet>(request.publicDeriver.self);
     if (withLevels == null) {
       throw new Error(`${nameof(this._resyncHistory)} missing levels`);

--- a/app/stores/ada/DelegationTransactionStore.js
+++ b/app/stores/ada/DelegationTransactionStore.js
@@ -104,12 +104,9 @@ export default class DelegationTransactionStore extends Store {
   @action
   _signTransaction: {|
     password: string,
+    publicDeriver: PublicDeriverWithCachedMeta,
   |} => Promise<void> = async (request) => {
-    const publicDeriver = this.stores.substores.ada.wallets.selected;
-    if (publicDeriver == null) {
-      throw new Error(`${nameof(this._signTransaction)} no public deriver selected`);
-    }
-    const withSigning = (asGetSigningKey(publicDeriver.self));
+    const withSigning = (asGetSigningKey(request.publicDeriver.self));
     if (withSigning == null) {
       throw new Error(`${nameof(this._signTransaction)} public deriver missing signing functionality.`);
     }
@@ -136,16 +133,12 @@ export default class DelegationTransactionStore extends Store {
         sendTx: this.stores.substores.ada.stateFetchStore.fetcher.sendTx,
       },
       refreshWallet: () => this.stores.substores[environment.API].wallets.refreshWallet(
-        publicDeriver
+        request.publicDeriver
       ),
     }).promise;
   }
 
-  _complete: void => Promise<void> = async () => {
-    const publicDeriver = this.stores.substores.ada.wallets.selected;
-    if (publicDeriver == null) {
-      throw new Error(`${nameof(this._complete)} no public deriver selected`);
-    }
+  _complete: PublicDeriverWithCachedMeta => void = (publicDeriver) => {
     this.actions.dialogs.closeActiveDialog.trigger();
     this.goToDashboardRoute(publicDeriver.self);
   }

--- a/app/stores/base/WalletStore.js
+++ b/app/stores/base/WalletStore.js
@@ -354,7 +354,7 @@ export default class WalletStore extends Store {
   /* @Attention:
       This method has a really tricky logic because is in charge of some redirection rules
       related to app urls and wallet status. Also, this behaviour is trigger by mobx reactions,
-      so it's hard to reason about all the scenarios could happenedd.
+      so it's hard to reason about all the scenarios could happened.
   */
   _updateActiveWalletOnRouteChanges = () => {
     const currentRoute = this.stores.app.currentRoute;

--- a/app/stores/base/WalletStore.js
+++ b/app/stores/base/WalletStore.js
@@ -70,18 +70,18 @@ export default class WalletStore extends Store {
     super.setup();
     this.publicDerivers = [];
     setInterval(this._pollRefresh, this.WALLET_REFRESH_INTERVAL);
+    // $FlowFixMe built-in types can't handle visibilitychange
     document.addEventListener('visibilitychange', debounce(this._pollRefresh, this.ON_VISIBLE_DEBOUNCE_WAIT));
-
     this.registerReactions([
       this._updateActiveWalletOnRouteChanges,
       this._showAddWalletPageWhenNoWallets,
     ]);
   }
 
-  _create = async (params: {
+  _create: {|
     name: string,
     password: string,
-  }) => {
+  |} => Promise<void> = async (params) => {
     const recoveryPhrase = await (
       this.generateWalletRecoveryPhraseRequest.execute({}).promise
     );
@@ -95,9 +95,9 @@ export default class WalletStore extends Store {
   };
 
   @action
-  _baseAddNewWallet = async (
-    newWallet: RestoreWalletResponse,
-  ): Promise<void> => {
+  _baseAddNewWallet: RestoreWalletResponse => Promise<void> = async (
+    newWallet,
+  ) => {
     // set the first created as the result
     const newWithCachedData: Array<PublicDeriverWithCachedMeta> = [];
     for (const newPublicDeriver of newWallet.publicDerivers) {
@@ -121,7 +121,7 @@ export default class WalletStore extends Store {
   }
 
   /** Create the wallet and go to wallet summary screen */
-  _finishCreation = async () => {
+  _finishCreation: void => Promise<void> = async () => {
     const persistentDb = this.stores.loading.loadPersitentDbRequest.result;
     if (persistentDb == null) {
       throw new Error('_finishCreation db not loaded. Should never happen');
@@ -207,8 +207,8 @@ export default class WalletStore extends Store {
   }
 
   getWalletRoute: (PublicDeriver<>, ?string) => string = (
-    publicDeriver: PublicDeriver<>,
-    page: ?string
+    publicDeriver,
+    page,
   ): string => (
     buildRoute(ROUTES.WALLETS.PAGE, {
       id: publicDeriver.getPublicDeriverId(),
@@ -247,25 +247,25 @@ export default class WalletStore extends Store {
 
   // ACTIONS
 
-  @action.bound _updateBalance(balance: BigNumber): void {
-    const selected = this.selected;
-    if (selected != null) {
-      selected.amount = balance.dividedBy(
-        LOVELACES_PER_ADA
-      );
-    }
+  @action.bound _updateBalance(request: {|
+    balance: BigNumber,
+    publicDeriver: PublicDeriverWithCachedMeta,
+  |}): void {
+    request.publicDeriver.amount = request.balance.dividedBy(
+      LOVELACES_PER_ADA
+    );
   }
 
   @action.bound
-  _updateLastSync(lastSync: IGetLastSyncInfoResponse): void {
-    const selected = this.selected;
-    if (selected != null) {
-      selected.lastSyncInfo = lastSync;
-    }
+  _updateLastSync(request: {|
+    lastSync: IGetLastSyncInfoResponse,
+    publicDeriver: PublicDeriverWithCachedMeta,
+  |}): void {
+    request.publicDeriver.lastSyncInfo = request.lastSync;
   }
 
   /** Make all API calls required to setup/update wallet */
-  @action restoreWalletsFromStorage: void => Promise<void> = async (): Promise<void> => {
+  @action restoreWalletsFromStorage: void => Promise<void> = async () => {
     const persistentDb = this.stores.loading.loadPersitentDbRequest.result;
     if (persistentDb == null) {
       throw new Error('restoreWalletsFromStorage db not loaded. Should never happen');
@@ -306,22 +306,22 @@ export default class WalletStore extends Store {
   };
 
   /** Make all API calls required to setup imported wallet */
-  @action refreshImportedWalletData: void => Promise<void> = async (): Promise<void> => {
+  @action refreshImportedWalletData: void => Promise<void> = async () => {
     if (this.hasAnyPublicDeriver) this._setActiveWallet({ wallet: this.publicDerivers[0] });
     return await this.restoreWalletsFromStorage();
   };
 
   // =================== ACTIVE WALLET ==================== //
 
-  @action _setActiveWallet = (
-    { wallet }: { wallet: PublicDeriverWithCachedMeta }
-  ): void => {
+  @action _setActiveWallet: {| wallet: PublicDeriverWithCachedMeta |} => void = (
+    { wallet }
+  ) => {
     this.selected = wallet;
     // do not await on purpose since the UI will handle adding loaders while refresh is happening
     this.refreshWallet(wallet);
   };
 
-  @action _unsetActiveWallet = (): void => {
+  @action _unsetActiveWallet: void => void = () => {
     this.selected = null;
   };
 
@@ -334,8 +334,9 @@ export default class WalletStore extends Store {
     return isRootRoute || isNoWalletsRoute;
   }
 
-  _pollRefresh = async (): Promise<void> => {
+  _pollRefresh: void => Promise<void> = async () => {
     // Do not update if screen not active
+    // TODO: use visibilityState instead
     if (!document.hidden) {
       const selected = this.selected;
       if (selected) {
@@ -353,7 +354,7 @@ export default class WalletStore extends Store {
   /* @Attention:
       This method has a really tricky logic because is in charge of some redirection rules
       related to app urls and wallet status. Also, this behaviour is trigger by mobx reactions,
-      so it's hard to reason about all the scenarios could happend.
+      so it's hard to reason about all the scenarios could happenedd.
   */
   _updateActiveWalletOnRouteChanges = () => {
     const currentRoute = this.stores.app.currentRoute;


### PR DESCRIPTION
We have access to the currently selected wallet through

```
stores.substores.ada.wallets.selected
```

but overusing this can cause problems once we support multi-wallet.

Imagine the following:

1) Start some long action (like wallet transfer)
2) While still processing switch to a different wallet
3) Transfer now sees the newly selected wallet in wallets.selected and so action may be performed on the wrong wallet

To avoid this, the selected wallet should always be passed in from the UI so that the action in (3) gets performed on the wallet that was selected at the time.