### PR TITLE
Fix transfer from cip1852 wallet

### DIFF
--- a/app/actions/ada/daedalus-transfer-actions.js
+++ b/app/actions/ada/daedalus-transfer-actions.js
@@ -2,18 +2,18 @@
 import { AsyncAction, Action } from '../lib/Action';
 import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
 
-export default class DaedalusTranferActions {
+export default class DaedalusTransferActions {
   startTransferFunds: Action<void> = new Action();
   startTransferPaperFunds: Action<void> = new Action();
   startTransferMasterKey: Action<void> = new Action();
-  setupTransferFundsWithMnemonic: AsyncAction<{
+  setupTransferFundsWithMnemonic: AsyncAction<{|
     recoveryPhrase: string,
     publicDeriver: PublicDeriverWithCachedMeta,
-  }> = new AsyncAction();
-  setupTransferFundsWithMasterKey: AsyncAction<{
+  |}> = new AsyncAction();
+  setupTransferFundsWithMasterKey: AsyncAction<{|
     masterKey: string,
     publicDeriver: PublicDeriverWithCachedMeta,
-  }> = new AsyncAction();
+  |}> = new AsyncAction();
   backToUninitialized: Action<void> = new Action();
   transferFunds: AsyncAction<{|
     next: () => Promise<void>,

--- a/app/api/ada/transactions/shelley/yoroiTransfer.js
+++ b/app/api/ada/transactions/shelley/yoroiTransfer.js
@@ -31,6 +31,7 @@ export async function buildYoroiTransferTx(payload: {|
   outputAddr: string,
   keyLevel: number,
   signingKey: RustModule.WalletV3.Bip32PrivateKey,
+  useLegacyWitness: boolean,
 |}): Promise<TransferTx> {
   try {
     const { senderUtxos, outputAddr, } = payload;
@@ -54,7 +55,7 @@ export async function buildYoroiTransferTx(payload: {|
       unsignedTxResponse,
       payload.keyLevel,
       payload.signingKey,
-      true,
+      payload.useLegacyWitness,
     );
 
     const uniqueSenders = Array.from(new Set(senderUtxos.map(utxo => utxo.receiver)));
@@ -72,7 +73,7 @@ export async function buildYoroiTransferTx(payload: {|
       ).to_string(Bech32Prefix.ADDRESS)
     };
   } catch (error) {
-    Logger.error(`transfer::buildTransferTx ${stringifyError(error)}`);
+    Logger.error(`transfer::${nameof(buildYoroiTransferTx)} ${stringifyError(error)}`);
     if (error instanceof LocalizableError) {
       throw error;
     }

--- a/app/api/ada/transactions/transfer/cip1852Transfer.js
+++ b/app/api/ada/transactions/transfer/cip1852Transfer.js
@@ -11,19 +11,16 @@ import type {
   Address, Addressing
 } from '../../lib/storage/models/PublicDeriver/interfaces';
 import { buildYoroiTransferTx as shelleyFormatYoroiTx } from '../shelley/yoroiTransfer';
-import { buildYoroiTransferTx as legacyFormatYoroiTx } from '../byron/yoroiTransfer';
 import { toSenderUtxos } from './utils';
 
-export async function generateLegacyYoroiTransferTx(payload: {|
+export async function generateCip1852TransferTx(payload: {|
   addresses: Array<{| ...Address, ...Addressing |}>,
   outputAddr: string,
   keyLevel: number,
   signingKey: RustModule.WalletV3.Bip32PrivateKey,
   getUTXOsForAddresses: AddressUtxoFunc,
-  legacy: boolean,
 |}): Promise<TransferTx> {
-  const { legacy, ...rest } = payload;
-  const senderUtxos = await toSenderUtxos(rest);
+  const senderUtxos = await toSenderUtxos(payload);
 
   const txRequest = {
     outputAddr: payload.outputAddr,
@@ -31,10 +28,8 @@ export async function generateLegacyYoroiTransferTx(payload: {|
     signingKey: payload.signingKey,
     senderUtxos,
   };
-  return legacy
-    ? legacyFormatYoroiTx(txRequest)
-    : shelleyFormatYoroiTx({
-      ...txRequest,
-      useLegacyWitness: true,
-    });
+  return shelleyFormatYoroiTx({
+    ...txRequest,
+    useLegacyWitness: false,
+  });
 }

--- a/app/api/ada/transactions/transfer/utils.js
+++ b/app/api/ada/transactions/transfer/utils.js
@@ -1,0 +1,60 @@
+// @flow
+
+import { isEmpty } from 'lodash';
+import {
+  Logger,
+  stringifyError,
+} from '../../../../utils/logging';
+import {
+  NoInputsError,
+} from '../../errors';
+import type { AddressedUtxo } from '../types';
+import type {
+  AddressUtxoFunc,
+} from '../../lib/state-fetch/types';
+import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
+import type {
+  Address, Addressing
+} from '../../lib/storage/models/PublicDeriver/interfaces';
+
+/**
+ * Generate transaction including all addresses with no change.
+*/
+export async function toSenderUtxos(payload: {|
+  addresses: Array<{| ...Address, ...Addressing |}>,
+  outputAddr: string,
+  keyLevel: number,
+  signingKey: RustModule.WalletV3.Bip32PrivateKey,
+  getUTXOsForAddresses: AddressUtxoFunc,
+|}): Promise<Array<AddressedUtxo>> {
+  // fetch UTXO
+  const utxos = await payload.getUTXOsForAddresses({
+    addresses: payload.addresses.map(addr => addr.address)
+  });
+
+  // add addressing info to the UTXO
+  const addressingMap = new Map<string, Addressing>(
+    payload.addresses.map(entry => [
+      entry.address,
+      { addressing: entry.addressing }
+    ])
+  );
+  const senderUtxos = utxos.map(utxo => {
+    const addressing = addressingMap.get(utxo.receiver);
+    if (addressing == null) {
+      throw new Error('should never happen');
+    }
+    return {
+      ...utxo,
+      addressing: addressing.addressing
+    };
+  });
+
+  if (isEmpty(utxos)) {
+    const error = new NoInputsError();
+    Logger.error(`utils::${nameof(toSenderUtxos)} ${stringifyError(error)}`);
+    throw error;
+  }
+
+  return senderUtxos;
+}

--- a/app/components/wallet/staking/dashboard/GraphWrapper.js
+++ b/app/components/wallet/staking/dashboard/GraphWrapper.js
@@ -45,12 +45,11 @@ const GraphTabs: {|
       {
         tabs.map(
           (tab, i) => (
-            <li>
+            <li key={tab}>
               <button
                 type="button"
                 onClick={() => setSelected(i)}
                 onKeyPress={() => setSelected(i)}
-                key={tab}
                 className={i === selected
                   ? classnames(styles.tab, styles.tabActive)
                   : styles.tab

--- a/app/containers/transfer/DaedalusTransferPage.js
+++ b/app/containers/transfer/DaedalusTransferPage.js
@@ -82,7 +82,11 @@ export default class DaedalusTransferPage extends Component<InjectedProps> {
     // broadcast transfer transaction then call continuation
     await this._getDaedalusTransferActions().transferFunds.trigger({
       next: async () => {
-        await walletsStore.refreshWallet(publicDeriver);
+        try {
+          await walletsStore.refreshWallet(publicDeriver);
+        } catch (_e) {
+          // still need to re-route even if refresh failed
+        }
         if (walletsStore.activeWalletRoute != null) {
           const newRoute = walletsStore.activeWalletRoute;
           this._getRouter().goToRoute.trigger({

--- a/app/containers/transfer/YoroiTransferPage.js
+++ b/app/containers/transfer/YoroiTransferPage.js
@@ -112,7 +112,13 @@ export default class YoroiTransferPage extends Component<InjectedProps> {
     }
     await this._getYoroiTransferActions().transferFunds.trigger({
       next: async () => {
-        await walletsStore.refreshWallet(publicDeriver);
+        const preRefreshTime = new Date().getTime();
+        try {
+          await walletsStore.refreshWallet(publicDeriver);
+        } catch (_e) {
+          // still need to re-route even if refresh failed
+        }
+        const timeToRefresh = (new Date().getTime()) - preRefreshTime;
         await new Promise(resolve => {
           setTimeout(() => {
             if (walletsStore.activeWalletRoute != null) {
@@ -122,7 +128,7 @@ export default class YoroiTransferPage extends Component<InjectedProps> {
               });
             }
             resolve();
-          }, SUCCESS_PAGE_STAY_TIME);
+          }, Math.max(SUCCESS_PAGE_STAY_TIME - timeToRefresh, 0));
         });
       },
       getDestinationAddress: yoroiTransfer.nextInternalAddress(publicDeriver),

--- a/app/stores/ada/DaedalusTransferStore.js
+++ b/app/stores/ada/DaedalusTransferStore.js
@@ -69,15 +69,15 @@ export default class DaedalusTransferStore extends Store {
     this._reset();
   }
 
-  _startTransferFunds = (): void => {
+  _startTransferFunds: void => void = () => {
     this._updateStatus(TransferStatus.GETTING_MNEMONICS);
   }
 
-  _startTransferPaperFunds = (): void => {
+  _startTransferPaperFunds: void => void = () => {
     this._updateStatus(TransferStatus.GETTING_PAPER_MNEMONICS);
   }
 
-  _startTransferMasterKey = (): void => {
+  _startTransferMasterKey: void => void = () => {
     this._updateStatus(TransferStatus.GETTING_MASTER_KEY);
   }
 
@@ -85,7 +85,7 @@ export default class DaedalusTransferStore extends Store {
       You should check wallets state outside of the runInAction,
       because this method run as a reaction.
   */
-  _enableDisableTransferFunds = (): void => {
+  _enableDisableTransferFunds: void => void = () => {
     const { wallets } = this.stores.substores[environment.API];
     // User must first make a Yoroi wallet before being able to transfer a Daedalus wallet
     if (wallets.hasActiveWallet) {
@@ -103,15 +103,18 @@ export default class DaedalusTransferStore extends Store {
    * Call the backend service to fetch all the UTXO then find which belong to the Daedalus wallet.
    * Finally, generate the tx to transfer the wallet to Yoroi
    */
-  _setupTransferWebSocket = async (
-    wallet: RustModule.WalletV2.DaedalusWallet,
-    publicDeriver: PublicDeriverWithCachedMeta,
-  ): Promise<void> => {
+  _setupTransferWebSocket: (
+    RustModule.WalletV2.DaedalusWallet,
+    PublicDeriverWithCachedMeta,
+  ) => Promise<void> = async (
+    wallet,
+    publicDeriver,
+  ) => {
     const withChains = asHasUtxoChains(publicDeriver.self);
-    if (!withChains) throw new Error('_setupTransferWebSocket missing chains functionality');
+    if (!withChains) throw new Error(`${nameof(this._setupTransferWebSocket)} missing chains functionality`);
     const nextInternal = await withChains.nextInternal();
     if (nextInternal.addressInfo == null) {
-      throw new Error('_setupTransferWebSocket no internal addresses left. Should never happen');
+      throw new Error(`${nameof(this._setupTransferWebSocket)} no internal addresses left. Should never happen`);
     }
     const nextInternalAddress = nextInternal.addressInfo.addr.Hash;
 
@@ -160,7 +163,7 @@ export default class DaedalusTransferStore extends Store {
           this._updateStatus(TransferStatus.READY_TO_TRANSFER);
         }
       } catch (error) {
-        Logger.error(`DaedalusTransferStore::_setupTransferWebSocket ${stringifyError(error)}`);
+        Logger.error(`${nameof(DaedalusTransferStore)}::${nameof(this._setupTransferWebSocket)} ${stringifyError(error)}`);
         runInAction(() => {
           this.status = TransferStatus.ERROR;
           this.error = localizedError(error);
@@ -188,10 +191,10 @@ export default class DaedalusTransferStore extends Store {
     });
   };
 
-  _setupTransferFundsWithMnemonic = async (payload: {
+  _setupTransferFundsWithMnemonic: {|
     recoveryPhrase: string,
     publicDeriver: PublicDeriverWithCachedMeta,
-  }): Promise<void> => {
+  |} => Promise<void> = async (payload) => {
     let { recoveryPhrase: secretWords } = payload;
     if (secretWords.split(' ').length === 27) {
       const [newSecretWords, unscrambledLen] =
@@ -211,10 +214,10 @@ export default class DaedalusTransferStore extends Store {
     );
   }
 
-  _setupTransferFundsWithMasterKey = async (payload: {
+  _setupTransferFundsWithMasterKey: {|
     masterKey: string,
     publicDeriver: PublicDeriverWithCachedMeta,
-  }): Promise<void> => {
+  |} => Promise<void> = async (payload) => {
     const { masterKey: key } = payload;
 
     await this._setupTransferWebSocket(
@@ -223,7 +226,7 @@ export default class DaedalusTransferStore extends Store {
     );
   }
 
-  _backToUninitialized = (): void => {
+  _backToUninitialized: void => void = () => {
     this._updateStatus(TransferStatus.UNINITIALIZED);
   }
 
@@ -239,10 +242,10 @@ export default class DaedalusTransferStore extends Store {
   )
 
   /** Broadcast the transfer transaction if one exists and proceed to continuation */
-  _transferFunds = async (payload: {
+  _transferFunds: {|
     next: Function,
     publicDeriver: PublicDeriverWithCachedMeta,
-  }): Promise<void> => {
+  |} => Promise<void> = async (payload) => {
     try {
       const { next } = payload;
       if (!this.transferTx) {
@@ -252,7 +255,6 @@ export default class DaedalusTransferStore extends Store {
         id: this.transferTx.id,
         encodedTx: this.transferTx.encodedTx,
       });
-      // TBD: why do we need a continuation instead of just putting the code here directly?
       next();
       this._reset();
     } catch (error) {

--- a/app/stores/ada/YoroiTransferStore.js
+++ b/app/stores/ada/YoroiTransferStore.js
@@ -19,8 +19,8 @@ import type {
 } from '../../types/TransferTypes';
 import { TransferStatus, TransferSource, TransferKind, } from '../../types/TransferTypes';
 import { generateLegacyYoroiTransferTx } from '../../api/ada/transactions/transfer/legacyYoroi';
+import { generateCip1852TransferTx } from '../../api/ada/transactions/transfer/cip1852Transfer';
 import environment from '../../environment';
-import type { SendFunc, } from '../../api/ada/lib/state-fetch/types';
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 import { generateWalletRootKey, generateLedgerWalletRootKey, } from '../../api/ada/lib/cardanoCrypto/cryptoWallet';
 import {
@@ -45,8 +45,8 @@ export default class YoroiTransferStore extends Store {
 
   @observable status: TransferStatusT = TransferStatus.UNINITIALIZED;
   @observable disableTransferFunds: boolean = true;
-  @observable transferFundsRequest: Request<SendFunc>
-    = new Request<SendFunc>(this._transferFundsRequest);
+  @observable transferFundsRequest: Request<typeof YoroiTransferStore.prototype._checkAndTransfer>
+    = new Request<typeof YoroiTransferStore.prototype._checkAndTransfer>(this._checkAndTransfer);
   @observable restoreForTransferRequest: Request<RestoreWalletForTransferFunc>
     = new Request(this.api.ada.restoreWalletForTransfer);
   @observable error: ?LocalizableError = null;
@@ -172,11 +172,15 @@ export default class YoroiTransferStore extends Store {
     };
   }
 
-  _generateTransferTxFromMnemonic = async (
-    recoveryPhrase: string,
-    updateStatusCallback: void => void,
-    getDestinationAddress: void => Promise<string>,
-  ): Promise<TransferTx> => {
+  _generateTransferTxFromMnemonic: (
+    string,
+    void => void,
+    void => Promise<string>
+  ) => Promise<TransferTx> = async (
+    recoveryPhrase,
+    updateStatusCallback,
+    getDestinationAddress,
+  ) => {
     // 1) get receive address
     const destinationAddress = await getDestinationAddress();
 
@@ -189,33 +193,42 @@ export default class YoroiTransferStore extends Store {
 
     updateStatusCallback();
 
+    const isShelley = this.transferSource === TransferSource.SHELLEY_UTXO ||
+      this.transferSource === TransferSource.SHELLEY_CHIMERIC_ACCOUNT;
+
     // 3) Calculate private keys for restored wallet utxo
     const accountKey = RustModule.WalletV3.Bip32PrivateKey
       .from_bytes(Buffer.from(masterKey, 'hex'))
-      .derive(this.transferSource === TransferSource.SHELLEY_UTXO
+      .derive(isShelley
         ? WalletTypePurpose.CIP1852
         : WalletTypePurpose.BIP44)
       .derive(CoinTypes.CARDANO)
       .derive(accountIndex);
 
     // 4) generate transaction
-    const transferTx = await generateLegacyYoroiTransferTx({
+    const baseRequest = {
       addresses,
       outputAddr: destinationAddress,
       keyLevel: Bip44DerivationLevels.ACCOUNT.level,
       signingKey: accountKey,
       getUTXOsForAddresses:
         this.stores.substores.ada.stateFetchStore.fetcher.getUTXOsForAddresses,
-      legacy: !environment.isShelley(),
-    });
+    };
+
+    const transferTx = isShelley
+      ? await generateCip1852TransferTx(baseRequest)
+      : await generateLegacyYoroiTransferTx({
+        ...baseRequest,
+        legacy: !environment.isShelley(),
+      });
     // Possible exception: NotEnoughMoneyToSendError
     return transferTx;
   }
 
-  _setupTransferFundsWithPaperMnemonic = (payload: {|
+  _setupTransferFundsWithPaperMnemonic: {|
     recoveryPhrase: string,
     paperPassword: string,
-  |}): void => {
+  |} => void = (payload) => {
     const result = unscramblePaperAdaMnemonic(
       payload.recoveryPhrase,
       config.wallets.YOROI_PAPER_RECOVERY_PHRASE_WORD_COUNT,
@@ -270,7 +283,7 @@ export default class YoroiTransferStore extends Store {
   }
 
   /** Broadcast the transfer transaction if one exists and proceed to continuation */
-  _transferFunds = async (payload: {
+  _transferFunds: {|
     next: void => Promise<void>,
     getDestinationAddress: void => Promise<string>,
     /*
@@ -278,7 +291,7 @@ export default class YoroiTransferStore extends Store {
      changes before the tx is submit (we can't really eliminate it).
      */
     rebuildTx: boolean,
-  }): Promise<void> => {
+  |} => Promise<void> = async (payload) => {
     const oldTx = (() => {
       const tx = this.transferTx;
       if (tx == null) {
@@ -287,51 +300,30 @@ export default class YoroiTransferStore extends Store {
       return tx;
     })();
 
-    let transferTx;
-    if (payload.rebuildTx) {
+    const getTransferTx = async () => {
+      if (!payload.rebuildTx) {
+        return oldTx;
+      }
       const newTx = await this._generateTransferTxFromMnemonic(
         this.recoveryPhrase,
         () => {},
         payload.getDestinationAddress,
       );
       if (this._isWalletChanged(oldTx, newTx)) {
-        return this._handleWalletChanged(newTx);
+        this._handleWalletChanged(newTx);
+        return null;
       }
-      transferTx = newTx;
-    } else {
-      transferTx = oldTx;
-    }
+      return newTx;
+    };
 
-    try {
-      const { next } = payload;
+    const { next } = payload;
 
-      await this.transferFundsRequest.execute({
-        id: transferTx.id,
-        encodedTx: transferTx.encodedTx,
-      });
-      this._updateStatus(TransferStatus.SUCCESS);
-      await next();
-      this.reset();
-    } catch (error) {
-      if (error.id === 'api.errors.sendTransactionApiError') {
-        /* See if the error is due to wallet change since last recovery.
-           This should be very rare because the window is short.
-        */
-        const newTransferTx = await this._generateTransferTxFromMnemonic(
-          this.recoveryPhrase,
-          () => {},
-          payload.getDestinationAddress,
-        );
-        if (this._isWalletChanged(newTransferTx, transferTx)) {
-          return this._handleWalletChanged(newTransferTx);
-        }
-      }
-
-      Logger.error(`YoroiTransferStore::transferFunds ${stringifyError(error)}`);
-      runInAction(() => {
-        this.error = new TransferFundsError();
-      });
-    }
+    await this.transferFundsRequest.execute({
+      getTransferTx,
+    });
+    this._updateStatus(TransferStatus.SUCCESS);
+    await next();
+    this.reset();
   }
 
   _isWalletChanged(transferTx1: TransferTx, transferTx2: TransferTx): boolean {
@@ -358,10 +350,10 @@ export default class YoroiTransferStore extends Store {
     this.transferSource = TransferSource.BYRON;
   }
 
-  _restoreWalletForTransfer = async (
-    recoveryPhrase: string,
-    accountIndex: number,
-  ): Promise<RestoreWalletForTransferResponse> => {
+  _restoreWalletForTransfer: (string, number) => Promise<RestoreWalletForTransferResponse> = async (
+    recoveryPhrase,
+    accountIndex,
+  ) => {
     this.restoreForTransferRequest.reset();
 
     const rootPk = this.transferKind === TransferKind.LEDGER
@@ -378,11 +370,31 @@ export default class YoroiTransferStore extends Store {
     return restoreResult;
   };
 
-  /** Send a transaction to the backend-service to be broadcast into the network */
-  _transferFundsRequest: SendFunc = async (request) => (
-    this.stores.substores.ada.stateFetchStore.fetcher.sendTx(request)
-  )
+  _checkAndTransfer: {|
+    getTransferTx: void => Promise<?TransferTx>,
+  |} => Promise<void> = async (request) => {
+    const transferTx = await request.getTransferTx();
+    if (transferTx == null) return;
 
+    try {
+      await this.stores.substores.ada.stateFetchStore.fetcher.sendTx({
+        id: transferTx.id,
+        encodedTx: transferTx.encodedTx,
+      });
+    } catch (error) {
+      if (error.id === 'api.errors.sendTransactionApiError') {
+        /* See if the error is due to wallet change since last recovery.
+           This should be very rare because the window is short.
+        */
+        await request.getTransferTx(); // will update the tx if something changed
+      }
+
+      Logger.error(`${nameof(YoroiTransferStore)}::${nameof(this._checkAndTransfer)} ${stringifyError(error)}`);
+      runInAction(() => {
+        this.error = new TransferFundsError();
+      });
+    }
+  }
 }
 
 const messages = defineMessages({

--- a/app/stores/base/AddressesStore.js
+++ b/app/stores/base/AddressesStore.js
@@ -103,7 +103,9 @@ export class AddressTypeStore<T> {
   ) => {
     const allRequest = this.getRequest(publicDeriver.self);
     allRequest.invalidate({ immediately: false });
-    await allRequest.execute({ publicDeriver: publicDeriver.self }).promise;
+    const promise = allRequest.execute({ publicDeriver: publicDeriver.self }).promise;
+    if (promise == null) throw new Error('Should never happen');
+    await promise.catch(() => {}); // Do nothing. It's logged in the api call
   };
 
   _flowCoerceResult: CachedRequest<SubRequestType<T>> => ?Array<T> = (request) => {

--- a/app/stores/base/TransactionsStore.js
+++ b/app/stores/base/TransactionsStore.js
@@ -201,8 +201,7 @@ export default class TransactionsStore extends Store {
         // Recent Request
         // Here we are sure that allRequest was resolved and the local database was updated
         return this.refreshLocal(basePubDeriver.self);
-      })
-      .catch(() => {}); // Do nothing. It's logged in the api call
+      });
   };
 
   @action refreshLocal: (

--- a/app/stores/base/WalletStore.js
+++ b/app/stores/base/WalletStore.js
@@ -22,6 +22,7 @@ import type {
 import { ConceptualWallet } from '../../api/ada/lib/storage/models/ConceptualWallet/index';
 import { LOVELACES_PER_ADA } from '../../config/numbersConfig';
 import PublicDeriverWithCachedMeta from '../../domain/PublicDeriverWithCachedMeta';
+import { Logger, stringifyError } from '../../utils/logging';
 
 type GroupedWallets = {|
   publicDerivers: Array<PublicDeriverWithCachedMeta>;
@@ -226,8 +227,15 @@ export default class WalletStore extends Store {
   async refreshWallet(
     publicDeriver: PublicDeriverWithCachedMeta
   ): Promise<void> {
-    await this.stores.substores[environment.API].addresses.refreshAddresses(publicDeriver);
-    await this.stores.substores[environment.API].transactions.refreshTransactionData(publicDeriver);
+    try {
+      const substore = this.stores.substores[environment.API];
+      await substore.addresses.refreshAddresses(publicDeriver);
+      // note: only refresh txs if refreshing addresses succeeded
+      await substore.transactions.refreshTransactionData(publicDeriver);
+    } catch (error) {
+      Logger.error(`${nameof(WalletStore)}::${nameof(this.refreshWallet)} ` + stringifyError(error));
+      throw error;
+    }
   }
 
   @action

--- a/app/stores/base/WalletStore.js
+++ b/app/stores/base/WalletStore.js
@@ -229,9 +229,8 @@ export default class WalletStore extends Store {
   ): Promise<void> {
     try {
       const substore = this.stores.substores[environment.API];
-      await substore.addresses.refreshAddresses(publicDeriver);
-      // note: only refresh txs if refreshing addresses succeeded
       await substore.transactions.refreshTransactionData(publicDeriver);
+      await substore.addresses.refreshAddressesFromDb(publicDeriver);
     } catch (error) {
       Logger.error(`${nameof(WalletStore)}::${nameof(this.refreshWallet)} ` + stringifyError(error));
       throw error;


### PR DESCRIPTION
This fixes the "15-word recovery phrase" to transfer one Shelley (cip1852) wallet to another. The witness data was incorrectly generated.

At the same time I fixed some other issues like the spinner was for some reason missing on this page.