### PR TITLE
fix scroll on pages with banners

### DIFF
--- a/app/components/layout/TopBarLayout.js
+++ b/app/components/layout/TopBarLayout.js
@@ -35,13 +35,8 @@ export default class TopBarLayout extends Component<Props> {
   render() {
     const {
       banner,
-      topbar,
-      navbar,
       sidebar,
-      children,
-      notification,
       showInContainer,
-      showAsCard
     } = this.props;
 
     const componentClasses = classnames([
@@ -57,19 +52,6 @@ export default class TopBarLayout extends Component<Props> {
       </div>
     );
 
-    const topbarComponent = (
-      <div className={styles.topbar}>
-        {topbar}
-      </div>
-    );
-
-    const navbarComponent = (
-      <div className={styles.navbar}>
-        {navbar}
-      </div>
-    );
-
-
     return (
       <div className={componentClasses}>
         <div className={styles.windowWrapper}>
@@ -83,34 +65,75 @@ export default class TopBarLayout extends Component<Props> {
             }
           >
             {banner}
-            <div
-              className={
-                classnames([
-                  styles.content,
-                  showInContainer !== null && showInContainer === true && styles.containerContent
-                ])
-              }
-            >
-              {topbar != null ? topbarComponent : null}
-              {navbar != null ? navbarComponent : null}
-              {notification}
-              <div
-                className={
-                  classnames([
-                    styles.inner,
-                    showInContainer !== null && showInContainer === true && styles.containerInner,
-                    showAsCard !== null && showAsCard === true && styles.containerCard
-                  ])
-                }
-              >
-                <div className={styles.content}>
-                  {children}
-                </div>
-              </div>
-            </div>
+            {this.getContentUnderBanner()}
           </div>
         </div>
       </div>
     );
+  }
+
+  optionallyWrapInContainer: Node => Node = (content) => {
+    const { showInContainer } = this.props;
+    if (showInContainer === true) {
+      return (
+        <div
+          className={
+            classnames([
+              styles.content,
+              showInContainer !== null && showInContainer === true && styles.containerContent
+            ])
+          }
+        >
+          {content}
+        </div>
+      );
+    }
+    return content;
+  }
+
+  getContentUnderBanner: void => Node = () => {
+    const {
+      topbar,
+      navbar,
+      children,
+      notification,
+      showInContainer,
+      showAsCard
+    } = this.props;
+
+    const topbarComponent = (
+      <div className={styles.topbar}>
+        {topbar}
+      </div>
+    );
+
+    const navbarComponent = (
+      <div className={styles.navbar}>
+        {navbar}
+      </div>
+    );
+
+    const content = (
+      <>
+        {topbar != null ? topbarComponent : null}
+        {navbar != null ? navbarComponent : null}
+        {notification}
+        <div
+          className={
+            classnames([
+              styles.inner,
+              showInContainer !== null && showInContainer === true && styles.containerInner,
+              showAsCard !== null && showAsCard === true && styles.containerCard
+            ])
+          }
+        >
+          <div className={styles.content}>
+            {children}
+          </div>
+        </div>
+      </>
+    );
+
+    return this.optionallyWrapInContainer(content);
   }
 }

--- a/app/components/layout/TopBarLayout.scss
+++ b/app/components/layout/TopBarLayout.scss
@@ -40,6 +40,7 @@
 .inner {
   height: 100%;
   position: relative;
+  overflow: auto;
   &::-webkit-scrollbar-button {
     height: 7px;
     display: block;

--- a/app/components/profile/nightly/NightlyForm.scss
+++ b/app/components/profile/nightly/NightlyForm.scss
@@ -11,8 +11,8 @@
   }
 
   .logo {
-    margin-top: 110px;
-    margin-bottom: 68px;
+    margin-top: 40px;
+    margin-bottom: 40px;
     & > svg {
       display: block;
       margin: auto;

--- a/app/containers/MainLayout.js
+++ b/app/containers/MainLayout.js
@@ -40,7 +40,7 @@ export default class MainLayout extends Component<MainLayoutProps> {
         topbar={this.props.topbar}
         sidebar={this.props.sidebar}
         navbar={this.props.navbar}
-        notification={<div />}
+        notification={undefined}
         showInContainer={this.props.showInContainer}
         showAsCard={this.props.showAsCard}
       >


### PR DESCRIPTION
All pages that had a banner at the top were missing a scrollbar. This usually doesn't affect the user but it was notable in the Yoroi Nightly page because it had a huge amount of whitespace.

This PR does two things:

1) Adds a scrollbar
2) Makes the whitespace in the Yoroi Nightly page much smaller so it fits in a 1366x768 display without a scrollbar

![image](https://user-images.githubusercontent.com/2608559/77368085-dd1ac180-6d9e-11ea-809b-d0c6f0891fa2.png)
