### PR TITLE
Stricter types for stores

### DIFF
--- a/app/actions/ada/paper-wallets-actions.js
+++ b/app/actions/ada/paper-wallets-actions.js
@@ -5,10 +5,10 @@ import type { PdfGenStepType } from '../../api/ada/paperWallet/paperWalletPdf';
 // ======= PAPER WALLET ACTIONS =======
 
 export default class PaperWalletsActions {
-  submitInit: Action<{
+  submitInit: Action<{|
     numAddresses: number,
     printAccountPlate: boolean,
-  }> = new Action();
+  |}> = new Action();
   submitUserPassword: AsyncAction<{| userPassword: string |}> = new AsyncAction();
   submitCreate: Action<void> = new Action();
   backToCreate: Action<void> = new Action();

--- a/app/actions/notifications-actions.js
+++ b/app/actions/notifications-actions.js
@@ -7,6 +7,6 @@ import type { Notification } from '../types/notificationType';
 export default class NotificationsActions {
   open: Action<Notification> = new Action();
   updateDataForActiveNotification: Action<{ data: Object }> = new Action();
-  closeActiveNotification: Action<{ id: string }>= new Action();
+  closeActiveNotification: Action<{| id: string |}>= new Action();
   resetActiveNotification: Action<void> = new Action();
 }

--- a/app/actions/router-actions.js
+++ b/app/actions/router-actions.js
@@ -4,7 +4,7 @@ import { Action } from './lib/Action';
 // ======= ROUTER ACTIONS =======
 
 export default class RouterActions {
-  goToRoute: Action<{ route: string, params?: ?Object }> = new Action();
+  goToRoute: Action<{| route: string, params?: ?Object |}> = new Action();
 
-  goToTransactionsList: Action<{ params?: ?Object }> = new Action();
+  goToTransactionsList: Action<{| params?: ?Object |}> = new Action();
 }

--- a/app/actions/topbar-actions.js
+++ b/app/actions/topbar-actions.js
@@ -2,5 +2,5 @@
 import { Action } from './lib/Action';
 
 export default class TopbarActions {
-  activateTopbarCategory: Action<{ category: string, showSubMenu?: boolean }> = new Action();
+  activateTopbarCategory: Action<{| category: string |}> = new Action();
 }

--- a/app/actions/wallet-backup-actions.js
+++ b/app/actions/wallet-backup-actions.js
@@ -5,11 +5,11 @@ import { AsyncAction, Action } from './lib/Action';
 
 export default class WalletBackupActions {
   startWalletBackup: Action<void> = new Action();
-  initiateWalletBackup: Action<{
+  initiateWalletBackup: Action<{|
     recoveryPhrase: Array<string>,
     name: string,
     password: string,
-  }> = new Action();
+  |}> = new Action();
   continueToPrivacyWarning: Action<void> = new Action();
   acceptPrivacyNoticeForWalletBackup: Action<void> = new Action();
   continueToRecoveryPhraseForWalletBackup: Action<void> = new Action();

--- a/app/components/profile/language-selection/LanguageSelectionForm.js
+++ b/app/components/profile/language-selection/LanguageSelectionForm.js
@@ -9,8 +9,8 @@ import { SelectSkin } from 'react-polymorph/lib/skins/simple/SelectSkin';
 import { defineMessages, intlShape } from 'react-intl';
 import ReactToolboxMobxForm from '../../../utils/ReactToolboxMobxForm';
 import LocalizableError from '../../../i18n/LocalizableError';
+import type { LanguageType } from '../../../i18n/translations';
 import styles from './LanguageSelectionForm.scss';
-import type { MessageDescriptor } from 'react-intl';
 import FlagLabel from '../../widgets/FlagLabel';
 import { tier1Languages } from '../../../config/languagesConfig';
 import globalMessages, { listOfTranslators } from '../../../i18n/global-messages';
@@ -24,7 +24,7 @@ const messages = defineMessages({
 
 type Props = {|
   +onSelectLanguage: {| locale: string |} => void,
-  +languages: Array<{ value: string, label: MessageDescriptor, svg: string }>,
+  +languages: Array<LanguageType>,
   +onSubmit: {| locale: string |} => PossiblyAsync<void>,
   +isSubmitting: boolean,
   +currentLocale: string,

--- a/app/components/settings/categories/general-setting/GeneralSettings.js
+++ b/app/components/settings/categories/general-setting/GeneralSettings.js
@@ -8,13 +8,13 @@ import { intlShape } from 'react-intl';
 import ReactToolboxMobxForm from '../../../../utils/ReactToolboxMobxForm';
 import LocalizableError from '../../../../i18n/LocalizableError';
 import styles from './GeneralSettings.scss';
-import type { MessageDescriptor } from 'react-intl';
+import type { LanguageType } from '../../../../i18n/translations';
 import FlagLabel from '../../../widgets/FlagLabel';
 import { tier1Languages } from '../../../../config/languagesConfig';
 import globalMessages, { listOfTranslators } from '../../../../i18n/global-messages';
 
 type Props = {|
-  +languages: Array<{ value: string, label: MessageDescriptor, svg: string }>,
+  +languages: Array<LanguageType>,
   +currentLocale: string,
   +onSelectLanguage: {| locale: string |} => PossiblyAsync<void>,
   +isSubmitting: boolean,

--- a/app/i18n/translations.js
+++ b/app/i18n/translations.js
@@ -1,6 +1,6 @@
 // @flow
 import globalMessages from './global-messages';
-
+import type { $npm$ReactIntl$MessageDescriptor } from 'react-intl';
 import EnglishFlag from '../assets/images/flags/english.inline.svg';
 import JapaneseFlag from '../assets/images/flags/japanese.inline.svg';
 import KoreanFlag from '../assets/images/flags/korean.inline.svg';
@@ -23,7 +23,13 @@ req.keys().forEach((file) => {
   translations[locale] = req(file);
 });
 
-export const LANGUAGES = [
+export type LanguageType = {|
+  value: string,
+  label: $npm$ReactIntl$MessageDescriptor,
+  svg: string,
+|};
+
+export const LANGUAGES: Array<LanguageType> = [
   {
     value: 'en-US',
     label: globalMessages.languageEnglish,

--- a/app/stores/.eslintrc.js
+++ b/app/stores/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
     "no-restricted-syntax": [
       "error",
       {
-        "selector": "ClassProperty:not([typeAnnotation])[key.name!=/_.*/]",
+        "selector": "ClassProperty:not([typeAnnotation])",
         "message": "Missing type annotation of class property. This has unexpected cross-module behavior."
       },
     ],

--- a/app/stores/ada/AdaTransactionBuilderStore.js
+++ b/app/stores/ada/AdaTransactionBuilderStore.js
@@ -92,6 +92,7 @@ export default class AdaTransactionBuilderStore extends Store {
   //   tentative tx
   // ================
 
+  // eslint-disable-next-line no-restricted-syntax
   _mismatchReaction = reaction(
     () => [
       this.plannedTx,
@@ -104,6 +105,7 @@ export default class AdaTransactionBuilderStore extends Store {
   //   planned tx
   // ==============
 
+  // eslint-disable-next-line no-restricted-syntax
   _updatePlannedTxReaction = reaction(
     () => this.createUnsignedTx.result,
     () => this._updatePlannedTx(),
@@ -137,10 +139,11 @@ export default class AdaTransactionBuilderStore extends Store {
   //   tx builder
   // ==============
 
+  // eslint-disable-next-line no-restricted-syntax
   _updateTxBuilderReaction = reaction(
     () => [
       // Need toJS for mobx to react to an array.
-      // Note: will not trigger if re-asigned same value
+      // Note: will not trigger if re-assigned same value
       toJS(this.plannedTxInfo),
       this.shouldSendAll,
       this.stores.substores.ada.wallets.selected,
@@ -275,9 +278,11 @@ export default class AdaTransactionBuilderStore extends Store {
    * We need to clone to tentative tx to avoid the dialog changing
    * when the send page recalculates the utxo
    */
-  _cloneTx = (
-    signRequest: BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput>
-  ): BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput> => {
+  _cloneTx: (
+    BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput>
+  ) => BaseSignRequest<RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput> = (
+    signRequest
+  ) => {
     // drop mobx observable behavior
     const copy = toJS(signRequest);
 

--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -81,7 +81,7 @@ export default class AdaWalletsStore extends WalletStore {
     this.goToWalletRoute(transactionDetails.publicDeriver.self);
   };
 
-  @action _onRouteChange = (options: { route: string, params: ?Object }): void => {
+  @action _onRouteChange: {| route: string, params: ?Object |} => void = (options) => {
     // Reset the send request anytime we visit the send page (e.g: to remove any previous errors)
     if (matchRoute(ROUTES.WALLETS.SEND, buildRoute(options.route, options.params)) !== false) {
       this.sendMoneyRequest.reset();
@@ -102,11 +102,11 @@ export default class AdaWalletsStore extends WalletStore {
 
   // =================== WALLET RESTORATION ==================== //
 
-  _restoreWallet = async (params: {|
+  _restoreWallet: {|
     recoveryPhrase: string,
     walletName: string,
     walletPassword: string,
-  |}) => {
+  |} => Promise<void> = async (params) => {
     await this.restore(params);
   };
 

--- a/app/stores/ada/DelegationTransactionStore.js
+++ b/app/stores/ada/DelegationTransactionStore.js
@@ -33,6 +33,7 @@ export default class DelegationTransactionStore extends Store {
   /** tracks if wallet balance changed during confirmation screen */
   @observable isStale: boolean = false;
 
+  // eslint-disable-next-line no-restricted-syntax
   _updateTxBuilderReaction = reaction(
     () => [
       this.stores.substores.ada.wallets.selected,

--- a/app/stores/ada/HWVerifyAddressStore.js
+++ b/app/stores/ada/HWVerifyAddressStore.js
@@ -50,9 +50,9 @@ export default class AddressesStore extends Store {
     actions.closeAddressDetailDialog.listen(this._closeAddressDetailDialog);
   }
 
-  @action _verifyAddress = async (
-    publicDeriver: PublicDeriver<>,
-  ): Promise<void> => {
+  @action _verifyAddress: (PublicDeriver<>) => Promise<void> = async (
+    publicDeriver,
+  ) => {
     Logger.info('AddressStore::_verifyAddress called');
 
     if (!this.selectedAddress) {
@@ -120,23 +120,23 @@ export default class AddressesStore extends Store {
     }
   }
 
-  @action _selectAddress = async (params: {|
+  @action _selectAddress: {|
     address: string,
     path: BIP32Path,
-  |}): Promise<void> => {
+  |} => Promise<void> = async (params) => {
     Logger.info('AddressStore::_selectAddress::called: ' + params.address);
     this.selectedAddress = { address: params.address, path: params.path };
   }
 
-  @action _setActionProcessing = (processing: boolean): void => {
+  @action _setActionProcessing: boolean => void = (processing) => {
     this.isActionProcessing = processing;
   }
 
-  @action _setError = (error: ?LocalizableError): void => {
+  @action _setError: ?LocalizableError => void = (error) => {
     this.error = error;
   }
 
-  @action _closeAddressDetailDialog = (): void => {
+  @action _closeAddressDetailDialog: void => void = () => {
     this.ledgerConnect && this.ledgerConnect.dispose();
     this.ledgerConnect = undefined;
     this.selectedAddress = null;

--- a/app/stores/ada/LedgerConnectStore.js
+++ b/app/stores/ada/LedgerConnectStore.js
@@ -91,11 +91,11 @@ export default class LedgerConnectStore
 
   /** setup() is called when stores are being created
     * _init() is called when connect dailog is about to show */
-  _init = (): void => {
+  _init: void => void = () => {
     Logger.debug('LedgerConnectStore::_init called');
   }
 
-  @action _cancel = (): void => {
+  @action _cancel: void => void = () => {
     this.teardown();
     this.ledgerConnect && this.ledgerConnect.dispose();
     this.ledgerConnect = undefined;
@@ -106,7 +106,7 @@ export default class LedgerConnectStore
     super.teardown();
   }
 
-  @action _reset = (): void => {
+  @action _reset: void => void = () => {
     this.progressInfo = {
       currentStep: ProgressStep.CHECK,
       stepState: StepState.LOAD,
@@ -118,7 +118,7 @@ export default class LedgerConnectStore
 
   // =================== CHECK =================== //
   /** CHECK dialog submit(Next button) */
-  @action _submitCheck = (): void => {
+  @action _submitCheck: void => void = () => {
     this.error = undefined;
     this.progressInfo.currentStep = ProgressStep.CONNECT;
     this.progressInfo.stepState = StepState.LOAD;
@@ -127,21 +127,21 @@ export default class LedgerConnectStore
 
   // =================== CONNECT =================== //
   /** CONNECT dialog goBack button */
-  @action _goBackToCheck = (): void => {
+  @action _goBackToCheck: void => void = () => {
     this.error = undefined;
     this.progressInfo.currentStep = ProgressStep.CHECK;
     this.progressInfo.stepState = StepState.LOAD;
   };
 
   /** CONNECT dialog submit (Connect button) */
-  @action _submitConnect = async (): Promise<void> => {
+  @action _submitConnect: void => Promise<void> = async () => {
     this.error = undefined;
     this.progressInfo.currentStep = ProgressStep.CONNECT;
     this.progressInfo.stepState = StepState.PROCESS;
     await this._checkAndStoreHWDeviceInfo();
   };
 
-  _checkAndStoreHWDeviceInfo = async (): Promise<void> => {
+  _checkAndStoreHWDeviceInfo: void => Promise<void> = async () => {
     try {
       this.ledgerConnect = new LedgerConnect({
         locale: this.stores.profile.currentLocale
@@ -174,9 +174,9 @@ export default class LedgerConnectStore
     }
   };
 
-  _normalizeHWResponse = (
-    resp: ExtendedPublicKeyResp,
-  ): HWDeviceInfo => {
+  _normalizeHWResponse: ExtendedPublicKeyResp => HWDeviceInfo = (
+    resp,
+  ) => {
     this._validateHWResponse(resp);
 
     const { ePublicKey, deviceVersion } = resp;
@@ -196,9 +196,9 @@ export default class LedgerConnectStore
     };
   }
 
-  _validateHWResponse = (
-    resp: ExtendedPublicKeyResp,
-  ): boolean => {
+  _validateHWResponse: ExtendedPublicKeyResp => boolean = (
+    resp,
+  ) => {
     const { ePublicKey, deviceVersion } = resp;
 
     if (deviceVersion == null) {
@@ -212,30 +212,30 @@ export default class LedgerConnectStore
     return true;
   };
 
-  _handleConnectError = (error: Error): void => {
+  _handleConnectError: Error => void = (error) => {
     this.hwDeviceInfo = undefined;
     this.error = convertToLocalizableError(error);
 
     this._goToConnectError();
   };
 
-  @action _goToConnectError = (): void => {
+  @action _goToConnectError: void => void = () => {
     this.progressInfo.currentStep = ProgressStep.CONNECT;
     this.progressInfo.stepState = StepState.ERROR;
   };
   // =================== CONNECT =================== //
 
   // =================== SAVE =================== //
-  @action _goToSaveLoad = (): void => {
+  @action _goToSaveLoad: void => void = () => {
     this.error = null;
     this.progressInfo.currentStep = ProgressStep.SAVE;
     this.progressInfo.stepState = StepState.LOAD;
   };
 
   /** SAVE dialog submit (Save button) */
-  @action _submitSave = async (
-    walletName: string,
-  ): Promise<void> => {
+  @action _submitSave: (string) => Promise<void> = async (
+    walletName,
+  ) => {
     this.error = null;
     this.progressInfo.currentStep = ProgressStep.SAVE;
     this.progressInfo.stepState = StepState.PROCESS;
@@ -245,11 +245,11 @@ export default class LedgerConnectStore
   };
 
   /** creates new wallet and loads it */
-  _saveHW = async (
-    walletName: string,
-  ): Promise<void>  => {
+  _saveHW: (string) => Promise<void> = async (
+    walletName,
+  )  => {
     try {
-      Logger.debug('LedgerConnectStore::_saveHW:: called');
+      Logger.debug(`${nameof(LedgerConnectStore)}::${nameof(this._saveHW)}:: called`);
       this._setIsCreateHWActive(true);
       this.createHWRequest.reset();
 
@@ -263,7 +263,7 @@ export default class LedgerConnectStore
 
       await this._onSaveSucess(newWallet.publicDeriver);
     } catch (error) {
-      Logger.error(`LedgerConnectStore::_saveHW::error ${stringifyError(error)}`);
+      Logger.error(`${nameof(LedgerConnectStore)}::${nameof(this._saveHW)}::error ${stringifyError(error)}`);
 
       // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1055
       if (error instanceof CheckAdressesInUseApiError) {
@@ -289,10 +289,10 @@ export default class LedgerConnectStore
     }
   };
 
-  _prepareCreateHWReqParams = (
-    walletName: string,
-    derivationIndex: number,
-  ): CreateHardwareWalletRequest => {
+  _prepareCreateHWReqParams: (string, number) => CreateHardwareWalletRequest = (
+    walletName,
+    derivationIndex,
+  ) => {
     if (this.hwDeviceInfo == null
       || this.hwDeviceInfo.publicMasterKey == null
       || this.hwDeviceInfo.hwFeatures == null) {
@@ -301,7 +301,7 @@ export default class LedgerConnectStore
 
     const persistentDb = this.stores.loading.loadPersitentDbRequest.result;
     if (persistentDb == null) {
-      throw new Error('_prepareCreateHWReqParams db not loaded. Should never happen');
+      throw new Error(`${nameof(this._prepareCreateHWReqParams)} db not loaded. Should never happen`);
     }
 
     const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
@@ -330,14 +330,14 @@ export default class LedgerConnectStore
     Logger.info('SUCCESS: Ledger Connected Wallet created and loaded');
   }
 
-  @action _goToSaveError = (): void => {
+  @action _goToSaveError: void => void = () => {
     this.progressInfo.currentStep = ProgressStep.SAVE;
     this.progressInfo.stepState = StepState.ERROR;
   };
   // =================== SAVE =================== //
 
   // =================== API =================== //
-  @action _setIsCreateHWActive = (active: boolean): void => {
+  @action _setIsCreateHWActive: boolean => void = (active) => {
     this.isCreateHWActive = active;
   };
 

--- a/app/stores/ada/PaperWalletCreateStore.js
+++ b/app/stores/ada/PaperWalletCreateStore.js
@@ -59,17 +59,14 @@ export default class PaperWalletCreateStore extends Store {
     a.cancel.listen(this._cancel);
   }
 
-  @action _submitInit = (
-    {
-      numAddresses,
-      printAccountPlate
-    }: {
-      numAddresses: number,
-      printAccountPlate: boolean
-    }
-  ): void => {
-    this.numAddresses = numAddresses;
-    this.printAccountPlate = printAccountPlate;
+  @action _submitInit: {|
+    numAddresses: number,
+    printAccountPlate: boolean
+  |} => void = (
+    request
+  ) => {
+    this.numAddresses = request.numAddresses;
+    this.printAccountPlate = request.printAccountPlate;
     this.progressInfo = ProgressStep.USER_PASSWORD;
   };
 
@@ -85,19 +82,19 @@ export default class PaperWalletCreateStore extends Store {
     await this.actions.ada.paperWallets.createPdfDocument.trigger();
   };
 
-  @action _backToCreatePaper = () => {
+  @action _backToCreatePaper: void => void = () => {
     this.progressInfo = ProgressStep.CREATE;
   };
 
-  @action _submitCreatePaper = () => {
+  @action _submitCreatePaper: void => void = () => {
     this.progressInfo = ProgressStep.VERIFY;
   };
 
-  @action _submitVerifyPaper = () => {
+  @action _submitVerifyPaper: void => void = () => {
     this.progressInfo = ProgressStep.FINALIZE;
   };
 
-  @action _createPaperWallet = () => {
+  @action _createPaperWallet: void => void = () => {
     if (this.numAddresses != null && this.userPassword != null) {
       this.paper = this.api.ada.createAdaPaper({
         numAddresses: this.numAddresses,
@@ -108,7 +105,7 @@ export default class PaperWalletCreateStore extends Store {
     }
   };
 
-  @action _createPdfDocument = async () => {
+  @action _createPdfDocument: void => Promise<void> = async () => {
     let pdf;
     if (this.paper) {
       pdf = await this.api.ada.createAdaPaperPdf({
@@ -126,19 +123,23 @@ export default class PaperWalletCreateStore extends Store {
     }
   };
 
-  @action _setPdfRenderStatus = ({ status }: {| status: PdfGenStepType |}) => {
+  @action _setPdfRenderStatus: {| status: PdfGenStepType |} => void = (
+    { status }
+  ) => {
     this.pdfRenderStatus = status;
   };
 
-  @action _setPdf = ({ pdf }: {| pdf: Blob |}) => {
+  @action _setPdf: {| pdf: Blob |} => void = (
+    { pdf }
+  ) => {
     this.pdf = pdf;
   };
 
-  @action _downloadPaperWallet = () => {
+  @action _downloadPaperWallet: void => void = () => {
     fileSaver.saveAs(this.pdf, 'Yoroi-Paper-Wallet.pdf');
   };
 
-  @action _cancel = () => {
+  @action _cancel: void => void = () => {
     this.teardown();
   };
 
@@ -148,7 +149,7 @@ export default class PaperWalletCreateStore extends Store {
   }
 
   @action
-  _reset = () => {
+  _reset: void => void = () => {
     this.progressInfo = ProgressStep.INIT;
     this.error = undefined;
     this.numAddresses = undefined;

--- a/app/stores/ada/ServerConnectionStore.js
+++ b/app/stores/ada/ServerConnectionStore.js
@@ -7,7 +7,7 @@ import environment from '../../environment';
 import type { ServerStatusResponse } from '../../api/ada/lib/state-fetch/types';
 
 export default class ServerConnectionStore extends Store {
-  SERVER_STATUS_REFRESH_INTERVAL = environment.serverStatusRefreshInterval;
+  SERVER_STATUS_REFRESH_INTERVAL: number = environment.serverStatusRefreshInterval;
 
   @observable serverStatus: ServerStatusErrorType = 'healthy';
 
@@ -20,7 +20,7 @@ export default class ServerConnectionStore extends Store {
     return this.serverStatus;
   }
 
-  @action _checkServerStatus = async (): Promise<void> => {
+  @action _checkServerStatus: void => Promise<void> = async () => {
     const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
     const checkServerStatusFunc = stateFetcher.checkServerStatus;
     try {

--- a/app/stores/ada/TimeStore.js
+++ b/app/stores/ada/TimeStore.js
@@ -125,7 +125,7 @@ export default class TimeStore extends Store {
     });
   }
 
-  @action _updateTime = async (): Promise<void> => {
+  @action _updateTime: void => Promise<void> = async () => {
     const currTime = new Date();
     runInAction(() => { this.time = currTime; });
 

--- a/app/stores/ada/TrezorConnectStore.js
+++ b/app/stores/ada/TrezorConnectStore.js
@@ -126,8 +126,8 @@ export default class TrezorConnectStore
 
   /** setup() is called when stores are being created
     * _init() is called when connect dailog is about to show */
-  _init = (): void => {
-    Logger.debug('TrezorConnectStore::_init called');
+  _init: void => void = () => {
+    Logger.debug(`${nameof(TrezorConnectStore)}::${nameof(this._init)} called`);
   }
 
   teardown(): void {
@@ -142,7 +142,7 @@ export default class TrezorConnectStore
     super.teardown();
   }
 
-  @action _reset = (): void => {
+  @action _reset: void => void = () => {
     this.progressInfo = {
       currentStep: ProgressStep.CHECK,
       stepState: StepState.LOAD,
@@ -152,13 +152,13 @@ export default class TrezorConnectStore
     this.trezorEventDevice = undefined;
   };
 
-  @action _cancel = (): void => {
+  @action _cancel: void => void = () => {
     this.teardown();
   };
 
   // =================== CHECK =================== //
   /** CHECK dialog submit(Next button) */
-  @action _submitCheck = (): void => {
+  @action _submitCheck: void => void = () => {
     this.error = undefined;
     this.trezorEventDevice = undefined;
     this._removeTrezorConnectEventListeners();
@@ -170,26 +170,26 @@ export default class TrezorConnectStore
 
   // =================== CONNECT =================== //
   /** CONNECT dialog goBack button */
-  @action _goBackToCheck = (): void => {
+  @action _goBackToCheck: void => void = () => {
     this.error = undefined;
     this.progressInfo.currentStep = ProgressStep.CHECK;
     this.progressInfo.stepState = StepState.LOAD;
   };
 
   /** CONNECT dialog submit (Connect button) */
-  @action _submitConnect = async (): Promise<void> => {
+  @action _submitConnect: void => Promise<void> = async () => {
     this.error = undefined;
     this.progressInfo.currentStep = ProgressStep.CONNECT;
     this.progressInfo.stepState = StepState.PROCESS;
     await this._checkAndStoreHWDeviceInfo();
   };
 
-  @action _goToConnectError = (): void => {
+  @action _goToConnectError: void => void = () => {
     this.progressInfo.currentStep = ProgressStep.CONNECT;
     this.progressInfo.stepState = StepState.ERROR;
   };
 
-  _checkAndStoreHWDeviceInfo = async (): Promise<void> => {
+  _checkAndStoreHWDeviceInfo: void => Promise<void> = async () => {
     try {
       this.hwDeviceInfo = undefined;
 
@@ -215,9 +215,9 @@ export default class TrezorConnectStore
     }
   };
 
-  _normalizeHWResponse = (
-    resp: TrezorConnectionResponse,
-  ): HWDeviceInfo => {
+  _normalizeHWResponse: (TrezorConnectionResponse) => HWDeviceInfo = (
+    resp,
+  ) => {
     this._validateHWResponse(resp);
     if (!resp.trezorResp.success) {
       throw new Error('TrezorConnectStore::_normalizeHWResponse should never happen');
@@ -249,9 +249,9 @@ export default class TrezorConnectStore
   }
 
   /** Validates the compatibility of data which we have received from Trezor device */
-  _validateHWResponse = (
-    resp: TrezorConnectionResponse,
-  ): boolean => {
+  _validateHWResponse: TrezorConnectionResponse => boolean = (
+    resp,
+  ) => {
     const { trezorResp, trezorEventDevice } = resp;
 
     if (trezorResp && !trezorResp.success) {
@@ -285,8 +285,8 @@ export default class TrezorConnectStore
     return true;
   };
 
-  _handleConnectError = (error: Error): void => {
-    Logger.error(`TrezorConnectStore::_handleConnectError ${stringifyError(error)}`);
+  _handleConnectError: Error => void = (error) => {
+    Logger.error(`${nameof(TrezorConnectStore)}::${nameof(this._handleConnectError)} ${stringifyError(error)}`);
 
     this.hwDeviceInfo = undefined;
 
@@ -299,28 +299,28 @@ export default class TrezorConnectStore
     this._goToConnectError();
   };
 
-  _addTrezorConnectEventListeners = (): void => {
+  _addTrezorConnectEventListeners: void => void = () => {
     if (TrezorConnect) {
       TrezorConnect.on(DEVICE_EVENT, this._onTrezorDeviceEvent);
       TrezorConnect.on(UI_EVENT, this._onTrezorUIEvent);
     } else {
-      Logger.error('TrezorConnectStore::_addTrezorConnectEventListeners:: TrezorConnect not installed');
+      Logger.error(`${nameof(TrezorConnectStore)}::${nameof(this._addTrezorConnectEventListeners)}:: TrezorConnect not installed`);
     }
   };
 
-  _removeTrezorConnectEventListeners = (): void => {
+  _removeTrezorConnectEventListeners: void => void = () => {
     if (TrezorConnect) {
       TrezorConnect.off(DEVICE_EVENT, this._onTrezorDeviceEvent);
       TrezorConnect.off(UI_EVENT, this._onTrezorUIEvent);
     }
   };
 
-  _onTrezorDeviceEvent = (event: DeviceMessage): void => {
+  _onTrezorDeviceEvent: DeviceMessage => void = (event) => {
     Logger.debug(`TrezorConnectStore:: DEVICE_EVENT: ${event.type}`);
     this.trezorEventDevice = event;
   };
 
-  _onTrezorUIEvent = (event: UiMessage): void => {
+  _onTrezorUIEvent: UiMessage => void = (event) => {
     Logger.debug(`TrezorConnectStore:: UI_EVENT: ${event.type}`);
     // TODO: [TREZOR] https://github.com/Emurgo/yoroi-frontend/issues/126
     // if(event.type === CLOSE_UI_WINDOW &&
@@ -334,16 +334,16 @@ export default class TrezorConnectStore
   // =================== CONNECT =================== //
 
   // =================== SAVE =================== //
-  @action _goToSaveLoad = (): void => {
+  @action _goToSaveLoad: void => void = () => {
     this.error = null;
     this.progressInfo.currentStep = ProgressStep.SAVE;
     this.progressInfo.stepState = StepState.LOAD;
   };
 
   /** SAVE dialog submit (Save button) */
-  @action _submitSave = async (
-    walletName: string,
-  ): Promise<void> => {
+  @action _submitSave: string => Promise<void> = async (
+    walletName,
+  ) => {
     this.error = null;
     this.progressInfo.currentStep = ProgressStep.SAVE;
     this.progressInfo.stepState = StepState.PROCESS;
@@ -354,11 +354,11 @@ export default class TrezorConnectStore
   };
 
   /** creates new wallet and loads it */
-  _saveHW = async (
-    walletName: string,
-  ): Promise<void>  => {
+  _saveHW: string => Promise<void> = async (
+    walletName,
+  )  => {
     try {
-      Logger.debug('TrezorConnectStore::_saveHW:: stated');
+      Logger.debug(`${nameof(TrezorConnectStore)}::${nameof(this._saveHW)}:: stated`);
       this._setIsCreateHWActive(true);
       this.createHWRequest.reset();
 
@@ -373,7 +373,7 @@ export default class TrezorConnectStore
 
       await this._onSaveSucess(newWallet.publicDeriver);
     } catch (error) {
-      Logger.error(`TrezorConnectStore::_saveHW::error ${stringifyError(error)}`);
+      Logger.error(`${nameof(TrezorConnectStore)}::${nameof(this._saveHW)}::error ${stringifyError(error)}`);
 
       // Refer: https://github.com/Emurgo/yoroi-frontend/pull/1055
       if (error instanceof CheckAdressesInUseApiError) {
@@ -399,10 +399,10 @@ export default class TrezorConnectStore
     }
   };
 
-  _prepareCreateHWReqParams = (
-    walletName: string,
-    derivationIndex: number,
-  ): CreateHardwareWalletRequest => {
+  _prepareCreateHWReqParams: (string, number) => CreateHardwareWalletRequest = (
+    walletName,
+    derivationIndex,
+  ) => {
     if (this.hwDeviceInfo == null
       || this.hwDeviceInfo.publicMasterKey == null
       || this.hwDeviceInfo.hwFeatures == null) {
@@ -411,7 +411,7 @@ export default class TrezorConnectStore
 
     const persistentDb = this.stores.loading.loadPersitentDbRequest.result;
     if (persistentDb == null) {
-      throw new Error('_prepareCreateHWReqParams db not loaded. Should never happen');
+      throw new Error(`${nameof(this._prepareCreateHWReqParams)} db not loaded. Should never happen`);
     }
 
     const stateFetcher = this.stores.substores[environment.API].stateFetchStore.fetcher;
@@ -425,14 +425,14 @@ export default class TrezorConnectStore
     };
   }
 
-  @action _goToSaveError = (): void => {
+  @action _goToSaveError: void => void = () => {
     this.progressInfo.currentStep = ProgressStep.SAVE;
     this.progressInfo.stepState = StepState.ERROR;
   };
 
-  _onSaveSucess = async (publicDeriver: PublicDeriver<>) => {
+  _onSaveSucess: (PublicDeriver<>) => Promise<void> = async (publicDeriver) => {
     // close the active dialog
-    Logger.debug('TrezorConnectStore::_saveTrezor success, closing dialog');
+    Logger.debug(`${nameof(TrezorConnectStore)}::${nameof(this._onSaveSucess)} success, closing dialog`);
     this.actions.dialogs.closeActiveDialog.trigger();
 
     const { wallets } = this.stores.substores[environment.API];
@@ -447,7 +447,7 @@ export default class TrezorConnectStore
   // =================== SAVE =================== //
 
   // =================== API =================== //
-  @action _setIsCreateHWActive = (active: boolean): void => {
+  @action _setIsCreateHWActive: boolean => void = (active) => {
     this.isCreateHWActive = active;
   };
   // =================== API =================== //

--- a/app/stores/ada/YoroiTransferStore.js
+++ b/app/stores/ada/YoroiTransferStore.js
@@ -55,6 +55,7 @@ export default class YoroiTransferStore extends Store {
   @observable transferKind: TransferKindType = TransferKind.NORMAL;
   @observable transferSource: TransferSourceType = TransferSource.BYRON;
 
+  // eslint-disable-next-line no-restricted-syntax
   _asyncErrorWrapper = <PT, RT>(func: PT=>Promise<RT>): (PT => Promise<RT>) => (async (payload) => {
     try {
       return await func(payload);
@@ -67,6 +68,7 @@ export default class YoroiTransferStore extends Store {
       throw error;
     }
   });
+  // eslint-disable-next-line no-restricted-syntax
   _errorWrapper = <PT, RT>(func: PT=>RT): (PT => RT) => ((payload) => {
     try {
       return func(payload);
@@ -272,7 +274,7 @@ export default class YoroiTransferStore extends Store {
     this._updateStatus(TransferStatus.READY_TO_TRANSFER);
   }
 
-  _backToUninitialized = (): void => {
+  _backToUninitialized: void => void = () => {
     this._updateStatus(TransferStatus.UNINITIALIZED);
   }
 

--- a/app/stores/base/AddressesStore.js
+++ b/app/stores/base/AddressesStore.js
@@ -50,7 +50,7 @@ export type StandardAddress = {|
   ...Address, ...Value, ...Addressing, ...UsedStatus
 |};
 
-type SubRequestType<T> = { publicDeriver: PublicDeriver<> } => Promise<Array<T>>;
+type SubRequestType<T> = {| publicDeriver: PublicDeriver<> |} => Promise<Array<T>>;
 export class AddressTypeStore<T> {
 
   @observable addressesRequests: Array<{
@@ -231,13 +231,13 @@ export default class AddressesStore extends Store {
     }
   }
 
-  _wrapForAllAddresses = async (request: {
+  _wrapForAllAddresses: {|
     publicDeriver: PublicDeriver<>,
     invertFilter: boolean,
-  }): Promise<Array<StandardAddress>> => {
+  |} => Promise<Array<StandardAddress>> = async (request) => {
     const withUtxos = asGetAllUtxos(request.publicDeriver);
     if (withUtxos == null) {
-      Logger.error(`_wrapForAllAddresses incorrect public deriver`);
+      Logger.error(`${nameof(this._wrapForAllAddresses)} incorrect public deriver`);
       return Promise.resolve([]);
     }
 
@@ -255,15 +255,15 @@ export default class AddressesStore extends Store {
     });
   }
 
-  _wrapForChainAddresses = async (request: {
+  _wrapForChainAddresses: {|
     publicDeriver: PublicDeriver<>,
     chainsRequest: IHasUtxoChainsRequest,
-  }): Promise<Array<StandardAddress>> => {
+  |}=> Promise<Array<StandardAddress>> = async (request) => {
     const withHasUtxoChains = asHasUtxoChains(
       request.publicDeriver
     );
     if (withHasUtxoChains == null) {
-      Logger.error(`_wrapForChainAddresses incorrect public deriver`);
+      Logger.error(`${nameof(this._wrapForChainAddresses)} incorrect public deriver`);
       return Promise.resolve([]);
     }
     const addresses = await this.api[environment.API].getChainAddressesForDisplay({

--- a/app/stores/base/TransactionsStore.js
+++ b/app/stores/base/TransactionsStore.js
@@ -24,13 +24,13 @@ import { ConceptualWallet } from '../../api/ada/lib/storage/models/ConceptualWal
 export default class TransactionsStore extends Store {
 
   /** How many transactions to display */
-  INITIAL_SEARCH_LIMIT = 5;
+  INITIAL_SEARCH_LIMIT: number = 5;
 
-  /** How many additonall transactions to display when user wants to show more */
-  SEARCH_LIMIT_INCREASE = 5;
+  /** How many additonal transactions to display when user wants to show more */
+  SEARCH_LIMIT_INCREASE: number = 5;
 
   /** Skip first n transactions from api */
-  SEARCH_SKIP = 0;
+  SEARCH_SKIP: number = 0;
 
   /** Track transactions for a set of wallets */
   @observable transactionsRequests: Array<{
@@ -41,10 +41,10 @@ export default class TransactionsStore extends Store {
     getBalanceRequest: CachedRequest<GetBalanceFunc>
   }> = [];
 
-  @observable _searchOptionsForWallets = observable.map<
-      PublicDeriver<>,
-      GetTransactionsRequestOptions,
-    >();
+  @observable _searchOptionsForWallets: Map<
+    PublicDeriver<>,
+    GetTransactionsRequestOptions
+  > = observable.map();
 
   _hasAnyPending: boolean = false;
 
@@ -254,9 +254,11 @@ export default class TransactionsStore extends Store {
     });
   }
 
-  _getTransactionsPendingRequest = (
-    publicDeriver: PublicDeriver<>
-  ): CachedRequest<RefreshPendingTransactionsFunc> => {
+  _getTransactionsPendingRequest: (
+    PublicDeriver<>
+  ) => CachedRequest<RefreshPendingTransactionsFunc> = (
+    publicDeriver
+  ) => {
     const foundRequest = find(this.transactionsRequests, { publicDeriver });
     if (foundRequest && foundRequest.pendingRequest) return foundRequest.pendingRequest;
     return new CachedRequest<RefreshPendingTransactionsFunc>(
@@ -266,9 +268,9 @@ export default class TransactionsStore extends Store {
 
   /** Get request for fetching transaction data.
    * Should ONLY be executed to cache query WITH search options */
-  _getTransactionsRecentRequest = (
-    publicDeriver: PublicDeriver<>
-  ): CachedRequest<GetTransactionsFunc> => {
+  _getTransactionsRecentRequest: PublicDeriver<> => CachedRequest<GetTransactionsFunc> = (
+    publicDeriver
+  ) => {
     const foundRequest = find(this.transactionsRequests, { publicDeriver });
     if (foundRequest && foundRequest.recentRequest) return foundRequest.recentRequest;
     return new CachedRequest<GetTransactionsFunc>(this.api[environment.API].refreshTransactions);
@@ -284,9 +286,9 @@ export default class TransactionsStore extends Store {
     return new CachedRequest<GetTransactionsFunc>(this.api[environment.API].refreshTransactions);
   };
 
-  _getBalanceRequest = (
-    publicDeriver: PublicDeriver<>
-  ): CachedRequest<GetBalanceFunc> => {
+  _getBalanceRequest: (PublicDeriver<>) => CachedRequest<GetBalanceFunc> = (
+    publicDeriver
+  ) => {
     const foundRequest = find(this.transactionsRequests, { publicDeriver });
     if (foundRequest && foundRequest.getBalanceRequest) return foundRequest.getBalanceRequest;
     return new CachedRequest<GetBalanceFunc>(this.api[environment.API].getBalance);

--- a/app/stores/base/WalletStore.js
+++ b/app/stores/base/WalletStore.js
@@ -56,8 +56,8 @@ function groupWallets(
  */
 export default class WalletStore extends Store {
 
-  WALLET_REFRESH_INTERVAL = environment.walletRefreshInterval;
-  ON_VISIBLE_DEBOUNCE_WAIT = 1000;
+  WALLET_REFRESH_INTERVAL: number = environment.walletRefreshInterval;
+  ON_VISIBLE_DEBOUNCE_WAIT: number = 1000;
 
   @observable publicDerivers: Array<PublicDeriverWithCachedMeta>;
   @observable selected: null | PublicDeriverWithCachedMeta;
@@ -352,7 +352,7 @@ export default class WalletStore extends Store {
     }
   };
 
-  _showAddWalletPageWhenNoWallets = () => {
+  _showAddWalletPageWhenNoWallets: void => void = () => {
     if (this.isWalletRoute && !this.hasAnyWallets) {
       this.actions.router.goToRoute.trigger({ route: ROUTES.WALLETS.ADD });
     }
@@ -363,7 +363,7 @@ export default class WalletStore extends Store {
       related to app urls and wallet status. Also, this behaviour is trigger by mobx reactions,
       so it's hard to reason about all the scenarios could happened.
   */
-  _updateActiveWalletOnRouteChanges = () => {
+  _updateActiveWalletOnRouteChanges: void => void = () => {
     const currentRoute = this.stores.app.currentRoute;
     const hasAnyPublicDeriver = this.hasAnyPublicDeriver;
     runInAction(`${nameof(WalletStore)}::${nameof(this._updateActiveWalletOnRouteChanges)}`, () => {

--- a/app/stores/toplevel/AppStore.js
+++ b/app/stores/toplevel/AppStore.js
@@ -16,17 +16,17 @@ export default class AppStore extends Store {
     return this.stores.router.location.pathname;
   }
 
-  _updateRouteLocation = (
-    options: { route: string, params: ?Object }
-  ): void => {
+  _updateRouteLocation: {| route: string, params: ?Object |} => void = (
+    options
+  ) => {
     const routePath = buildRoute(options.route, options.params);
     const currentRoute = this.stores.router.location.pathname;
     if (currentRoute !== routePath) this.stores.router.push(routePath);
   };
 
-  _setRouteLocationToTransactionsList = (
-    options: { params: ?Object }
-  ): void => {
+  _setRouteLocationToTransactionsList: {| params: ?Object |} => void = (
+    options
+  ) => {
     const routePath = buildRoute(ROUTES.WALLETS.TRANSACTIONS, options.params);
     const currentRoute = this.stores.router.location.pathname;
     if (currentRoute !== routePath) this.stores.router.push(routePath);

--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -119,9 +119,9 @@ export default class LoadingStore extends Store {
     this._originRoute = { route: '', location: '' };
   }
 
-  _isRefresh = (): boolean => this.isLoading;
+  _isRefresh: void => boolean = () => this.isLoading;
 
-  _redirectToLoading = (): void => {
+  _redirectToLoading: void => void = () => {
     // before redirecting, save origin route in case we need to come back to
     // it later (this is the case when user comes from a URI link)
     runInAction(() => {

--- a/app/stores/toplevel/NoticeBoardStore.js
+++ b/app/stores/toplevel/NoticeBoardStore.js
@@ -50,12 +50,12 @@ export default class NoticeBoardStore extends Store {
     await this._loadNew();
   }
 
-  _loadMore = async () => {
+  _loadMore: void => Promise<void> = async () => {
     this.searchOptions.limit += SEARCH_LIMIT_INCREASE;
     await this._loadNew();
   }
 
-  _loadNew = async (): Promise<void> => {
+  _loadNew: void => Promise<void> = async () => {
     try {
       this.setLoading(true);
 

--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -9,6 +9,7 @@ import { THEMES } from '../../themes';
 import type { Theme } from '../../themes';
 import { ROUTES } from '../../routes-config';
 import { LANGUAGES } from '../../i18n/translations';
+import type { LanguageType } from '../../i18n/translations';
 import type { ExplorerType } from '../../domain/Explorer';
 import type {
   GetSelectedExplorerFunc, SaveSelectedExplorerFunc,
@@ -19,7 +20,7 @@ import type {
 
 export default class ProfileStore extends Store {
 
-  LANGUAGE_OPTIONS = [
+  LANGUAGE_OPTIONS: Array<LanguageType> = [
     ...LANGUAGES,
     ...(!environment.isProduction()
       ? [
@@ -43,10 +44,10 @@ export default class ProfileStore extends Store {
 
   /** Linear list of steps that need to be completed before app start */
   @observable
-  SETUP_STEPS = [
+  SETUP_STEPS: Array<{| isDone: void => boolean, action: void => Promise<void> |}> = [
     {
       isDone: () => (this.isCurrentLocaleSet),
-      action: () => {
+      action: async () => {
         const route = ROUTES.PROFILE.LANGUAGE_SELECTION;
         if (this.stores.app.currentRoute === route) {
           return;
@@ -56,7 +57,7 @@ export default class ProfileStore extends Store {
     },
     {
       isDone: () => this.areTermsOfUseAccepted,
-      action: () => {
+      action: async () => {
         const route = ROUTES.PROFILE.TERMS_OF_USE;
         if (this.stores.app.currentRoute === route) {
           return;
@@ -70,7 +71,7 @@ export default class ProfileStore extends Store {
         !environment.userAgentInfo.canRegisterProtocol() ||
         this.isUriSchemeAccepted
       ),
-      action: () => {
+      action: async () => {
         const route = ROUTES.PROFILE.URI_PROMPT;
         if (this.stores.app.currentRoute === route) {
           return;
@@ -207,7 +208,7 @@ export default class ProfileStore extends Store {
     super.teardown();
   }
 
-  _setBigNumberFormat = () => {
+  _setBigNumberFormat: void => void = () => {
     BigNumber.config({ FORMAT: this.bigNumberDecimalFormat });
   };
 

--- a/app/stores/toplevel/TopbarStore.js
+++ b/app/stores/toplevel/TopbarStore.js
@@ -60,22 +60,22 @@ export default class TopbarStore extends Store {
     () => this.activeTopbarCategory && this.activeTopbarCategory === category.route
   ).get();
 
-  @action _onActivateTopbarCategory = (
-    params: { category: string, }
-  ): void => {
+  @action _onActivateTopbarCategory: {| category: string |} => void = (
+    params
+  ) => {
     const { category } = params;
     if (category !== this.activeTopbarCategory) {
       this.actions.router.goToRoute.trigger({ route: category });
     }
   };
 
-  @action _setActivateTopbarCategory = (
-    category: string
-  ): void => {
+  @action _setActivateTopbarCategory: string => void = (
+    category
+  ) => {
     this.activeTopbarCategory = category;
   };
 
-  _syncTopbarRouteWithRouter = (): void => {
+  _syncTopbarRouteWithRouter: void => void = () => {
     const route = this.stores.app.currentRoute;
     this.categories.forEach((category) => {
       // If the current route starts with the route of the category

--- a/app/stores/toplevel/UiDialogsStore.js
+++ b/app/stores/toplevel/UiDialogsStore.js
@@ -40,7 +40,7 @@ export default class UiDialogsStore extends Store {
     Math.max(countDownTo - this.secondsSinceActiveDialogIsOpen, 0)
   );
 
-  @action _onOpen = ({ dialog, params } : {| dialog : Function, params?: Object |}) => {
+  @action _onOpen: {| dialog : Function, params?: Object |} => void = ({ dialog, params }) => {
     this._reset();
     this.activeDialog = dialog;
     this.paramsForActiveDialog = params || {};
@@ -50,19 +50,19 @@ export default class UiDialogsStore extends Store {
     this._secondsTimerInterval = setInterval(this._updateSeconds, 1000);
   };
 
-  @action _onClose = () => {
+  @action _onClose: void => void = () => {
     this._reset();
   };
 
-  @action _updateSeconds = () => {
+  @action _updateSeconds: void => void = () => {
     this.secondsSinceActiveDialogIsOpen += 1;
   };
 
-  @action _onUpdateDataForActiveDialog = ({ data }: { [key: string]: any }) => {
+  @action _onUpdateDataForActiveDialog: { [key: string]: any } => void = ({ data }) => {
     Object.assign(this.dataForActiveDialog, data);
   };
 
-  @action _reset = () => {
+  @action _reset: void => void = () => {
     this.activeDialog = null;
     this.secondsSinceActiveDialogIsOpen = 0;
     this.dataForActiveDialog = {};

--- a/app/stores/toplevel/UiNotificationsStore.js
+++ b/app/stores/toplevel/UiNotificationsStore.js
@@ -37,11 +37,11 @@ export default class UiNotificationsStore extends Store {
     return notification;
   }
 
-  _findNotificationById = (id: string): ?Notification => (
+  _findNotificationById: string => ?Notification = (id) => (
     this.activeNotifications.find(notification => notification.id === id)
   );
 
-  @action _onOpen = ({ id, message, duration }: Notification) => {
+  @action _onOpen: Notification => void = ({ id, message, duration }) => {
     const notification: Notification = {
       id,
       message,
@@ -58,11 +58,11 @@ export default class UiNotificationsStore extends Store {
     }
   };
 
-  @action _set = (notification: Notification) => {
+  @action _set: Notification => void = (notification) => {
     this.activeNotifications.push(notification);
   };
 
-  @action _onClose = ({ id } : { id: string }) => {
+  @action _onClose: {| id: string |} => void = ({ id }) => {
     const notification = this._findNotificationById(id);
     if (notification) {
       if (notification.secondsTimerInterval) clearInterval(notification.secondsTimerInterval);
@@ -71,7 +71,7 @@ export default class UiNotificationsStore extends Store {
     }
   };
 
-  @action _updateSeconds = (id: string) => {
+  @action _updateSeconds: string => void = (id) => {
     const notification = this._findNotificationById(id);
     if (notification && notification.duration != null) {
       notification.duration -= 1;

--- a/app/stores/toplevel/WalletBackupStore.js
+++ b/app/stores/toplevel/WalletBackupStore.js
@@ -49,11 +49,11 @@ class WalletBackupStore extends Store {
     a.removeOneMnemonicWord.listen(this._removeOneWord);
   }
 
-  @action _initiateWalletBackup = (params: {
+  @action _initiateWalletBackup: {|
       recoveryPhrase: Array<string>,
       name: string,
       password: string,
-  }) => {
+  |} => void = (params) => {
     this.recoveryPhrase = params.recoveryPhrase;
     this.name = params.name;
     this.password = params.password;
@@ -83,37 +83,40 @@ class WalletBackupStore extends Store {
     });
   };
 
-  @action _continueToPrivacyWarning = () => {
+  @action _continueToPrivacyWarning: void => void = () => {
     this.currentStep = 'privacyWarning';
   };
 
-  @action _acceptPrivacyNoticeForWalletBackup = () => {
+  @action _acceptPrivacyNoticeForWalletBackup: void => void = () => {
     this.isPrivacyNoticeAccepted = true;
   };
 
-  @action _continueToRecoveryPhraseForWalletBackup = () => {
+  @action _continueToRecoveryPhraseForWalletBackup: void => void = () => {
     this.currentStep = 'recoveryPhraseDisplay';
   };
 
-  @action _startWalletBackup = () => {
+  @action _startWalletBackup: void => void = () => {
     this.currentStep = 'recoveryPhraseEntry';
   };
 
-  @action _addWordToWalletBackupVerification = (params: { word: string, index: number }) => {
+  @action _addWordToWalletBackupVerification: {|
+    word: string,
+    index: number
+  |} => void = (params) => {
     const { word, index } = params;
     this.enteredPhrase.push({ word, index });
     const pickedWord = this.recoveryPhraseSorted[index];
     if (pickedWord && pickedWord.word === word) pickedWord.isActive = false;
   };
 
-  @action _clearEnteredRecoveryPhrase = () => {
+  @action _clearEnteredRecoveryPhrase: void => void = () => {
     this.enteredPhrase = [];
     this.recoveryPhraseSorted = this.recoveryPhraseSorted.map(
       ({ word }) => ({ word, isActive: true })
     );
   };
 
-  @action _removeOneWord = () => {
+  @action _removeOneWord: void => void = () => {
     if (!this.enteredPhrase) {
       return;
     }
@@ -128,20 +131,20 @@ class WalletBackupStore extends Store {
     );
   }
 
-  @action _acceptWalletBackupTermDevice = () => {
+  @action _acceptWalletBackupTermDevice: void => void = () => {
     this.isTermDeviceAccepted = true;
   };
 
-  @action _acceptWalletBackupTermRecovery = () => {
+  @action _acceptWalletBackupTermRecovery: void => void = () => {
     this.isTermRecoveryAccepted = true;
   };
 
-  @action _restartWalletBackup = () => {
+  @action _restartWalletBackup: void => void = () => {
     this._clearEnteredRecoveryPhrase();
     this.currentStep = 'recoveryPhraseDisplay';
   };
 
-  @action _cancelWalletBackup = () => {
+  @action _cancelWalletBackup: void => void = () => {
     this.teardown();
   };
 
@@ -151,7 +154,7 @@ class WalletBackupStore extends Store {
   }
 
   @action
-  _reset = () => {
+  _reset: void => void = () => {
     this.inProgress = false;
     this.name = '';
     this.password = '';


### PR DESCRIPTION
As I've mentioned before, when declaring member variables function types, you need to specify the type of left-hand side and not the right-hand side otherwise Flow fails to resolve the type when calling it cross-module.

I cleaned up a lot of these in the past but left some folders as TODOs since there were too big to bother at the time. Since I've fixed a lot of them just by refactoring stuff over the months, the stores folder was now cleaned up enough to do the rest in one PR.