### PR TITLE
Fix some issues related to tx state switching 

### DIFF
--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -165,7 +165,7 @@ export default class Transaction extends Component<Props, State> {
     isExpanded: false
   };
 
-  toggleDetails() {
+  toggleDetails: void => void = () => {
     this.setState(prevState => ({ isExpanded: !prevState.isExpanded }));
   }
 
@@ -355,7 +355,7 @@ export default class Transaction extends Component<Props, State> {
               </h2>
               {uniq(data.addresses.from).map(address => (
                 <ExplorableHashContainer
-                  key={`${data.id}-from-${address}`}
+                  key={`${data.txid}-from-${address}`}
                   selectedExplorer={this.props.selectedExplorer}
                   hash={addressToDisplayString(address)}
                   light
@@ -372,7 +372,7 @@ export default class Transaction extends Component<Props, State> {
               {data.addresses.to.map((address, addressIndex) => (
                 <ExplorableHashContainer
                   // eslint-disable-next-line react/no-array-index-key
-                  key={`${data.id}-to-${address}-${addressIndex}`}
+                  key={`${data.txid}-to-${address}-${addressIndex}`}
                   selectedExplorer={this.props.selectedExplorer}
                   hash={addressToDisplayString(address)}
                   light
@@ -398,12 +398,12 @@ export default class Transaction extends Component<Props, State> {
               <h2>{intl.formatMessage(globalMessages.transactionId)}</h2>
               <ExplorableHashContainer
                 selectedExplorer={this.props.selectedExplorer}
-                hash={data.id}
+                hash={data.txid}
                 light
                 linkType="transaction"
               >
                 <span className={classnames([styles.rowData, styles.hash])}>
-                  {data.id}
+                  {data.txid}
                 </span>
               </ExplorableHashContainer>
             </div>

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -31,7 +31,6 @@ type Props = {|
   +hasMoreToLoad: boolean,
   +selectedExplorer: ExplorerType,
   +assuranceMode: AssuranceMode,
-  +walletId: string,
   +onLoadMore: void => PossiblyAsync<void>,
   +shouldHideBalance: boolean,
 |};
@@ -92,7 +91,7 @@ export default class WalletTransactionsList extends Component<Props> {
   getTransactionKey(transactions: Array<WalletTransaction>): string {
     if (transactions.length) {
       const firstTransaction = transactions[0];
-      return firstTransaction.id + '-' + firstTransaction.type;
+      return firstTransaction.uniqueKey;
     }
     // this branch should not happen
     Logger.error(
@@ -108,7 +107,6 @@ export default class WalletTransactionsList extends Component<Props> {
       isLoadingTransactions,
       hasMoreToLoad,
       assuranceMode,
-      walletId,
       onLoadMore,
     } = this.props;
 
@@ -128,7 +126,7 @@ export default class WalletTransactionsList extends Component<Props> {
     return (
       <div className={styles.component}>
         {transactionsGroups.map(group => (
-          <div className={styles.group} key={walletId + '-' + this.getTransactionKey(group.transactions)}>
+          <div className={styles.group} key={`${this.getTransactionKey(group.transactions)}`}>
             <div className={styles.bar}>
               <OneSideBarDecoration>
                 <div className={styles.groupDate}>{this.localizedDate(group.date)}</div>
@@ -137,7 +135,7 @@ export default class WalletTransactionsList extends Component<Props> {
             <div className={styles.list}>
               {group.transactions.map((transaction, transactionIndex) => (
                 <Transaction
-                  key={`${walletId}-${transaction.id}-${transaction.type}`}
+                  key={`${transaction.uniqueKey}-${transaction.numberOfConfirmations}`}
                   selectedExplorer={this.props.selectedExplorer}
                   data={transaction}
                   isLastInList={transactionIndex === group.transactions.length - 1}

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -78,7 +78,6 @@ export default class WalletSummaryPage extends Component<InjectedOrGenerated<Gen
             hasMoreToLoad={totalAvailable > limit}
             onLoadMore={() => actions.ada.transactions.loadMoreTransactions.trigger(publicDeriver)}
             assuranceMode={assuranceMode}
-            walletId={publicDeriver.getPublicDeriverId().toString()}
             shouldHideBalance={profile.shouldHideBalance}
           />
         );
@@ -107,7 +106,13 @@ export default class WalletSummaryPage extends Component<InjectedOrGenerated<Gen
         <WalletSummary
           numberOfTransactions={totalAvailable}
           pendingAmount={unconfirmedAmount}
-          isLoadingTransactions={isLoadingTx}
+          isLoadingTransactions={
+            /**
+             * only use first load
+             * to avoid wallet summary disappearing when wallet tx list is updating
+            */
+            !recentTransactionsRequest.wasExecuted
+          }
           openExportTxToFileDialog={this.openExportTransactionDialog}
         />
 

--- a/app/containers/wallet/WalletSummaryPage.stories.js
+++ b/app/containers/wallet/WalletSummaryPage.stories.js
@@ -226,6 +226,7 @@ export const Transaction = () => {
     };
   const walletTransaction = new WalletTransaction({
     txid: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
+    blockHash: '111111865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
     type: select(
       'txDirection',
       transactionTypes,
@@ -309,6 +310,7 @@ export const ManyTransactions = () => {
   for (let i = 0; i < INITIAL_SEARCH_LIMIT + 1; i++) {
     transactions.push(new WalletTransaction({
       txid: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
+      blockHash: '111111865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
       type: transactionTypes.EXPEND,
       amount: new BigNumber(1000),
       fee: new BigNumber(5),
@@ -354,6 +356,7 @@ export const TxHistoryExport = () => {
 
   const transactions = [new WalletTransaction({
     txid: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
+    blockHash: '111111865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
     type: transactionTypes.EXPEND,
     amount: new BigNumber(1000),
     fee: new BigNumber(5),

--- a/app/containers/wallet/WalletSummaryPage.stories.js
+++ b/app/containers/wallet/WalletSummaryPage.stories.js
@@ -225,7 +225,7 @@ export const Transaction = () => {
       },
     };
   const walletTransaction = new WalletTransaction({
-    id: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
+    txid: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
     type: select(
       'txDirection',
       transactionTypes,
@@ -308,7 +308,7 @@ export const ManyTransactions = () => {
   const transactions = [];
   for (let i = 0; i < INITIAL_SEARCH_LIMIT + 1; i++) {
     transactions.push(new WalletTransaction({
-      id: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
+      txid: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
       type: transactionTypes.EXPEND,
       amount: new BigNumber(1000),
       fee: new BigNumber(5),
@@ -353,7 +353,7 @@ export const TxHistoryExport = () => {
   const lookup = walletLookup([wallet]);
 
   const transactions = [new WalletTransaction({
-    id: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
+    txid: '915f2e6865fb31cc93410efb6c0e580ca74862374b3da461e20135c01f312e7c',
     type: transactionTypes.EXPEND,
     amount: new BigNumber(1000),
     fee: new BigNumber(5),

--- a/app/containers/wallet/staking/SeizaFetcher.js
+++ b/app/containers/wallet/staking/SeizaFetcher.js
@@ -130,7 +130,7 @@ export default class SeizaFetcher extends Component<Props> {
 
     const showSignDialog = delegationTxStore.signAndBroadcastDelegationTx.isExecuting ||
       !delegationTxStore.signAndBroadcastDelegationTx.wasExecuted ||
-      delegationTxStore.signAndBroadcastDelegationTx.error;
+      delegationTxStore.signAndBroadcastDelegationTx.error != null;
 
     return (
       <>
@@ -245,8 +245,8 @@ export default class SeizaFetcher extends Component<Props> {
               },
               signAndBroadcastDelegationTx: {
                 error: delegationTxStore.signAndBroadcastDelegationTx.error,
-                isExecuting: delegationTxStore.createDelegationTx.isExecuting,
-                wasExecuted: delegationTxStore.createDelegationTx.wasExecuted,
+                isExecuting: delegationTxStore.signAndBroadcastDelegationTx.isExecuting,
+                wasExecuted: delegationTxStore.signAndBroadcastDelegationTx.wasExecuted,
               },
             },
           },

--- a/app/containers/wallet/staking/StakingPage.js
+++ b/app/containers/wallet/staking/StakingPage.js
@@ -42,6 +42,10 @@ export default class StakingPage extends Component<Props> {
     intl: intlShape.isRequired,
   };
 
+  componentWillUnmount() {
+    this.generated.actions.ada.delegationTransaction.reset.trigger();
+  }
+
   getBrowserReplacement(): string {
     // 1) handle Yoroi running as an extension
 
@@ -169,6 +173,15 @@ export default class StakingPage extends Component<Props> {
                 wasExecuted:
                   adaStores.delegationTransaction.signAndBroadcastDelegationTx.wasExecuted,
               },
+            },
+          },
+        },
+      },
+      actions: {
+        ada: {
+          delegationTransaction: {
+            reset: {
+              trigger: actions.ada.delegationTransaction.reset.trigger,
             },
           },
         },

--- a/app/containers/wallet/staking/StakingPage.stories.js
+++ b/app/containers/wallet/staking/StakingPage.stories.js
@@ -82,6 +82,13 @@ const genBaseProps: {|
         },
       },
     },
+    actions: {
+      ada: {
+        delegationTransaction: {
+          reset: { trigger: action('reset'), },
+        },
+      },
+    },
     SeizaFetcherProps: {
       generated: {
         stores: {

--- a/app/stores/ada/AdaTransactionBuilderStore.js
+++ b/app/stores/ada/AdaTransactionBuilderStore.js
@@ -147,10 +147,8 @@ export default class AdaTransactionBuilderStore extends Store {
       toJS(this.plannedTxInfo),
       this.shouldSendAll,
       this.stores.wallets.selected,
-      // num tx sync changed => valid inputs may have changed
-      this.stores.substores.ada.transactions.totalAvailable,
-      // need to recalculate when there are no more pending transactions
-      this.stores.substores.ada.transactions.hasAnyPending,
+      // update if tx history changes
+      this.stores.substores.ada.transactions.hash,
     ],
     async () => this._updateTxBuilder(),
   )

--- a/app/stores/ada/AdaTransactionsStore.js
+++ b/app/stores/ada/AdaTransactionsStore.js
@@ -157,6 +157,9 @@ export function calculateUnconfirmedAmount(
   };
 
   for (const transaction of transactions) {
+    // skip any failed transactions
+    if (transaction.state < 0) continue;
+
     const assuranceForTx = transaction.getAssuranceLevelForMode(assuranceMode);
     if (assuranceForTx !== assuranceLevels.HIGH) {
       // total

--- a/app/stores/ada/DelegationStore.js
+++ b/app/stores/ada/DelegationStore.js
@@ -243,10 +243,8 @@ export default class DelegationStore extends Store {
     this._recalculateDelegationInfoDisposer = reaction(
       () => [
         this.stores.wallets.selected,
-        // num tx sync changed => valid inputs may have changed
-        this.stores.substores.ada.transactions.totalAvailable,
-        // need to recalculate when there are no more pending transactions
-        this.stores.substores.ada.transactions.hasAnyPending,
+        // update if tx history changes
+        this.stores.substores.ada.transactions.hash,
         // if query failed due to server issue, need to re-query when it comes back online
         this.stores.substores.ada.serverConnectionStore.checkAdaServerStatus,
         // reward grows every epoch so we have to refresh

--- a/app/stores/ada/DelegationTransactionStore.js
+++ b/app/stores/ada/DelegationTransactionStore.js
@@ -38,10 +38,8 @@ export default class DelegationTransactionStore extends Store {
   _updateTxBuilderReaction = reaction(
     () => [
       this.stores.wallets.selected,
-      // num tx sync changed => valid inputs may have changed
-      this.stores.substores.ada.transactions.totalAvailable,
-      // need to recalculate when there are no more pending transactions
-      this.stores.substores.ada.transactions.hasAnyPending,
+      // update if tx history changes
+      this.stores.substores.ada.transactions.hash,
     ],
     () => {
       if (this.createDelegationTx.wasExecuted) {

--- a/app/stores/base/TransactionsStore.js
+++ b/app/stores/base/TransactionsStore.js
@@ -113,7 +113,6 @@ export default class TransactionsStore extends Store {
     for (const tx of result.transactions) {
       hash = digetForHash(hash.toString(16) + tx.uniqueKey, seed);
     }
-    console.log(hash);
     return hash;
   }
 

--- a/app/stores/lib/CachedRequest.js
+++ b/app/stores/lib/CachedRequest.js
@@ -74,7 +74,6 @@ export default class CachedRequest<
           setTimeout(action(() => {
             this.error = error;
             this.isExecuting = false;
-            this.isError = true;
             this.wasExecuted = true;
             this._isWaitingForResponse = false;
             reject(error);

--- a/app/stores/lib/Request.js
+++ b/app/stores/lib/Request.js
@@ -26,7 +26,6 @@ export default class Request<Func: (...args: any) => Promise<any>, Err> {
   @observable result: ?PromisslessReturnType<Func> = null;
   @observable error: ?Err = null;
   @observable isExecuting: boolean = false;
-  @observable isError: boolean = false;
   @observable wasExecuted: boolean = false;
 
   currentlyExecuting: Set<number> = new Set();
@@ -75,7 +74,6 @@ export default class Request<Func: (...args: any) => Promise<any>, Err> {
             this.isExecuting = false;
             this.wasExecuted = true;
             this.error = null;
-            this.isError = false;
             this._isWaitingForResponse = false;
             resolve(result);
           }), 1);
@@ -92,7 +90,6 @@ export default class Request<Func: (...args: any) => Promise<any>, Err> {
             this.error = error;
             this.result = null;
             this.isExecuting = false;
-            this.isError = true;
             this.wasExecuted = true;
             this._isWaitingForResponse = false;
             reject(error);
@@ -160,7 +157,6 @@ export default class Request<Func: (...args: any) => Promise<any>, Err> {
   @action reset(): void {
     this.result = null;
     this.error = null;
-    this.isError = false;
     this.isExecuting = false;
     this.wasExecuted = false;
     this._isWaitingForResponse = false;


### PR DESCRIPTION
Fixes:

- tx history page and delegation dashboard now properly refresh if one of your transactions switches states
- Summary at the top of the tx history pages no longer flashes briefly when backend tx history requests are made
- "Success" message now properly shows and redirects to dashboard when making a delegation transaction from Seiza