### PR TITLE
Tooltips cut out in the ui

### DIFF
--- a/app/components/wallet/WalletAdd.scss
+++ b/app/components/wallet/WalletAdd.scss
@@ -1,5 +1,7 @@
 @import './add/card-mixin.scss';
 
+$linebreakWidth: 1540px;
+
 .component {
   height: 100%;
   overflow: auto;
@@ -12,7 +14,7 @@
     display: flex;
     align-items: center;
   
-    @media screen and (max-width: 1300px) {
+    @media screen and (max-width: $linebreakWidth) {
       max-width: 992px;
     }
   }
@@ -24,7 +26,7 @@
     justify-content: space-between;
     width: 100%;
   
-    @media screen and (max-width: 1300px) {
+    @media screen and (max-width: $linebreakWidth) {
       flex-direction: column;
       padding: 0 15px;
     }
@@ -52,7 +54,7 @@
     font-size: 22px;
     line-height: 27px;
   
-    @media screen and (max-width: 1300px) {
+    @media screen and (max-width: 1530px) {
       margin-bottom: 30px;
     }
   }
@@ -126,7 +128,7 @@
     background-repeat: no-repeat;
     background-position: center -13vw;
 
-    @media screen and (max-width: 1400px) {
+    @media screen and (max-width: $linebreakWidth) {
       background-position: 0 0;
     }
 

--- a/app/components/wallet/add/AddAnotherWallet.js
+++ b/app/components/wallet/add/AddAnotherWallet.js
@@ -1,11 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
+import classnames from 'classnames';
 
 import MainCards from './MainCards';
 import LogoYoroiIcon from '../../../assets/images/yoroi-logo-white.inline.svg';
-import LogoYoroiShelleyTestnetIcon from '../../../assets/images/yoroi-logo-shelley-testnet-white.inline.svg';
-import NightlyLogo from '../../../assets/images/yoroi-logo-nightly-white.inline.svg';
+import LogoYoroiShelleyTestnetIcon from '../../../assets/images/yoroi-logotestnet-gradient.inline.svg';
+import NightlyLogo from '../../../assets/images/yoroi-logo-nightly.inline.svg';
 
 import styles from './AddAnotherWallet.scss';
 
@@ -33,12 +34,16 @@ export default class AddAnotherWallet extends Component<Props> {
   render() {
     const LogoIcon = this.getLogo();
 
+    const iconClass = classnames(
+      styles.heroLogo,
+      LogoIcon === LogoYoroiIcon ? styles.makeBlue : null,
+    );
     return (
       <div className={styles.component}>
         <div className={styles.hero}>
           <div className={styles.heroInner}>
             {/* Left block  */}
-            <div className={styles.heroLogo}>
+            <div className={iconClass}>
               <LogoIcon width="400" height="128" />
             </div>
             {/* Right block  */}

--- a/app/components/wallet/add/AddAnotherWallet.scss
+++ b/app/components/wallet/add/AddAnotherWallet.scss
@@ -20,10 +20,8 @@
     justify-content: space-between;
     width: 100%;
   
-    @media screen and (max-width: 1300px) {
-      flex-direction: column;
-      align-items: center;
-    }
+    flex-direction: column;
+    align-items: center;
   }
   
   .heroLogo {
@@ -31,11 +29,12 @@
     position: relative;
     top: 50%;
     margin: auto auto;
+    margin-bottom: 24px;
+  }
+
+  .makeBlue {
     path {
       fill: var(--cmn-color-black);
-    }
-    @media screen and (max-width: 1300px) {
-      margin-bottom: 24px;
     }
   }
 }

--- a/app/containers/wallet/staking/StakingDashboardPage.stories.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.stories.js
@@ -195,7 +195,10 @@ const genBaseProps: {|
           substores: {
             ada: {
               wallets: {
-                sendMoneyRequest: request.transactionBuilderStore == null || (request.transactionBuilderStore.tentativeTx == null)
+                sendMoneyRequest: (
+                  request.transactionBuilderStore == null
+                  || request.transactionBuilderStore.tentativeTx == null
+                )
                   ? {
                     reset: action('reset'),
                     error: undefined,


### PR DESCRIPTION
Three different locations had tooltips that were being cutoff due to screen size

- add another wallet page for "restore wallet" case
- add first wallet page for "restore wallet" case
- add first wallet page for "daedalus" case

![image](https://user-images.githubusercontent.com/2608559/77361367-7c858780-6d92-11ea-9e72-aa1b3b82e158.png)

I fixed this by making the line warp-around more aggressively to make sure there is always room for the tooltip.
