### PR TITLE
Add balance wallet support in Shelley

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -1358,10 +1358,10 @@ export default class AdaApi {
       const reverseAddressLookup = new Map<number, Array<string>>();
       const foundAddresses = new Set<string>();
 
-      const isShelley = request.transferSource === TransferSource.SHELLEY_UTXO ||
+      const sourceIsShelleyWallet = request.transferSource === TransferSource.SHELLEY_UTXO ||
         request.transferSource === TransferSource.SHELLEY_CHIMERIC_ACCOUNT;
       const accountKey = rootPk
-        .derive(isShelley
+        .derive(sourceIsShelleyWallet
           ? WalletTypePurpose.CIP1852
           : WalletTypePurpose.BIP44)
         .derive(CoinTypes.CARDANO)
@@ -1389,7 +1389,7 @@ export default class AdaApi {
           checkAddressesInUse,
           addByHash,
         });
-      } else if (isShelley) {
+      } else if (sourceIsShelleyWallet) {
         const stakingKey = accountKey
           .derive(ChainDerivations.CHIMERIC_ACCOUNT)
           .derive(STAKING_KEY_INDEX)

--- a/app/components/topbar/NavWalletDetails.js
+++ b/app/components/topbar/NavWalletDetails.js
@@ -17,7 +17,7 @@ type Props = {|
     +shouldHideBalance: boolean,
     +highlightTitle?: boolean,
     /**
-      * undefined => wallet doesn't is not a reward wallet
+      * undefined => wallet is not a reward wallet
       * null => still calculating
       * value => done calculating
     */

--- a/app/components/topbar/SideBarCategory.js
+++ b/app/components/topbar/SideBarCategory.js
@@ -9,7 +9,7 @@ import styles from './SideBarCategory.scss';
 type Props = {|
   +icon: string,
   +active: boolean,
-  +onClick: Function,
+  +onClick: void => void,
   +showLabel?: boolean,
   +label: ?MessageDescriptor,
 |};

--- a/app/components/topbar/TopBarCategory.scss
+++ b/app/components/topbar/TopBarCategory.scss
@@ -110,7 +110,7 @@
       margin-left: 14px;
     }
 
-    &.daedalus-transfer {
+    &.wallet-transfer {
       right: 86px;
       width: 72px;
     }

--- a/app/components/wallet/layouts/WalletWithNavigation.js
+++ b/app/components/wallet/layouts/WalletWithNavigation.js
@@ -4,9 +4,11 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import WalletNavigation from '../navigation/WalletNavigation';
 import styles from './WalletWithNavigation.scss';
+import { PublicDeriver } from '../../../api/ada/lib/storage/models/PublicDeriver';
 
 type Props = {|
   +children?: Node,
+  +wallet: PublicDeriver<>,
   +isActiveScreen: (string, ?boolean) => boolean,
   +onWalletNavItemClick: string => void,
 |};
@@ -23,6 +25,7 @@ export default class WalletWithNavigation extends Component<Props> {
       <div className={styles.component}>
         <div className={styles.navigation}>
           <WalletNavigation
+            wallet={this.props.wallet}
             isActiveNavItem={isActiveScreen}
             onNavItemClick={onWalletNavItemClick}
           />

--- a/app/components/wallet/my-wallets/WalletDetails.js
+++ b/app/components/wallet/my-wallets/WalletDetails.js
@@ -15,7 +15,7 @@ type Props = {|
     +onUpdateHideBalance: void => void,
     +shouldHideBalance: boolean,
     /**
-      * undefined => wallet doesn't is not a reward wallet
+      * undefined => wallet is not a reward wallet
       * null => still calculating
       * value => done calculating
     */

--- a/app/config/topbarConfig.js
+++ b/app/config/topbarConfig.js
@@ -64,16 +64,12 @@ export const BACK_TO_MY_WALLETS: Category = {
   inlineText: globalMessages.goBack
 };
 
-export const CURRENCY_SPECIFIC_CATEGORIES = {
-  ada: [
-    {
-      name: 'DAEDALUS_TRANSFER',
-      className: 'daedalus-transfer',
-      route: ROUTES.TRANSFER.ROOT,
-      icon: transferIcon,
-      label: globalMessages.sidebarTransfer
-    }
-  ]
+export const TRANSFER_PAGE: Category = {
+  name: 'WALLET_TRANSFER',
+  className: 'wallet-transfer',
+  route: ROUTES.TRANSFER.ROOT,
+  icon: transferIcon,
+  label: globalMessages.sidebarTransfer
 };
 
 export const SETTINGS: Category = {

--- a/app/containers/wallet/Wallet.js
+++ b/app/containers/wallet/Wallet.js
@@ -109,6 +109,7 @@ export default class Wallet extends Component<Props> {
         showAsCard
       >
         <WalletWithNavigation
+          wallet={wallets.selected.self}
           isActiveScreen={this.isActiveScreen}
           onWalletNavItemClick={this.handleWalletNavItemClick}
         >

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -84,12 +84,15 @@ export default class WalletReceivePage extends Component<Props, State> {
     const addressTypeStore = this.getTypeStore(publicDeriver);
 
     if (!addressTypeStore.getRequest(publicDeriver.self).wasExecuted || !addressTypeStore.hasAny) {
+      console.log(addressTypeStore);
+      console.log(addressTypeStore.getRequest(publicDeriver.self));
       return (
         <VerticallyCenteredLayout>
           <LoadingSpinner />
         </VerticallyCenteredLayout>
       );
     }
+    console.log('2');
 
     // get info about the latest address generated for special rendering
     const lastAddress = addressTypeStore.last;

--- a/app/stores/ada/DelegationStore.js
+++ b/app/stores/ada/DelegationStore.js
@@ -259,7 +259,9 @@ export default class DelegationStore extends Store {
         }
         const selected = this.stores.wallets.selected;
         if (selected == null) return;
-        await this.refreshDelegation(selected);
+        if (asGetStakingKey(selected.self) != null) {
+          await this.refreshDelegation(selected);
+        }
       },
     );
   }

--- a/app/stores/ada/YoroiTransferStore.js
+++ b/app/stores/ada/YoroiTransferStore.js
@@ -195,13 +195,13 @@ export default class YoroiTransferStore extends Store {
 
     updateStatusCallback();
 
-    const isShelley = this.transferSource === TransferSource.SHELLEY_UTXO ||
+    const sourceIsShelleyWallet = this.transferSource === TransferSource.SHELLEY_UTXO ||
       this.transferSource === TransferSource.SHELLEY_CHIMERIC_ACCOUNT;
 
     // 3) Calculate private keys for restored wallet utxo
     const accountKey = RustModule.WalletV3.Bip32PrivateKey
       .from_bytes(Buffer.from(masterKey, 'hex'))
-      .derive(isShelley
+      .derive(sourceIsShelleyWallet
         ? WalletTypePurpose.CIP1852
         : WalletTypePurpose.BIP44)
       .derive(CoinTypes.CARDANO)
@@ -217,7 +217,7 @@ export default class YoroiTransferStore extends Store {
         this.stores.substores.ada.stateFetchStore.fetcher.getUTXOsForAddresses,
     };
 
-    const transferTx = isShelley
+    const transferTx = sourceIsShelleyWallet
       ? await generateCip1852TransferTx(baseRequest)
       : await generateLegacyYoroiTransferTx({
         ...baseRequest,

--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -104,6 +104,7 @@ export default class LoadingStore extends Store {
       const uriParams = await getURIParameters(
         decodeURIComponent(this._originRoute.location),
         address => {
+          // TODO: validation should be done based on wallet type
           const addressKind = tryAddressToKind(address, 'bech32');
           const valid = environment.isShelley()
             ? addressKind != null && addressKind !== CoreAddressTypes.CARDANO_LEGACY

--- a/app/stores/toplevel/TopbarStore.js
+++ b/app/stores/toplevel/TopbarStore.js
@@ -11,7 +11,7 @@ import {
   BACK_TO_ADD,
   BACK_TO_MY_WALLETS,
   WALLETS,
-  CURRENCY_SPECIFIC_CATEGORIES,
+  TRANSFER_PAGE,
   SETTINGS,
   NOTICE_BOARD,
 } from '../../config/topbarConfig';
@@ -19,6 +19,7 @@ import {
   isTrezorTWallet,
   isLedgerNanoWallet,
 } from '../../api/ada/lib/storage/models/ConceptualWallet/index';
+import { Bip44Wallet } from '../../api/ada/lib/storage/models/Bip44Wallet/wrapper';
 
 export default class TopbarStore extends Store {
 
@@ -60,13 +61,17 @@ export default class TopbarStore extends Store {
       isTrezorT = isTrezorTWallet(conceptualWallet);
       isNano = isLedgerNanoWallet(conceptualWallet);
     }
+    const canTransfer = selected != null &&
+      // recall: legacy bip44 wallets can't receive in Shelley era
+      (!environment.isShelley() || !(selected.self.getParent() instanceof Bip44Wallet));
+
 
     return [
       this._genTopCategory(),
       ...(isTrezorT ? [WITH_TREZOR_T] : []),
       ...(isNano ? [WITH_LEDGER_NANO] : []),
       SETTINGS,
-      ...CURRENCY_SPECIFIC_CATEGORIES[environment.API],
+      ...(canTransfer ? [TRANSFER_PAGE] : []),
       ...(environment.isTest() ? [NOTICE_BOARD] : []), // Temporarily Hide
     ];
   }

--- a/app/stores/toplevel/WalletStore.js
+++ b/app/stores/toplevel/WalletStore.js
@@ -25,7 +25,8 @@ import {
 } from '../../api/ada/lib/storage/models/PublicDeriver/index';
 import {
   asGetSigningKey,
-  asGetPublicKey
+  asGetPublicKey,
+  asGetStakingKey,
 } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
 import type {
   IGetLastSyncInfoResponse,
@@ -344,7 +345,7 @@ export default class WalletStore extends Store {
     stores.addresses.addObservedWallet(publicDeriver);
     stores.transactions.addObservedWallet(publicDeriver);
     stores.time.addObservedTime(publicDeriver);
-    if (environment.isShelley()) {
+    if (asGetStakingKey(publicDeriver.self) != null) {
       stores.delegation.addObservedWallet(publicDeriver);
     }
   };


### PR DESCRIPTION
When Shelley mainnet is released, users will still have bip44 ("balance wallets") wallets in storage until they upgrade to a Shelley reward wallet (similar to how Daedalus does it now). That means we need to support balance wallets in Shelley mode

**Notable points**:
1) "Transfer wallet" is disabled when you have a balance wallet selected (it can't receive ADA)
2) "Send" page is disabled when you have a balance wallet selected (can't generate change address)

![image](https://user-images.githubusercontent.com/2608559/75191980-bb75ec80-5796-11ea-849c-e6cd7ef03b75.png)
