### PR TITLE
Move an non dialog spinners inside dialog

### DIFF
--- a/app/components/profile/terms-of-use/TermsOfUseForm.js
+++ b/app/components/profile/terms-of-use/TermsOfUseForm.js
@@ -69,7 +69,7 @@ export default class TermsOfUseForm extends Component<Props, State> {
             <Checkbox
               label={intl.formatMessage(messages[checkboxLabel])}
               onChange={this.toggleAcceptance.bind(this)}
-              checked={areTermsOfUseAccepted}
+              checked={areTermsOfUseAccepted || this.props.isSubmitting}
               skin={CheckboxSkin}
             />
 
@@ -77,7 +77,7 @@ export default class TermsOfUseForm extends Component<Props, State> {
               className={buttonClasses}
               label={intl.formatMessage(globalMessages.continue)}
               onMouseUp={this.props.onSubmit}
-              disabled={!areTermsOfUseAccepted}
+              disabled={!areTermsOfUseAccepted || this.props.isSubmitting}
               skin={ButtonSkin}
             />
           </div>

--- a/app/components/wallet/settings/ResyncBlock.js
+++ b/app/components/wallet/settings/ResyncBlock.js
@@ -7,7 +7,7 @@ import { observer } from 'mobx-react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 
-const messages = defineMessages({
+export const messages = defineMessages({
   titleLabel: {
     id: 'wallet.settings.resync.label',
     defaultMessage: '!!!Resync wallet with the blockchain',
@@ -23,8 +23,7 @@ const messages = defineMessages({
 });
 
 type Props = {|
-  isSubmitting: boolean,
-  onResync: void => PossiblyAsync<void>,
+  openDialog: void => void,
 |};
 
 @observer
@@ -38,7 +37,7 @@ export default class ResyncBlock extends Component<Props> {
 
     const buttonClassNames = classNames([
       'primary',
-      this.props.isSubmitting ? styles.submitButtonSpinning : styles.submitButton,
+      styles.submitButton,
       'resyncButton' // classname for UI tests
     ]);
     return (
@@ -53,8 +52,7 @@ export default class ResyncBlock extends Component<Props> {
           className={buttonClassNames}
           label={this.context.intl.formatMessage(messages.resyncButtonlabel)}
           skin={ButtonSkin}
-          onClick={this.props.onResync}
-          disabled={this.props.isSubmitting}
+          onClick={this.props.openDialog}
         />
       </div>
     );

--- a/app/components/wallet/settings/ResyncBlock.scss
+++ b/app/components/wallet/settings/ResyncBlock.scss
@@ -24,12 +24,7 @@
     margin-bottom: 10px;
   }  
 
-  .submitButton,
-  .submitButtonSpinning {
+  .submitButton {
     margin-top: 20px;
-  }
-
-  .submitButtonSpinning {
-    @include loading-spinner("../../../assets/images/spinner-light.svg");
   }
 }

--- a/app/components/wallet/staking/dashboard/StakePool.js
+++ b/app/components/wallet/staking/dashboard/StakePool.js
@@ -93,7 +93,6 @@ type Props = {|
    * since the UX in this case is not obvious (undelegate from one pool or all pools)
   */
   +undelegate: void | (void => Promise<void>),
-  +isUndelegating: boolean,
   +reputationInfo: ReputationObject,
   +openReputationDialog: void => void,
 |};
@@ -230,7 +229,6 @@ export default class StakePool extends Component<Props> {
     ]);
     const undelegateButtonClasses = classnames([
       'secondary',
-      this.props.isUndelegating ? styles.submitButtonSpinning : null,
     ]);
     return (
       <>
@@ -256,7 +254,6 @@ export default class StakePool extends Component<Props> {
               className={undelegateButtonClasses}
               skin={ButtonSkin}
               onClick={this.props.undelegate}
-              disabled={this.props.isUndelegating}
             />
           </>
         }

--- a/app/components/wallet/staking/dashboard/StakePool.scss
+++ b/app/components/wallet/staking/dashboard/StakePool.scss
@@ -1,5 +1,3 @@
-@import '../../../../themes/mixins/loading-spinner';
-
 .wrapper {
     display: block;
     padding: 20px 24px;
@@ -7,10 +5,6 @@
 
     button {
         width: 100%;
-    }
-
-    .submitButtonSpinning {
-        @include loading-spinner("../../../../assets/images/spinner-dark.svg");
     }
 }
 

--- a/app/components/wallet/staking/dashboard/UndelegateDialog.js
+++ b/app/components/wallet/staking/dashboard/UndelegateDialog.js
@@ -16,6 +16,7 @@ import DialogCloseButton from '../../../widgets/DialogCloseButton';
 import globalMessages from '../../../../i18n/global-messages';
 import LocalizableError from '../../../../i18n/LocalizableError';
 import styles from './UndelegateDialog.scss';
+import AnnotatedLoader from '../../../transfer/AnnotatedLoader';
 import config from '../../../../config';
 
 import {
@@ -43,6 +44,7 @@ type Props = {|
   +onSubmit: ({| password: string |}) => PossiblyAsync<void>,
   +classicTheme: boolean,
   +error: ?LocalizableError,
+  +generatingTx: boolean,
 |};
 
 @observer
@@ -94,6 +96,22 @@ export default class UndelegateDialog extends Component<Props> {
   render() {
     const { form } = this;
     const { intl } = this.context;
+
+    if (this.props.generatingTx) {
+      return (
+        <Dialog
+          title={intl.formatMessage(globalMessages.processingLabel)}
+          closeOnOverlayClick={false}
+          className={styles.dialog}
+        >
+          <AnnotatedLoader
+            title={intl.formatMessage(globalMessages.processingLabel)}
+            details={intl.formatMessage(globalMessages.txGeneration)}
+          />
+        </Dialog>
+      );
+    }
+
     const walletPasswordField = form.$('walletPassword');
 
     const staleTxWarning = (

--- a/app/components/widgets/DangerousActionDialog.js
+++ b/app/components/widgets/DangerousActionDialog.js
@@ -1,50 +1,36 @@
 // @flow
 import React, { Component } from 'react';
-import { action, observable } from 'mobx';
+import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
-import { defineMessages, intlShape } from 'react-intl';
-import DialogCloseButton from '../../widgets/DialogCloseButton';
-import Dialog from '../../widgets/Dialog';
-import globalMessages from '../../../i18n/global-messages';
-import LocalizableError from '../../../i18n/LocalizableError';
+import { intlShape } from 'react-intl';
+import DialogCloseButton from './DialogCloseButton';
+import Dialog from './Dialog';
+import globalMessages from '../../i18n/global-messages';
+import LocalizableError from '../../i18n/LocalizableError';
 import { Checkbox } from 'react-polymorph/lib/components/Checkbox';
 import { CheckboxSkin } from 'react-polymorph/lib/skins/simple/CheckboxSkin';
-import styles from './RemoveWalletDialog.scss';
-import dangerousButtonStyles from '../../../themes/overrides/DangerousButton.scss';
-import { messages } from './RemoveWallet';
-
-const dialogMessages = defineMessages({
-  warning2: {
-    id: 'wallet.settings.delete.warning2',
-    defaultMessage: '!!!Please double-check you still have the means to restore access to this wallet. If you cannot, removing the wallet may result in irreversible loss of funds.',
-  },
-  accept: {
-    id: 'wallet.settings.delete.accept',
-    defaultMessage: '!!!I still have the means to restore this wallet',
-  },
-});
+import styles from './DangerousActionDialog.scss';
+import dangerousButtonStyles from '../../themes/overrides/DangerousButton.scss';
 
 type Props = {|
+  +title: string,
+  +checkboxAcknowledge: string,
+  +buttonLabel: string,
   +onSubmit: void => PossiblyAsync<void>,
   +isSubmitting: boolean,
   +onCancel: void => void,
+  +isChecked: boolean,
+  +toggleCheck: void => void,
   +error: ?LocalizableError,
+  +children: Node,
 |};
 
 @observer
-export default class RemoveWalletDialog extends Component<Props> {
+export default class DangerousActionDialog extends Component<Props> {
   static contextTypes = {
     intl: intlShape.isRequired,
   };
-
-  @observable isChecked: boolean = false;
-
-  @action
-  toggleCheck: void => void = () => {
-    if (this.props.isSubmitting) return;
-    this.isChecked = !this.isChecked;
-  }
 
   render() {
     const { intl } = this.context;
@@ -70,11 +56,11 @@ export default class RemoveWalletDialog extends Component<Props> {
         disabled: this.props.isSubmitting,
       },
       {
-        label: intl.formatMessage(globalMessages.remove),
+        label: this.props.buttonLabel,
         onClick: this.props.onSubmit,
         primary: true,
         className: confirmButtonClasses,
-        disabled: !this.isChecked ? true : undefined,
+        disabled: !this.props.isChecked ? true : undefined,
         themeOverrides: dangerousButtonStyles,
         isSubmitting: this.props.isSubmitting
       },
@@ -82,7 +68,7 @@ export default class RemoveWalletDialog extends Component<Props> {
 
     return (
       <Dialog
-        title={intl.formatMessage(messages.titleLabel)}
+        title={this.props.title}
         actions={actions}
         closeOnOverlayClick={false}
         onClose={onCancel}
@@ -90,14 +76,13 @@ export default class RemoveWalletDialog extends Component<Props> {
         closeButton={<DialogCloseButton onClose={onCancel} />}
       >
 
-        <p>{intl.formatMessage(messages.removeExplanation)}</p>
-        <p>{intl.formatMessage(dialogMessages.warning2)}</p>
+        {this.props.children}
 
         <div className={styles.checkbox}>
           <Checkbox
-            label={intl.formatMessage(dialogMessages.accept)}
-            onChange={this.toggleCheck}
-            checked={this.props.isSubmitting || this.isChecked}
+            label={this.props.checkboxAcknowledge}
+            onChange={this.props.toggleCheck}
+            checked={this.props.isSubmitting || this.props.isChecked}
             skin={CheckboxSkin}
           />
         </div>

--- a/app/components/widgets/DangerousActionDialog.scss
+++ b/app/components/widgets/DangerousActionDialog.scss
@@ -1,5 +1,5 @@
-@import '../../../themes/mixins/loading-spinner';
-@import '../../../themes/mixins/error-message';
+@import '../../themes/mixins/loading-spinner';
+@import '../../themes/mixins/error-message';
 
 .dialog {
   font-family: var(--font-light);
@@ -32,5 +32,5 @@
 }
 
 .isSubmitting {
-  @include loading-spinner("../../../assets/images/spinner-light.svg");
+  @include loading-spinner("../../assets/images/spinner-light.svg");
 }

--- a/app/containers/settings/categories/RemoveWalletDialogContainer.js
+++ b/app/containers/settings/categories/RemoveWalletDialogContainer.js
@@ -1,0 +1,105 @@
+// @flow
+import React, { Component } from 'react';
+import { computed, action, observable } from 'mobx';
+import { observer } from 'mobx-react';
+import { defineMessages, intlShape } from 'react-intl';
+import globalMessages from '../../../i18n/global-messages';
+import { messages } from '../../../components/wallet/settings/RemoveWallet';
+import { PublicDeriver } from '../../../api/ada/lib/storage/models/PublicDeriver/index';
+
+import type { InjectedOrGenerated } from '../../../types/injectedPropsType';
+
+import DangerousActionDialog from '../../../components/widgets/DangerousActionDialog';
+
+export type GeneratedData = typeof RemoveWalletDialogContainer.prototype.generated;
+
+type Props = {|
+  ...InjectedOrGenerated<GeneratedData>,
+  publicDeriver: void | PublicDeriver<>,
+|};
+
+const dialogMessages = defineMessages({
+  warning2: {
+    id: 'wallet.settings.delete.warning2',
+    defaultMessage: '!!!Please double-check you still have the means to restore access to this wallet. If you cannot, removing the wallet may result in irreversible loss of funds.',
+  },
+  accept: {
+    id: 'wallet.settings.delete.accept',
+    defaultMessage: '!!!I still have the means to restore this wallet',
+  },
+});
+
+@observer
+export default class RemoveWalletDialogContainer extends Component<Props> {
+  static contextTypes = {
+    intl: intlShape.isRequired,
+  };
+
+  componentWillUnmount() {
+    this.generated.stores.walletSettings.removeWalletRequest.reset();
+  }
+
+  @observable isChecked: boolean = false;
+
+  @action
+  toggleCheck: void => void = () => {
+    if (this.generated.stores.walletSettings.removeWalletRequest.isExecuting) return;
+    this.isChecked = !this.isChecked;
+  }
+
+  render() {
+    const { intl } = this.context;
+    const settingsStore = this.generated.stores.walletSettings;
+    const settingsActions = this.generated.actions.walletSettings;
+
+    return (
+      <DangerousActionDialog
+        title={intl.formatMessage(messages.titleLabel)}
+        checkboxAcknowledge={intl.formatMessage(dialogMessages.accept)}
+        buttonLabel={intl.formatMessage(globalMessages.remove)}
+        isChecked={this.isChecked}
+        toggleCheck={this.toggleCheck}
+        onSubmit={() => this.props.publicDeriver && settingsActions.removeWallet.trigger({
+          publicDeriver: this.props.publicDeriver,
+        })}
+        isSubmitting={settingsStore.removeWalletRequest.isExecuting}
+        onCancel={this.generated.actions.dialogs.closeActiveDialog.trigger}
+        error={settingsStore.removeWalletRequest.error}
+      >
+        <p>{intl.formatMessage(messages.removeExplanation)}</p>
+        <p>{intl.formatMessage(dialogMessages.warning2)}</p>
+      </DangerousActionDialog>
+    );
+  }
+
+  @computed get generated() {
+    if (this.props.generated !== undefined) {
+      return this.props.generated;
+    }
+    if (this.props.stores == null || this.props.actions == null) {
+      throw new Error(`${nameof(RemoveWalletDialogContainer)} no way to generated props`);
+    }
+    const { actions, stores } = this.props;
+    const settingActions = actions.ada.walletSettings;
+    const settingStore = stores.substores.ada.walletSettings;
+    return Object.freeze({
+      stores: {
+        walletSettings: {
+          removeWalletRequest: {
+            reset: settingStore.removeWalletRequest.reset,
+            isExecuting: settingStore.removeWalletRequest.isExecuting,
+            error: settingStore.removeWalletRequest.error,
+          },
+        },
+      },
+      actions: {
+        walletSettings: {
+          removeWallet: { trigger: settingActions.removeWallet.trigger },
+        },
+        dialogs: {
+          closeActiveDialog: { trigger: actions.dialogs.closeActiveDialog.trigger },
+        },
+      },
+    });
+  }
+}

--- a/app/containers/settings/categories/ResyncWalletDialogContainer.js
+++ b/app/containers/settings/categories/ResyncWalletDialogContainer.js
@@ -1,0 +1,103 @@
+// @flow
+import React, { Component } from 'react';
+import { computed, action, observable } from 'mobx';
+import { observer } from 'mobx-react';
+import { defineMessages, intlShape } from 'react-intl';
+import globalMessages from '../../../i18n/global-messages';
+import { messages } from '../../../components/wallet/settings/ResyncBlock';
+import { PublicDeriver } from '../../../api/ada/lib/storage/models/PublicDeriver/index';
+
+import type { InjectedOrGenerated } from '../../../types/injectedPropsType';
+
+import DangerousActionDialog from '../../../components/widgets/DangerousActionDialog';
+
+export type GeneratedData = typeof ResyncWalletDialogContainer.prototype.generated;
+
+type Props = {|
+  ...InjectedOrGenerated<GeneratedData>,
+  publicDeriver: PublicDeriver<>,
+|};
+
+const dialogMessages = defineMessages({
+  warning: {
+    id: 'wallet.settings.resync.warning',
+    defaultMessage: '!!!This will also cause failed transactions to disappear as they are not stored on the blockchain.',
+  },
+});
+
+@observer
+export default class ResyncWalletDialogContainer extends Component<Props> {
+  static contextTypes = {
+    intl: intlShape.isRequired,
+  };
+
+  componentWillUnmount() {
+    this.generated.stores.walletSettings.clearHistory.reset();
+  }
+
+  @observable isChecked: boolean = false;
+
+  @action
+  toggleCheck: void => void = () => {
+    if (this.generated.stores.walletSettings.clearHistory.isExecuting) return;
+    this.isChecked = !this.isChecked;
+  }
+
+  render() {
+    const { intl } = this.context;
+    const settingsStore = this.generated.stores.walletSettings;
+
+    return (
+      <DangerousActionDialog
+        title={intl.formatMessage(messages.titleLabel)}
+        checkboxAcknowledge={intl.formatMessage(globalMessages.uriLandingDialogConfirmLabel)}
+        buttonLabel={intl.formatMessage(messages.resyncButtonlabel)}
+        isChecked={this.isChecked}
+        toggleCheck={this.toggleCheck}
+        onSubmit={async () => {
+          await this.generated.actions.walletSettings.resyncHistory.trigger({
+            publicDeriver: this.props.publicDeriver,
+          });
+          this.generated.actions.dialogs.closeActiveDialog.trigger();
+        }}
+        isSubmitting={settingsStore.clearHistory.isExecuting}
+        onCancel={this.generated.actions.dialogs.closeActiveDialog.trigger}
+        error={settingsStore.clearHistory.error}
+      >
+        <p>{intl.formatMessage(messages.resyncExplanation)}</p>
+        <p>{intl.formatMessage(dialogMessages.warning)}</p>
+      </DangerousActionDialog>
+    );
+  }
+
+  @computed get generated() {
+    if (this.props.generated !== undefined) {
+      return this.props.generated;
+    }
+    if (this.props.stores == null || this.props.actions == null) {
+      throw new Error(`${nameof(ResyncWalletDialogContainer)} no way to generated props`);
+    }
+    const { actions, stores } = this.props;
+    const settingActions = actions.ada.walletSettings;
+    const settingStore = stores.substores.ada.walletSettings;
+    return Object.freeze({
+      stores: {
+        walletSettings: {
+          clearHistory: {
+            reset: settingStore.clearHistory.reset,
+            isExecuting: settingStore.clearHistory.isExecuting,
+            error: settingStore.clearHistory.error,
+          },
+        },
+      },
+      actions: {
+        walletSettings: {
+          resyncHistory: { trigger: settingActions.resyncHistory.trigger },
+        },
+        dialogs: {
+          closeActiveDialog: { trigger: actions.dialogs.closeActiveDialog.trigger },
+        },
+      },
+    });
+  }
+}

--- a/app/containers/settings/categories/WalletSettingsPage.stories.js
+++ b/app/containers/settings/categories/WalletSettingsPage.stories.js
@@ -12,7 +12,8 @@ import {
 } from '../../../../stories/helpers/StoryWrapper';
 import { IncorrectWalletPasswordError } from '../../../api/common';
 import ChangeWalletPasswordDialogContainer from '../../wallet/dialogs/ChangeWalletPasswordDialogContainer';
-import RemoveWalletDialog from '../../../components/wallet/settings/RemoveWalletDialog';
+import RemoveWalletDialogContainer from './RemoveWalletDialogContainer';
+import ResyncWalletDialogContainer from './ResyncWalletDialogContainer';
 import { wrapSettings } from '../../../Routes';
 import { mockSettingsProps } from '../Settings.mock';
 import { ROUTES } from '../../../routes-config';
@@ -41,15 +42,6 @@ const defaultSettingsPageProps: {|
     },
     walletSettings: {
       getConceptualWalletSettingsCache: request.getConceptualWalletSettingsCache,
-      removeWalletRequest: {
-        reset: action('removeWalletRequest reset'),
-        isExecuting: false,
-        error: undefined,
-      },
-      clearHistory: {
-        reset: action('clearHistory reset'),
-        isExecuting: false,
-      },
       renameModelRequest: {
         error: undefined,
         isExecuting: false,
@@ -73,12 +65,9 @@ const defaultSettingsPageProps: {|
       stopEditingWalletField: { trigger: action('stopEditingWalletField') },
       cancelEditingWalletField: { trigger: action('cancelEditingWalletField') },
       renameConceptualWallet: { trigger: async (req) => action('renameConceptualWallet')(req) },
-      resyncHistory: { trigger: async (req) => action('resyncHistory')(req) },
-      removeWallet: { trigger: async (req) => action('removeWallet')(req) },
     },
     dialogs: {
       open: { trigger: action('open') },
-      closeActiveDialog: { trigger: action('closeActiveDialog') },
     },
   },
 });
@@ -122,6 +111,8 @@ export const EditName = () => {
             },
             // dialog is close so no need to give props
             ChangeWalletPasswordDialogContainerProps: (null: any),
+            RemoveWalletDialogContainerProps: (null: any),
+            ResyncWalletDialogContainerProps: (null: any),
           }}
         />
       );
@@ -173,6 +164,8 @@ export const PasswordUpdateTime = () => {
               },
               // dialog is close so no need to give props
               ChangeWalletPasswordDialogContainerProps: (null: any),
+              RemoveWalletDialogContainerProps: (null: any),
+              ResyncWalletDialogContainerProps: (null: any),
             }}
           />
         );
@@ -202,16 +195,35 @@ export const ResyncWallet = () => {
             ...settingPageProps,
             stores: {
               ...settingPageProps.stores,
-              walletSettings: {
-                ...settingPageProps.stores.walletSettings,
-                clearHistory: {
-                  ...settingPageProps.stores.walletSettings.clearHistory,
-                  isExecuting: true,
-                },
+              uiDialogs: {
+                ...settingPageProps.stores.uiDialogs,
+                isOpen: (clazz) => clazz === ResyncWalletDialogContainer,
               },
             },
             // dialog is close so no need to give props
             ChangeWalletPasswordDialogContainerProps: (null: any),
+            RemoveWalletDialogContainerProps: (null: any),
+            ResyncWalletDialogContainerProps: {
+              generated: {
+                stores: {
+                  walletSettings: {
+                    clearHistory: {
+                      reset: action('clearHistory reset'),
+                      isExecuting: boolean('isExecuting', false),
+                      error: undefined,
+                    },
+                  }
+                },
+                actions: {
+                  walletSettings: {
+                    resyncHistory: { trigger: async (req) => action('resyncHistory')(req) },
+                  },
+                  dialogs: {
+                    closeActiveDialog: { trigger: action('closeActiveDialog') },
+                  },
+                },
+              },
+            },
           }}
         />
       );
@@ -219,9 +231,7 @@ export const ResyncWallet = () => {
   );
 };
 
-const defaultChangeWalletPasswordDialogContainerProps: {|
-  selected: null | PublicDeriver<>,
-|} => * = (request) => ({
+const defaultChangeWalletPasswordDialogContainerProps: void => * = (_request) => ({
   stores: {
     walletSettings: {
       changeSigningKeyRequest: {
@@ -232,9 +242,6 @@ const defaultChangeWalletPasswordDialogContainerProps: {|
     },
     profile: {
       isClassicTheme: globalKnobs.currentTheme() === THEMES.YOROI_CLASSIC,
-    },
-    wallets: {
-      selected: request.selected,
     },
     uiDialogs: {
       dataForActiveDialog: {
@@ -270,9 +277,7 @@ export const EditPassword = () => {
         getConceptualWalletSettingsCache: lookup.getConceptualWalletSettingsCache,
         getSigningKeyCache: lookup.getSigningKeyCache,
       });
-      const defaultProps = defaultChangeWalletPasswordDialogContainerProps({
-        selected: wallet.publicDeriver,
-      });
+      const defaultProps = defaultChangeWalletPasswordDialogContainerProps();
       const errorCases = {
         None: undefined,
         WrongPassword: new IncorrectWalletPasswordError(),
@@ -355,6 +360,8 @@ export const EditPassword = () => {
                 },
               },
             },
+            RemoveWalletDialogContainerProps: (null: any),
+            ResyncWalletDialogContainerProps: (null: any),
           }}
         />
       );
@@ -377,9 +384,6 @@ export const RemoveWallet = () => {
         getConceptualWalletSettingsCache: lookup.getConceptualWalletSettingsCache,
         getSigningKeyCache: lookup.getSigningKeyCache,
       });
-      const defaultProps = defaultChangeWalletPasswordDialogContainerProps({
-        selected: wallet.publicDeriver,
-      });
       return (
         <WalletSettingsPage
           generated={{
@@ -388,21 +392,32 @@ export const RemoveWallet = () => {
               ...settingPageProps.stores,
               uiDialogs: {
                 ...settingPageProps.stores.uiDialogs,
-                isOpen: (clazz) => clazz === RemoveWalletDialog,
+                isOpen: (clazz) => clazz === RemoveWalletDialogContainer,
               },
-              walletSettings: {
-                ...settingPageProps.stores.walletSettings,
-                removeWalletRequest: {
-                  ...settingPageProps.stores.walletSettings.removeWalletRequest,
-                  isExecuting: boolean('isExecuting', false),
+            },
+            ChangeWalletPasswordDialogContainerProps: (null: any),
+            RemoveWalletDialogContainerProps: {
+              generated: {
+                stores: {
+                  walletSettings: {
+                    removeWalletRequest: {
+                      reset: action('removeWalletRequest reset'),
+                      error: undefined,
+                      isExecuting: boolean('isExecuting', false),
+                    },
+                  },
+                },
+                actions: {
+                  walletSettings: {
+                    removeWallet: { trigger: async (req) => action('removeWallet')(req) },
+                  },
+                  dialogs: {
+                    closeActiveDialog: { trigger: action('closeActiveDialog') },
+                  },
                 },
               },
             },
-            ChangeWalletPasswordDialogContainerProps: {
-              generated: {
-                ...defaultProps,
-              },
-            },
+            ResyncWalletDialogContainerProps: (null: any),
           }}
         />
       );

--- a/app/containers/wallet/dialogs/ChangeWalletPasswordDialogContainer.js
+++ b/app/containers/wallet/dialogs/ChangeWalletPasswordDialogContainer.js
@@ -4,12 +4,17 @@ import { observer } from 'mobx-react';
 import { computed } from 'mobx';
 import ChangeWalletPasswordDialog from '../../../components/wallet/settings/ChangeWalletPasswordDialog';
 import type { InjectedOrGenerated } from '../../../types/injectedPropsType';
+import { PublicDeriver } from '../../../api/ada/lib/storage/models/PublicDeriver/index';
 
 export type GeneratedData = typeof ChangeWalletPasswordDialogContainer.prototype.generated;
 
+type Props = {|
+  ...InjectedOrGenerated<GeneratedData>,
+  publicDeriver: PublicDeriver<>,
+|};
+
 @observer
-export default class ChangeWalletPasswordDialogContainer
-  extends Component<InjectedOrGenerated<GeneratedData>> {
+export default class ChangeWalletPasswordDialogContainer extends Component<Props> {
 
   render() {
     const { actions } = this.generated;
@@ -17,10 +22,7 @@ export default class ChangeWalletPasswordDialogContainer
     const { walletSettings } = this.generated.stores;
     const dialogData = uiDialogs.dataForActiveDialog;
     const { updateDataForActiveDialog } = actions.dialogs;
-    const publicDeriver = this.generated.stores.wallets.selected;
     const { changeSigningKeyRequest } = walletSettings;
-
-    if (!publicDeriver) throw new Error('Active wallet required for ChangeWalletPasswordDialogContainer.');
 
     return (
       <ChangeWalletPasswordDialog
@@ -28,7 +30,7 @@ export default class ChangeWalletPasswordDialogContainer
         onSave={async (values) => {
           const { oldPassword, newPassword } = values;
           await actions.walletSettings.updateSigningPassword.trigger({
-            publicDeriver,
+            publicDeriver: this.props.publicDeriver,
             oldPassword,
             newPassword
           });
@@ -71,9 +73,6 @@ export default class ChangeWalletPasswordDialogContainer
         },
         profile: {
           isClassicTheme: stores.profile.isClassicTheme,
-        },
-        wallets: {
-          selected: stores.wallets.selected,
         },
         uiDialogs: {
           dataForActiveDialog: {

--- a/app/containers/wallet/staking/SeizaFetcher.js
+++ b/app/containers/wallet/staking/SeizaFetcher.js
@@ -141,8 +141,6 @@ export default class SeizaFetcher extends Component<Props> {
           <Dialog
             title={intl.formatMessage(globalMessages.processingLabel)}
             closeOnOverlayClick={false}
-            onClose={this.cancel}
-            closeButton={<DialogCloseButton onClose={this.cancel} />}
           >
             <AnnotatedLoader
               title={intl.formatMessage(globalMessages.processingLabel)}

--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -218,6 +218,12 @@ export default class StakingDashboardPage extends Component<Props> {
           .trigger({ password: request.password, publicDeriver, });
         cancel();
       }}
+      generatingTx={
+        this.generated.stores.substores[environment.API]
+          .delegationTransaction
+          .createDelegationTx
+          .isExecuting
+      }
       isSubmitting={delegationTxStore.signAndBroadcastDelegationTx.isExecuting}
       transactionFee={getShelleyTxFee(delegationTx.unsignedTx.IOs, true)}
       staleTx={delegationTxStore.isStale}
@@ -491,12 +497,6 @@ export default class StakingDashboardPage extends Component<Props> {
                   this.generated.actions.dialogs.open.trigger({ dialog: UndelegateDialog });
                 }
                 : undefined
-            }
-            isUndelegating={
-              this.generated.stores.substores[environment.API]
-                .delegationTransaction
-                .createDelegationTx
-                .isExecuting
             }
             reputationInfo={poolReputation[pool[0]] ?? {}}
             openReputationDialog={() => this.generated.actions.dialogs.open.trigger({

--- a/app/containers/wallet/staking/StakingDashboardPage.stories.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.stories.js
@@ -793,7 +793,7 @@ export const UndelegateExecuting = () => {
       generated={genBaseProps({
         wallet,
         lookup,
-        openDialog: undefined,
+        openDialog: UndelegateDialog,
         delegationTransaction: {
           isStale: false,
           createDelegationTx: {
@@ -827,7 +827,7 @@ export const UndelegateError = () => {
       generated={genBaseProps({
         wallet,
         lookup,
-        openDialog: undefined,
+        openDialog: UndelegateDialog,
         delegationTransaction: {
           isStale: false,
           createDelegationTx: {

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -528,6 +528,7 @@
   "wallet.settings.resync.buttonLabel": "Resync wallet",
   "wallet.settings.resync.explanation": "If you are experiencing issues with your wallet, or think you have an incorrect balance or transaction history, you can delete the local data stored by Yoroi and resync with the blockchain.",
   "wallet.settings.resync.label": "Resync wallet with the blockchain",
+  "wallet.settings.resync.warning": "This will also cause failed transactions to disappear as they are not stored on the blockchain.",
   "wallet.settings.unchangedPassword": "Password unchanged since wallet creation",
   "wallet.staking.pool.unknownLabel": "Unknown pool",
   "wallet.staking.warning.pendingTx": "You cannot change your delegation preference while a transaction is pending",

--- a/features/step_definitions/settings-ui-steps.js
+++ b/features/step_definitions/settings-ui-steps.js
@@ -119,7 +119,7 @@ When(/^I click on remove wallet$/, async function () {
 });
 
 Then(/^I click on the checkbox$/, async function () {
-  await this.click('.RemoveWalletDialog_checkbox .SimpleCheckbox_root');
+  await this.click('.DangerousActionDialog_checkbox > .SimpleCheckbox_root');
 });
 
 

--- a/stories/helpers/StoryWrapper.js
+++ b/stories/helpers/StoryWrapper.js
@@ -292,7 +292,7 @@ function genDummyWallet(): PublicDeriver<> {
     null,
     0,
   );
-  const clazz = GetSigningKey(GetPublicKey(HasLevels(HasSign(PublicDeriver))));
+  const clazz = GetPublicKey(HasLevels(HasSign(PublicDeriver)));
   const self = new clazz({
     publicDeriverId: publicDeriverCounter++,
     parent,


### PR DESCRIPTION
We want to block the user from switching wallets while an action is on-going and the easiest way to do that is by blocking the screen with a dialog.

# Resync wallet

Previously
![image](https://user-images.githubusercontent.com/2608559/76977362-8d8c5e00-6978-11ea-828d-88c926115949.png)

Now
![image](https://user-images.githubusercontent.com/2608559/76977239-66359100-6978-11ea-927e-6ff307af5b7a.png)

# Undelegate button

Previously
![image](https://user-images.githubusercontent.com/2608559/76977390-98df8980-6978-11ea-8550-87a01715961d.png)

Now
![image](https://user-images.githubusercontent.com/2608559/76976746-be1fc800-6977-11ea-8099-742f9699667b.png)

