### PR TITLE
Put contents of transfer wallet flow inside

### DIFF
--- a/app/components/transfer/BaseTransferPage.js
+++ b/app/components/transfer/BaseTransferPage.js
@@ -3,11 +3,10 @@ import React, { Component } from 'react';
 import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
-import { Button } from 'react-polymorph/lib/components/Button';
-import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import { intlShape } from 'react-intl';
-import BorderedBox from '../widgets/BorderedBox';
 import globalMessages from '../../i18n/global-messages';
+import DialogBackButton from '../widgets/DialogBackButton';
+import Dialog from '../widgets/Dialog';
 import styles from './BaseTransferPage.scss';
 
 type Props = {|
@@ -32,62 +31,45 @@ export default class BaseTransferPage extends Component<Props> {
       step0,
     } = this.props;
 
-    const nextButtonClasses = classnames([
-      'proceedTransferButtonClasses',
-      'primary',
-      styles.button,
-    ]);
-    const backButtonClasses = classnames([
-      'backTransferButtonClasses',
-      'secondary',
-      styles.button,
-    ]);
+    const actions = [
+      {
+        label: intl.formatMessage(globalMessages.backButtonLabel),
+        onClick: onBack,
+        className: classnames(['backTransferButtonClasses']),
+      },
+      {
+        label: intl.formatMessage(globalMessages.nextButtonLabel),
+        onClick: this.props.onSubmit,
+        primary: true,
+        className: classnames(['proceedTransferButtonClasses']),
+        disabled: this.props.isDisabled,
+      },
+    ];
 
     return (
-      <div className={styles.component}>
-        <BorderedBox>
-
+      <Dialog
+        title={intl.formatMessage(globalMessages.instructionTitle)}
+        actions={actions}
+        closeOnOverlayClick={false}
+        onClose={onBack}
+        className={styles.dialog}
+        backButton={<DialogBackButton onBack={onBack} />}
+      >
+        <div className={styles.component}>
           <div className={styles.body}>
-
-            { /* Instructions for how to transfer */ }
             <div>
-              <div className={styles.title}>
-                {intl.formatMessage(globalMessages.instructionTitle)}
-              </div>
-
               <ul className={styles.instructionsList}>
                 <div className={styles.text}>
                   {step0}
-                  &nbsp;
+                  <br /><br />
                   {intl.formatMessage(globalMessages.step1)}
                 </div>
               </ul>
             </div>
-
             {this.props.children}
-
-            <div className={styles.buttonsWrapper}>
-              <Button
-                className={nextButtonClasses}
-                label={intl.formatMessage(globalMessages.nextButtonLabel)}
-                onClick={this.props.onSubmit}
-                skin={ButtonSkin}
-                disabled={this.props.isDisabled}
-              />
-
-              <Button
-                className={backButtonClasses}
-                label={intl.formatMessage(globalMessages.backButtonLabel)}
-                onClick={onBack}
-                skin={ButtonSkin}
-              />
-            </div>
-
           </div>
-
-        </BorderedBox>
-
-      </div>
+        </div>
+      </Dialog>
     );
   }
 }

--- a/app/components/transfer/BaseTransferPage.scss
+++ b/app/components/transfer/BaseTransferPage.scss
@@ -1,24 +1,10 @@
-@import '../../themes/mixins/loading-spinner';
-
 .component {
-
-  .button {
-    display: block !important;
-    margin: 20px auto 0;
-  }
   
   .body {
     color: var(--theme-bordered-box-text-color);
     font-family: var(--font-regular);
     font-size: 14px;
     line-height: 19px;
-  
-    .title {
-      line-height: 1.38;
-      margin-bottom: 4px;
-      font-size: 18px;
-      font-family: var(--font-semibold);
-    }
   
     .text {
       font-size: 15px;
@@ -29,31 +15,19 @@
     .instructionsList {
       list-style-type: disc;
       list-style-position: inside;
-      margin-bottom: 20px;
-    }
-  
-    .buttonsWrapper {
-      display: flex;
-      flex-direction: row-reverse;
-      justify-content: center;
-    }
-  
-    .submitWithPasswordButton {
-      &.spinning {
-        @include loading-spinner("../../assets/images/spinner-light.svg");
-      }
+      margin-bottom: 10px;
     }
   }
 }
 
-:global(.YoroiClassic) .component {
-  .button {
-    margin: 0 auto 0;
-  }
-}
-
-:global(.YoroiModern) .component {
+:global(.YoroiModern) {
   .inputWrapper span[class*='selectedWordBox'] {
     background-color: var(--rp-autocomplete-selected-word-box-bg-color-secondary);
+  }
+
+  .dialog {
+    :global(.Dialog_actions) {
+      margin-top: 0px;
+    }
   }
 }

--- a/app/components/transfer/ErrorPage.js
+++ b/app/components/transfer/ErrorPage.js
@@ -1,11 +1,11 @@
 // @flow
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
-import classnames from 'classnames';
 import { intlShape } from 'react-intl';
-import { Button } from 'react-polymorph/lib/components/Button';
-import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import LocalizableError from '../../i18n/LocalizableError';
+import Dialog from '../widgets/Dialog';
+import DialogCloseButton from '../widgets/DialogCloseButton';
+import globalMessages from '../../i18n/global-messages';
 import styles from './ErrorPage.scss';
 
 type Props = {|
@@ -29,36 +29,35 @@ export default class ErrorPage extends Component<Props> {
   render() {
     const { intl } = this.context;
     const { error, onCancel, title, backButtonLabel, } = this.props;
-    const backButtonClasses = classnames([
-      'secondary',
-      styles.button,
-    ]);
+
+    const actions = [
+      {
+        label: backButtonLabel,
+        onClick: onCancel,
+      },
+    ];
 
     return (
-      <div className={styles.component}>
+      <Dialog
+        title={intl.formatMessage(globalMessages.errorLabel)}
+        actions={actions}
+        closeOnOverlayClick={false}
+        closeButton={<DialogCloseButton />}
+        onClose={onCancel}
+        className={styles.dialog}
+      >
+        <div className={styles.component}>
+          <div>
+            <div className={styles.body}>
+              <div className={styles.title}>
+                {title}
+              </div>
 
-        <div>
-          <div className={styles.body}>
-
-            <div className={styles.title}>
-              {title}
+              {error && <p className={styles.error}>{intl.formatMessage(error)}</p>}
             </div>
-
-            {error && <p className={styles.error}>{intl.formatMessage(error)}</p>}
-
-            <div className={styles.buttonsWrapper}>
-              <Button
-                className={backButtonClasses}
-                label={backButtonLabel}
-                onClick={onCancel}
-                skin={ButtonSkin}
-              />
-            </div>
-
           </div>
         </div>
-
-      </div>
+      </Dialog>
     );
   }
 }

--- a/app/components/transfer/ErrorPage.scss
+++ b/app/components/transfer/ErrorPage.scss
@@ -7,10 +7,6 @@
   justify-content: center;
 }
 
-.button {
-  margin: 20px auto 0;
-}
-
 .body {
   color: var(--theme-bordered-box-text-color);
   font-family: var(--font-regular);
@@ -33,11 +29,5 @@
     margin-bottom: 12px;
     word-break: break-word;
     text-align: center;
-  }
-
-  .buttonsWrapper {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
   }
 }

--- a/app/components/transfer/HardwareDisclaimer.js
+++ b/app/components/transfer/HardwareDisclaimer.js
@@ -7,6 +7,8 @@ import { CheckboxSkin } from 'react-polymorph/lib/skins/simple/CheckboxSkin';
 import { defineMessages, intlShape } from 'react-intl';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
+import DialogBackButton from '../widgets/DialogBackButton';
+import Dialog from '../widgets/Dialog';
 import styles from './HardwareDisclaimer.scss';
 import globalMessages from '../../i18n/global-messages';
 
@@ -37,56 +39,54 @@ export default class HardwareDisclaimer extends Component<Props> {
 
   render() {
     const { intl } = this.context;
-    const buttonClasses = (primary: boolean) => classnames([
-      primary ? 'primary' : 'secondary',
-      styles.button,
-    ]);
 
+    const actions = [
+      {
+        label: intl.formatMessage(globalMessages.backButtonLabel),
+        onClick: this.props.onBack,
+      },
+      {
+        label: intl.formatMessage(globalMessages.uriLandingDialogConfirmLabel),
+        onClick: this.props.onNext,
+        primary: true,
+        disabled: !this.props.isChecked,
+      },
+    ];
+
+    const title = (
+      <>
+        <span className={styles.headerIcon} />
+        {intl.formatMessage(globalMessages.attentionTitle)}
+      </>
+    );
     return (
-      <div className={styles.component}>
+      <Dialog
+        title={title}
+        actions={actions}
+        closeOnOverlayClick={false}
+        onClose={this.props.onBack}
+        backButton={<DialogBackButton onBack={this.props.onBack} />}
+      >
+        <div className={styles.component}>
+          <div>
+            <div className={styles.body}>
+              <p className={styles.message}>
+                {intl.formatMessage(globalMessages.hardwareTransferInstructions)}<br /><br />
+                {intl.formatMessage(messages.instructions2)}
+              </p>
 
-        <div>
-          <div className={styles.body}>
-
-            <div className={styles.title}>
-              <span className={styles.headerIcon} />
-              {intl.formatMessage(globalMessages.attentionTitle)}
+              <div className={styles.checkbox}>
+                <Checkbox
+                  label={intl.formatMessage(messages.hardwareDisclaimer)}
+                  onChange={this.props.toggleCheck}
+                  checked={this.props.isChecked}
+                  skin={CheckboxSkin}
+                />
+              </div>
             </div>
-
-            <p className={styles.message}>
-              {intl.formatMessage(globalMessages.hardwareTransferInstructions)}<br /><br />
-              {intl.formatMessage(messages.instructions2)}
-            </p>
-
-            <div className={styles.checkbox}>
-              <Checkbox
-                label={intl.formatMessage(messages.hardwareDisclaimer)}
-                onChange={this.props.toggleCheck}
-                checked={this.props.isChecked}
-                skin={CheckboxSkin}
-              />
-            </div>
-
-            <div className={styles.buttonsWrapper}>
-              <Button
-                className={buttonClasses(false)}
-                label={intl.formatMessage(globalMessages.backButtonLabel)}
-                onClick={this.props.onBack}
-                skin={ButtonSkin}
-              />
-              <Button
-                disabled={!this.props.isChecked}
-                className={buttonClasses(true)}
-                label={intl.formatMessage(globalMessages.uriLandingDialogConfirmLabel)}
-                onClick={this.props.onNext}
-                skin={ButtonSkin}
-              />
-            </div>
-
           </div>
         </div>
-
-      </div>
+      </Dialog>
     );
   }
 }

--- a/app/components/transfer/HardwareDisclaimer.js
+++ b/app/components/transfer/HardwareDisclaimer.js
@@ -1,12 +1,9 @@
 // @flow
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
-import classnames from 'classnames';
 import { Checkbox } from 'react-polymorph/lib/components/Checkbox';
 import { CheckboxSkin } from 'react-polymorph/lib/skins/simple/CheckboxSkin';
 import { defineMessages, intlShape } from 'react-intl';
-import { Button } from 'react-polymorph/lib/components/Button';
-import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import DialogBackButton from '../widgets/DialogBackButton';
 import Dialog from '../widgets/Dialog';
 import styles from './HardwareDisclaimer.scss';

--- a/app/components/transfer/HardwareDisclaimer.scss
+++ b/app/components/transfer/HardwareDisclaimer.scss
@@ -7,33 +7,18 @@
   justify-content: center;
 }
 
-.button {
-  width: 350px !important;
-  margin-top: 30px;
+.headerIcon {
+  width: 16px;
+  height: 16px;
+  margin-right: 3px;
+  vertical-align: top;
 }
 
 .body {
-  width: 800px;
   color: var(--theme-bordered-box-text-color);
   font-family: var(--font-regular);
   font-size: 14px;
   line-height: 19px;
-
-  .title {
-    font-size: 19px;
-    font-family: var(--font-medium);
-    line-height: 23px;
-    margin-bottom: 20px;
-    word-break: break-all;
-    text-align: center;
-
-    .headerIcon {
-      width: 19px;
-      height: 19px;
-      margin-right: 3px;
-      vertical-align: top;
-    }
-  }
 
   .message {
     font-size: 16px;
@@ -42,30 +27,16 @@
     word-break: break-word;
     text-align: center;
   }
-
-  .buttonsWrapper {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-  }
 }
 
 :global(.YoroiClassic) {
-  .body {
-    .title {
-      .headerIcon {
-        content:url(../../assets/images/attention-classic.inline.svg);
-      }
-    }
+  .headerIcon {
+    content:url(../../assets/images/attention-classic.inline.svg);
   }
 }
 
 :global(.YoroiModern) {
-  .body {
-    .title {
-      .headerIcon {
-        content:url(../../assets/images/attention-modern.inline.svg);
-      }
-    }
+  .headerIcon {
+    content:url(../../assets/images/attention-modern.inline.svg);
   }
 }

--- a/app/components/transfer/SuccessPage.js
+++ b/app/components/transfer/SuccessPage.js
@@ -3,11 +3,15 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { intlShape } from 'react-intl';
 import styles from './SuccessPage.scss';
+import Dialog from '../widgets/Dialog';
+import DialogCloseButton from '../widgets/DialogCloseButton';
 
 type Props = {|
   +title: string,
   +text: string,
-  +classicTheme: boolean
+  +classicTheme: boolean,
+  +onClose: void => PossiblyAsync<void>,
+  +closeLabel: string,
 |};
 
 @observer
@@ -20,18 +24,35 @@ export default class SuccessPage extends Component<Props> {
   render() {
     const { title, text } = this.props;
 
+    const actions = [
+      {
+        label: this.props.closeLabel,
+        onClick: this.props.onClose,
+        primary: true
+      }
+    ];
+
     return (
-      <div className={styles.component}>
-        <div>
-          <div className={styles.successImg} />
-          <div className={styles.title}>
-            {title}
-          </div>
-          <div className={styles.text}>
-            {text}
+      <Dialog
+        title=""
+        actions={actions}
+        closeOnOverlayClick={false}
+        onClose={this.props.onClose}
+        className={styles.dialog}
+        closeButton={<DialogCloseButton />}
+      >
+        <div className={styles.component}>
+          <div>
+            <div className={styles.successImg} />
+            <div className={styles.title}>
+              {title}
+            </div>
+            <div className={styles.text}>
+              {text}
+            </div>
           </div>
         </div>
-      </div>
+      </Dialog>
     );
   }
 }

--- a/app/components/transfer/SuccessPage.js
+++ b/app/components/transfer/SuccessPage.js
@@ -5,13 +5,16 @@ import { intlShape } from 'react-intl';
 import styles from './SuccessPage.scss';
 import Dialog from '../widgets/Dialog';
 import DialogCloseButton from '../widgets/DialogCloseButton';
+import LoadingSpinner from '../widgets/LoadingSpinner';
 
 type Props = {|
   +title: string,
   +text: string,
   +classicTheme: boolean,
-  +onClose: void => PossiblyAsync<void>,
-  +closeLabel: string,
+  +closeInfo?: {|
+    +onClose: void => PossiblyAsync<void>,
+    +closeLabel: string,
+  |},
 |};
 
 @observer
@@ -21,25 +24,29 @@ export default class SuccessPage extends Component<Props> {
     intl: intlShape.isRequired
   };
 
+  static defaultProps = {
+    closeInfo: undefined
+  };
+
   render() {
     const { title, text } = this.props;
 
-    const actions = [
-      {
-        label: this.props.closeLabel,
-        onClick: this.props.onClose,
+    const actions = this.props.closeInfo == null
+      ? undefined
+      : [{
+        label: this.props.closeInfo.closeLabel,
+        onClick: this.props.closeInfo.onClose,
         primary: true
-      }
-    ];
+      }];
 
     return (
       <Dialog
         title=""
         actions={actions}
         closeOnOverlayClick={false}
-        onClose={this.props.onClose}
+        onClose={this.props.closeInfo ? this.props.closeInfo.onClose : undefined}
         className={styles.dialog}
-        closeButton={<DialogCloseButton />}
+        closeButton={this.props.closeInfo ? (<DialogCloseButton />) : undefined}
       >
         <div className={styles.component}>
           <div>
@@ -50,6 +57,11 @@ export default class SuccessPage extends Component<Props> {
             <div className={styles.text}>
               {text}
             </div>
+            {this.props.closeInfo == null && (
+              <div className={styles.spinnerSection}>
+                <LoadingSpinner />
+              </div>
+            )}
           </div>
         </div>
       </Dialog>

--- a/app/components/transfer/SuccessPage.scss
+++ b/app/components/transfer/SuccessPage.scss
@@ -22,6 +22,11 @@
     line-height: 22px;
     text-align: center;
   }
+
+  .spinnerSection {
+    margin-top: 12px;
+    margin-bottom: 5px;
+  }
 }
 
 :global(.YoroiModern):not(:global(.YoroiShelley)) .component {

--- a/app/components/transfer/TransferSummaryPage.scss
+++ b/app/components/transfer/TransferSummaryPage.scss
@@ -1,18 +1,6 @@
 @import '../../themes/mixins/error-message';
 @import '../../themes/mixins/loading-spinner';
 
-.isSubmitting {
-  @include loading-spinner("../../assets/images/spinner-light.svg");
-}
-
-.button {
-  margin: 0;
-
-  & + button {
-    margin-left: 20px;
-  }
-}
-
 .body {
   color: var(--theme-bordered-box-text-color);
   font-family: var(--font-regular);
@@ -97,12 +85,6 @@
     line-height: 1.38;
     margin-top: 6px;
     word-break: break-word;
-  }
-
-  .buttonsWrapper {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
   }
 
   .form {

--- a/app/components/wallet/staking/DelegationSuccessDialog.js
+++ b/app/components/wallet/staking/DelegationSuccessDialog.js
@@ -40,8 +40,10 @@ export default class DelegationSuccessDialog extends Component<Props> {
         title={intl.formatMessage(messages.title)}
         text={intl.formatMessage(messages.explanation)}
         classicTheme={this.props.classicTheme}
-        onClose={this.props.onClose}
-        closeLabel={intl.formatMessage(messages.buttonLabel)}
+        closeInfo={{
+          onClose: this.props.onClose,
+          closeLabel: intl.formatMessage(messages.buttonLabel),
+        }}
       />
     );
   }

--- a/app/components/wallet/staking/DelegationSuccessDialog.js
+++ b/app/components/wallet/staking/DelegationSuccessDialog.js
@@ -3,9 +3,6 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import Dialog from '../../widgets/Dialog';
-import DialogCloseButton from '../../widgets/DialogCloseButton';
-import styles from './DelegationTxDialog.scss';
 import SuccessPage from '../../transfer/SuccessPage';
 
 const messages = defineMessages({
@@ -38,29 +35,14 @@ export default class DelegationSuccessDialog extends Component<Props> {
   render() {
     const { intl } = this.context;
 
-    const actions = [
-      {
-        label: intl.formatMessage(messages.buttonLabel),
-        onClick: this.props.onClose,
-        primary: true
-      }
-    ];
-
     return (
-      <Dialog
-        title=""
-        actions={actions}
-        closeOnOverlayClick={false}
+      <SuccessPage
+        title={intl.formatMessage(messages.title)}
+        text={intl.formatMessage(messages.explanation)}
+        classicTheme={this.props.classicTheme}
         onClose={this.props.onClose}
-        className={styles.dialog}
-        closeButton={<DialogCloseButton />}
-      >
-        <SuccessPage
-          title={intl.formatMessage(messages.title)}
-          text={intl.formatMessage(messages.explanation)}
-          classicTheme={this.props.classicTheme}
-        />
-      </Dialog>
+        closeLabel={intl.formatMessage(messages.buttonLabel)}
+      />
     );
   }
 }

--- a/app/components/widgets/Dialog.js
+++ b/app/components/widgets/Dialog.js
@@ -21,7 +21,7 @@ type ActionType = {|
 |};
 
 type Props = {|
-  +title?: string,
+  +title?: string | Node,
   +children?: Node,
   +actions?: Array<ActionType>,
   +closeButton?: Element<any>,

--- a/app/containers/settings/Settings.js
+++ b/app/containers/settings/Settings.js
@@ -59,7 +59,7 @@ export default class Settings extends Component<Props> {
       />
     );
 
-    const navbarTitle = (
+    const navbar = (
       <NavBarContainer
         {...this.generated.NavBarContainerProps}
         title={<NavBarTitle
@@ -71,7 +71,7 @@ export default class Settings extends Component<Props> {
     return (
       <MainLayout
         sidebar={sidebarContainer}
-        navbar={navbarTitle}
+        navbar={navbar}
         connectionErrorType={checkAdaServerStatus}
         showInContainer
         showAsCard

--- a/app/containers/transfer/DaedalusTransferErrorPage.js
+++ b/app/containers/transfer/DaedalusTransferErrorPage.js
@@ -35,7 +35,7 @@ export default class DaedalusTransferErrorPage extends Component<Props> {
 
     return (<ErrorPage
       title={intl.formatMessage(messages.title)}
-      backButtonLabel={intl.formatMessage(globalMessages.backButtonLabel)}
+      backButtonLabel={intl.formatMessage(globalMessages.cancel)}
       onCancel={onCancel}
       error={error}
       classicTheme={classicTheme}

--- a/app/containers/transfer/DaedalusTransferPage.js
+++ b/app/containers/transfer/DaedalusTransferPage.js
@@ -7,7 +7,6 @@ import validWords from 'bip39/src/wordlists/english.json';
 import type { InjectedOrGenerated } from '../../types/injectedPropsType';
 import TransferLayout from '../../components/transfer/TransferLayout';
 import TransferInstructionsPage from '../../components/transfer/TransferInstructionsPage';
-import BorderedBox from '../../components/widgets/BorderedBox';
 import TransferSummaryPage from '../../components/transfer/TransferSummaryPage';
 import DaedalusTransferFormPage from './DaedalusTransferFormPage';
 import DaedalusTransferMasterKeyFormPage from './DaedalusTransferMasterKeyFormPage';
@@ -18,6 +17,7 @@ import config from '../../config';
 import { TransferStatus, } from '../../types/TransferTypes';
 import type { TransferStatusT, TransferTx } from '../../types/TransferTypes';
 import LocalizableError from '../../i18n/LocalizableError';
+import globalMessages from '../../i18n/global-messages';
 
 import { formattedWalletAmount } from '../../utils/formatters';
 import { ROUTES } from '../../routes-config';
@@ -190,26 +190,27 @@ export default class DaedalusTransferPage extends Component<InjectedOrGenerated<
             <DaedalusTransferWaitingPage status={daedalusTransfer.status} />
           </TransferLayout>
         );
-      case TransferStatus.READY_TO_TRANSFER:
+      case TransferStatus.READY_TO_TRANSFER: {
         if (daedalusTransfer.transferTx == null) {
           return null; // TODO: throw error? Shouldn't happen
         }
+        const { intl } = this.context;
         return (
           <TransferLayout>
-            <BorderedBox>
-              <TransferSummaryPage
-                form={null}
-                formattedWalletAmount={formattedWalletAmount}
-                selectedExplorer={this.generated.stores.profile.selectedExplorer}
-                transferTx={daedalusTransfer.transferTx}
-                onSubmit={this.transferFunds}
-                isSubmitting={daedalusTransfer.transferFundsRequest.isExecuting}
-                onCancel={this.cancelTransferFunds}
-                error={daedalusTransfer.error}
-              />
-            </BorderedBox>
+            <TransferSummaryPage
+              form={null}
+              formattedWalletAmount={formattedWalletAmount}
+              selectedExplorer={this.generated.stores.profile.selectedExplorer}
+              transferTx={daedalusTransfer.transferTx}
+              onSubmit={this.transferFunds}
+              isSubmitting={daedalusTransfer.transferFundsRequest.isExecuting}
+              onCancel={this.cancelTransferFunds}
+              error={daedalusTransfer.error}
+              dialogTitle={intl.formatMessage(globalMessages.walletSendConfirmationDialogTitle)}
+            />
           </TransferLayout>
         );
+      }
       case TransferStatus.ERROR:
         return (
           <TransferLayout>

--- a/app/containers/transfer/DaedalusTransferPage.stories.js
+++ b/app/containers/transfer/DaedalusTransferPage.stories.js
@@ -7,6 +7,7 @@ import { boolean, select, } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import {
   globalKnobs,
+  walletLookup,
   genDummyWithCache,
 } from '../../../stories/helpers/StoryWrapper';
 import { wrapTransfer } from '../../Routes';
@@ -97,13 +98,18 @@ export const Uninitialized = () => {
     walletCases,
     walletCases.NoWallet,
   );
+  const walletVal = walletValue();
+  const lookup = walletLookup(walletVal === walletCases.NoWallet
+    ? []
+    : [wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: walletVal === walletCases.NoWallet ? null : wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
-        const walletVal = walletValue();
         const baseProps = walletVal === walletCases.NoWallet
           ? genBaseProps({
             wallet: null,
@@ -128,10 +134,13 @@ export const Uninitialized = () => {
 
 export const GettingMnemonics = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -154,10 +163,13 @@ export const GettingMnemonics = () => {
 
 export const GettingPaperMnemonics = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -180,10 +192,13 @@ export const GettingPaperMnemonics = () => {
 
 export const GettingMasterKey = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -206,10 +221,13 @@ export const GettingMasterKey = () => {
 
 export const RestoringAddresses = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -232,10 +250,13 @@ export const RestoringAddresses = () => {
 
 export const CheckingAddresses = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -258,10 +279,13 @@ export const CheckingAddresses = () => {
 
 export const GeneratingTx = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -284,10 +308,13 @@ export const GeneratingTx = () => {
 
 export const ReadyToTransfer = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -322,10 +349,13 @@ export const ReadyToTransfer = () => {
 
 export const Error = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.DAEDALUS
+        currentRoute: ROUTES.TRANSFER.DAEDALUS,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const errorCases = {

--- a/app/containers/transfer/DaedalusTransferWaitingPage.js
+++ b/app/containers/transfer/DaedalusTransferWaitingPage.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import TransferWaitingPage from '../../components/transfer/TransferWaitingPage';
 import type { TransferStatusT } from '../../types/TransferTypes';
+import Dialog from '../../components/widgets/Dialog';
 
 type Props = {|
   +status: TransferStatusT
@@ -13,7 +14,11 @@ export default class DaedalusTransferWaitingPage extends Component<Props> {
 
   render() {
     return (
-      <TransferWaitingPage status={this.props.status} />
+      <Dialog
+        closeOnOverlayClick={false}
+      >
+        <TransferWaitingPage status={this.props.status} />
+      </Dialog>
     );
   }
 }

--- a/app/containers/transfer/Transfer.js
+++ b/app/containers/transfer/Transfer.js
@@ -11,9 +11,10 @@ import TransferWithNavigation from '../../components/transfer/layouts/TransferWi
 import type { TransferNavigationProps } from '../../components/transfer/layouts/TransferWithNavigation';
 import { ROUTES } from '../../routes-config';
 import NavBarTitle from '../../components/topbar/NavBarTitle';
-import NavBar from '../../components/topbar/NavBar';
+import NavBarContainer from '../NavBarContainer';
 import globalMessages from '../../i18n/global-messages';
 import type { GeneratedData as SidebarContainerData } from '../SidebarContainer';
+import type { GeneratedData as NavBarContainerData } from '../NavBarContainer';
 
 export type GeneratedData = typeof Transfer.prototype.generated;
 
@@ -33,7 +34,50 @@ export default class Transfer extends Component<Props> {
     children: undefined,
   };
 
-  @computed get generated(): GeneratedData {
+  isActiveScreen : $PropertyType<TransferNavigationProps, 'isActiveNavItem'> = page => {
+    const { app } = this.generated.stores;
+    return app.currentRoute.endsWith(page);
+  };
+
+  handleTransferNavItemClick : $PropertyType<TransferNavigationProps, 'onNavItemClick'> = page => {
+    this.generated.actions.router.goToRoute.trigger({
+      route: { daedalus: ROUTES.TRANSFER.DAEDALUS, yoroi: ROUTES.TRANSFER.YOROI }[page],
+    });
+  }
+
+  render() {
+    const { stores } = this.generated;
+    const sidebarContainer = (<SidebarContainer {...this.generated.SidebarContainerProps} />);
+    const { checkAdaServerStatus } = stores.serverConnectionStore;
+
+    const navbar = (
+      <NavBarContainer
+        {...this.generated.NavBarContainerProps}
+        title={<NavBarTitle
+          title={this.context.intl.formatMessage(globalMessages.sidebarTransfer)}
+        />}
+      />
+    );
+
+    return (
+      <MainLayout
+        navbar={navbar}
+        sidebar={sidebarContainer}
+        connectionErrorType={checkAdaServerStatus}
+        showInContainer
+        showAsCard
+      >
+        <TransferWithNavigation
+          isActiveScreen={this.isActiveScreen}
+          onTransferNavItemClick={this.handleTransferNavItemClick}
+        >
+          {this.props.children}
+        </TransferWithNavigation>
+      </MainLayout>
+    );
+  }
+
+  @computed get generated() {
     if (this.props.generated !== undefined) {
       return this.props.generated;
     }
@@ -58,44 +102,9 @@ export default class Transfer extends Component<Props> {
       SidebarContainerProps: (
         { actions, stores, }: InjectedOrGenerated<SidebarContainerData>
       ),
+      NavBarContainerProps: (
+        { actions, stores, }: InjectedOrGenerated<NavBarContainerData>
+      ),
     });
-  }
-
-  isActiveScreen : $PropertyType<TransferNavigationProps, 'isActiveNavItem'> = page => {
-    const { app } = this.generated.stores;
-    return app.currentRoute.endsWith(page);
-  };
-
-  handleTransferNavItemClick : $PropertyType<TransferNavigationProps, 'onNavItemClick'> = page => {
-    this.generated.actions.router.goToRoute.trigger({
-      route: { daedalus: ROUTES.TRANSFER.DAEDALUS, yoroi: ROUTES.TRANSFER.YOROI }[page],
-    });
-  }
-
-  render() {
-    const { stores } = this.generated;
-    const sidebarContainer = (<SidebarContainer {...this.generated.SidebarContainerProps} />);
-    const { checkAdaServerStatus } = stores.serverConnectionStore;
-
-    const navbarTitle = (
-      <NavBarTitle title={this.context.intl.formatMessage(globalMessages.sidebarTransfer)} />
-    );
-
-    return (
-      <MainLayout
-        navbar={<NavBar title={navbarTitle} />}
-        sidebar={sidebarContainer}
-        connectionErrorType={checkAdaServerStatus}
-        showInContainer
-        showAsCard
-      >
-        <TransferWithNavigation
-          isActiveScreen={this.isActiveScreen}
-          onTransferNavItemClick={this.handleTransferNavItemClick}
-        >
-          {this.props.children}
-        </TransferWithNavigation>
-      </MainLayout>
-    );
   }
 }

--- a/app/containers/transfer/Transfer.mock.js
+++ b/app/containers/transfer/Transfer.mock.js
@@ -3,11 +3,27 @@
 import { select, } from '@storybook/addon-knobs';
 import { ServerStatusErrors } from '../../types/serverStatusErrorType';
 import { action } from '@storybook/addon-actions';
+import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver';
+import WalletSettingsStore from '../../stores/base/WalletSettingsStore';
+import TransactionsStore from '../../stores/base/TransactionsStore';
+import DelegationStore from '../../stores/ada/DelegationStore';
+import WalletStore from '../../stores/toplevel/WalletStore';
 import type { GeneratedData } from './Transfer';
 
-export const mockTransferProps: {|
+export const mockTransferProps: {
+  selected: null | PublicDeriver<>,
+  publicDerivers: Array<PublicDeriver<>>,
+  getConceptualWalletSettingsCache:
+    typeof WalletSettingsStore.prototype.getConceptualWalletSettingsCache,
+  getPublicKeyCache:
+    typeof WalletStore.prototype.getPublicKeyCache,
+  getTransactions:
+    typeof TransactionsStore.prototype.getTxRequests,
+  getDelegation:
+    typeof DelegationStore.prototype.getDelegationRequests,
   currentRoute: string,
-|} => {| generated: GeneratedData |} = (request) => ({
+  ...
+} => {| generated: GeneratedData |} = (request) => ({
   generated: {
     stores: {
       app: {
@@ -46,6 +62,44 @@ export const mockTransferProps: {|
           },
         },
       },
+    },
+    NavBarContainerProps: {
+      generated: {
+        stores: {
+          app: {
+            currentRoute: request.currentRoute,
+          },
+          walletSettings: {
+            getConceptualWalletSettingsCache:
+              request.getConceptualWalletSettingsCache,
+          },
+          wallets: {
+            selected: request.selected,
+            publicDerivers: request.publicDerivers,
+            getPublicKeyCache: request.getPublicKeyCache,
+          },
+          profile: {
+            shouldHideBalance: false,
+          },
+          delegation: {
+            getDelegationRequests: request.getDelegation,
+          },
+          transactions: {
+            getTxRequests: request.getTransactions,
+          },
+        },
+        actions: {
+          wallets: {
+            setActiveWallet: { trigger: action('setActiveWallet') },
+          },
+          profile: {
+            updateHideBalance: { trigger: async (req) => action('updateHideBalance')(req) },
+          },
+          router: {
+            goToRoute: { trigger: action('goToRoute') },
+          },
+        },
+      }
     },
   },
 });

--- a/app/containers/transfer/UnmangleTxDialogContainer.js
+++ b/app/containers/transfer/UnmangleTxDialogContainer.js
@@ -11,7 +11,6 @@ import TransferSummaryPage from '../../components/transfer/TransferSummaryPage';
 import YoroiTransferErrorPage from './YoroiTransferErrorPage';
 import VerticallyCenteredLayout from '../../components/layout/VerticallyCenteredLayout';
 import Dialog from '../../components/widgets/Dialog';
-import DialogCloseButton from '../../components/widgets/DialogCloseButton';
 import LoadingSpinner from '../../components/widgets/LoadingSpinner';
 import environment from '../../environment';
 import { formattedWalletAmount } from '../../utils/formatters';

--- a/app/containers/transfer/UnmangleTxDialogContainer.js
+++ b/app/containers/transfer/UnmangleTxDialogContainer.js
@@ -16,6 +16,8 @@ import LoadingSpinner from '../../components/widgets/LoadingSpinner';
 import environment from '../../environment';
 import { formattedWalletAmount } from '../../utils/formatters';
 import { IGetFee, IReceivers, ITotalInput } from '../../api/ada/transactions/utils';
+import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
+import type { BaseSignRequest } from '../../api/ada/transactions/types';
 import {
   asHasUtxoChains,
 } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
@@ -105,25 +107,6 @@ export default class UnmangleTxDialogContainer extends Component<Props> {
   };
 
   render() {
-    const { intl } = this.context;
-
-    return (
-      <Dialog
-        title={intl.formatMessage(globalMessages.walletSendConfirmationDialogTitle)}
-        closeOnOverlayClick={false}
-        closeButton={this._getAdaWalletsStore().sendMoneyRequest.isExecuting
-          ? undefined
-          : (<DialogCloseButton />)}
-        onClose={this.props.onClose}
-      >
-        {this.getContent()}
-      </Dialog>
-    );
-  }
-
-  getContent: (void) => Node = () => {
-    const { profile } = this.generated.stores;
-
     const txBuilder = this._getTxBuilderStore();
 
     if (txBuilder.setupSelfTx.error != null) {
@@ -131,22 +114,39 @@ export default class UnmangleTxDialogContainer extends Component<Props> {
         <YoroiTransferErrorPage
           error={txBuilder.setupSelfTx.error}
           onCancel={this.props.onClose}
-          classicTheme={profile.isClassicTheme}
+          classicTheme={this.generated.stores.profile.isClassicTheme}
         />
       );
     }
 
     if (txBuilder.tentativeTx == null) {
-      return (
+      return this.getSpinner();
+    }
+    const tentativeTx = txBuilder.tentativeTx;
+    return this.getContent(tentativeTx);
+  }
+
+  getSpinner: void => Node = () => {
+    const { intl } = this.context;
+    return (
+      <Dialog
+        title={intl.formatMessage(globalMessages.processingLabel)}
+        closeOnOverlayClick={false}
+      >
         <TransferLayout>
           <VerticallyCenteredLayout>
             <LoadingSpinner />
           </VerticallyCenteredLayout>
         </TransferLayout>
-      );
-    }
-    const tentativeTx = txBuilder.tentativeTx;
+      </Dialog>
+    );
+  }
 
+  getContent: BaseSignRequest<
+    RustModule.WalletV2.Transaction | RustModule.WalletV3.InputOutput
+  > => Node = (
+    tentativeTx
+  ) => {
     const transferTx = {
       recoveredBalance: ITotalInput(tentativeTx, true),
       fee: IGetFee(tentativeTx, true),
@@ -162,6 +162,8 @@ export default class UnmangleTxDialogContainer extends Component<Props> {
       isSubmitting={this._getAdaWalletsStore().sendMoneyRequest.isExecuting}
     />);
 
+    const { intl } = this.context;
+
     return (
       <TransferSummaryPage
         form={spendingPasswordForm}
@@ -172,6 +174,7 @@ export default class UnmangleTxDialogContainer extends Component<Props> {
         isSubmitting={this._getAdaWalletsStore().sendMoneyRequest.isExecuting}
         onCancel={this.props.onClose}
         error={this._getAdaWalletsStore().sendMoneyRequest.error}
+        dialogTitle={intl.formatMessage(globalMessages.walletSendConfirmationDialogTitle)}
       />
     );
   }

--- a/app/containers/transfer/YoroiTransferErrorPage.js
+++ b/app/containers/transfer/YoroiTransferErrorPage.js
@@ -35,7 +35,7 @@ export default class YoroiTransferErrorPage extends Component<Props> {
 
     return (<ErrorPage
       title={intl.formatMessage(messages.title)}
-      backButtonLabel={intl.formatMessage(globalMessages.backButtonLabel)}
+      backButtonLabel={intl.formatMessage(globalMessages.cancel)}
       onCancel={onCancel}
       error={error}
       classicTheme={classicTheme}

--- a/app/containers/transfer/YoroiTransferPage.js
+++ b/app/containers/transfer/YoroiTransferPage.js
@@ -265,7 +265,7 @@ export default class YoroiTransferPage extends Component<InjectedOrGenerated<Gen
         }
         return (
           <TransferLayout>
-            <BorderedBox>
+            <Dialog>
               <TransferSummaryPage
                 form={null}
                 formattedWalletAmount={formattedWalletAmount}
@@ -276,7 +276,7 @@ export default class YoroiTransferPage extends Component<InjectedOrGenerated<Gen
                 onCancel={this.cancelTransferFunds}
                 error={yoroiTransfer.error}
               />
-            </BorderedBox>
+            </Dialog>
           </TransferLayout>
         );
       case TransferStatus.ERROR:

--- a/app/containers/transfer/YoroiTransferPage.js
+++ b/app/containers/transfer/YoroiTransferPage.js
@@ -11,7 +11,6 @@ import type { InjectedOrGenerated } from '../../types/injectedPropsType';
 import TransferLayout from '../../components/transfer/TransferLayout';
 import TransferSummaryPage from '../../components/transfer/TransferSummaryPage';
 import HardwareDisclaimerPage from './HardwareDisclaimerPage';
-import BorderedBox from '../../components/widgets/BorderedBox';
 import YoroiTransferFormPage from './YoroiTransferFormPage';
 import YoroiPaperWalletFormPage from './YoroiPaperWalletFormPage';
 import HardwareTransferFormPage from './HardwareTransferFormPage';
@@ -28,6 +27,7 @@ import type { TransferStatusT, TransferTx } from '../../types/TransferTypes';
 import LocalizableError from '../../i18n/LocalizableError';
 import { ROUTES } from '../../routes-config';
 import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/index';
+import globalMessages from '../../i18n/global-messages';
 import type { GeneratedData as YoroiPlateData } from './YoroiPlatePage';
 
 // Stay this long on the success page, then jump to the wallet transactions page
@@ -259,26 +259,27 @@ export default class YoroiTransferPage extends Component<InjectedOrGenerated<Gen
             <YoroiTransferWaitingPage status={yoroiTransfer.status} />
           </TransferLayout>
         );
-      case TransferStatus.READY_TO_TRANSFER:
+      case TransferStatus.READY_TO_TRANSFER: {
         if (yoroiTransfer.transferTx == null) {
           return null; // TODO: throw error? Shouldn't happen
         }
+        const { intl } = this.context;
         return (
           <TransferLayout>
-            <Dialog>
-              <TransferSummaryPage
-                form={null}
-                formattedWalletAmount={formattedWalletAmount}
-                selectedExplorer={this.generated.stores.profile.selectedExplorer}
-                transferTx={yoroiTransfer.transferTx}
-                onSubmit={this.transferFunds}
-                isSubmitting={yoroiTransfer.transferFundsRequest.isExecuting}
-                onCancel={this.cancelTransferFunds}
-                error={yoroiTransfer.error}
-              />
-            </Dialog>
+            <TransferSummaryPage
+              form={null}
+              formattedWalletAmount={formattedWalletAmount}
+              selectedExplorer={this.generated.stores.profile.selectedExplorer}
+              transferTx={yoroiTransfer.transferTx}
+              onSubmit={this.transferFunds}
+              isSubmitting={yoroiTransfer.transferFundsRequest.isExecuting}
+              onCancel={this.cancelTransferFunds}
+              error={yoroiTransfer.error}
+              dialogTitle={intl.formatMessage(globalMessages.walletSendConfirmationDialogTitle)}
+            />
           </TransferLayout>
         );
+      }
       case TransferStatus.ERROR:
         return (
           <TransferLayout>

--- a/app/containers/transfer/YoroiTransferPage.stories.js
+++ b/app/containers/transfer/YoroiTransferPage.stories.js
@@ -7,6 +7,7 @@ import { boolean, select, } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import {
   globalKnobs,
+  walletLookup,
   genDummyWithCache,
 } from '../../../stories/helpers/StoryWrapper';
 import { wrapTransfer } from '../../Routes';
@@ -137,13 +138,18 @@ export const Uninitialized = () => {
     walletCases,
     walletCases.NoWallet,
   );
+  const walletVal = walletValue();
+  const lookup = walletLookup(walletVal === walletCases.NoWallet
+    ? []
+    : [wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: walletVal === walletCases.NoWallet ? null : wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
-        const walletVal = walletValue();
         const baseProps = walletVal === walletCases.NoWallet
           ? genBaseProps({
             wallet: null,
@@ -167,10 +173,13 @@ export const Uninitialized = () => {
 
 export const GettingMnemonics = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -193,10 +202,13 @@ export const GettingMnemonics = () => {
 
 export const GettingPaperMnemonics = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -219,10 +231,13 @@ export const GettingPaperMnemonics = () => {
 
 export const HardwareDisclaimer = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -245,10 +260,13 @@ export const HardwareDisclaimer = () => {
 
 export const HardwareMnemonic = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -271,10 +289,13 @@ export const HardwareMnemonic = () => {
 
 export const Checksum = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const transferKindSelect = () => select(
@@ -306,10 +327,13 @@ export const Checksum = () => {
 
 export const RestoringAddresses = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -332,10 +356,13 @@ export const RestoringAddresses = () => {
 
 export const CheckingAddresses = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -358,10 +385,13 @@ export const CheckingAddresses = () => {
 
 export const GeneratingTx = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({
@@ -384,10 +414,13 @@ export const GeneratingTx = () => {
 
 export const TransferTx = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const errorCases = {
@@ -434,10 +467,13 @@ export const TransferTx = () => {
 
 export const Error = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const errorCases = {
@@ -472,10 +508,13 @@ export const Error = () => {
 
 export const Success = () => {
   const wallet = genDummyWithCache();
+  const lookup = walletLookup([wallet]);
   return (() => {
     return wrapTransfer(
       mockTransferProps({
-        currentRoute: ROUTES.TRANSFER.YOROI
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
       }),
       (() => {
         const baseProps = genBaseProps({

--- a/app/containers/transfer/YoroiTransferSuccessPage.js
+++ b/app/containers/transfer/YoroiTransferSuccessPage.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import SuccessPage from '../../components/transfer/SuccessPage';
+import globalMessages from '../../i18n/global-messages';
 
 const messages = defineMessages({
   title: {
@@ -34,6 +35,8 @@ export default class YoroiTransferSuccessPage extends Component<Props> {
       title={intl.formatMessage(messages.title)}
       text={intl.formatMessage(messages.text)}
       classicTheme={classicTheme}
+      closeLabel={intl.formatMessage(globalMessages.continue)}
+      onClose={() => {} /* TODO: replace timeout logic with this button */}
     />);
   }
 }

--- a/app/containers/transfer/YoroiTransferSuccessPage.js
+++ b/app/containers/transfer/YoroiTransferSuccessPage.js
@@ -35,8 +35,6 @@ export default class YoroiTransferSuccessPage extends Component<Props> {
       title={intl.formatMessage(messages.title)}
       text={intl.formatMessage(messages.text)}
       classicTheme={classicTheme}
-      closeLabel={intl.formatMessage(globalMessages.continue)}
-      onClose={() => {} /* TODO: replace timeout logic with this button */}
     />);
   }
 }

--- a/app/containers/transfer/YoroiTransferSuccessPage.js
+++ b/app/containers/transfer/YoroiTransferSuccessPage.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import SuccessPage from '../../components/transfer/SuccessPage';
-import globalMessages from '../../i18n/global-messages';
 
 const messages = defineMessages({
   title: {

--- a/app/containers/transfer/YoroiTransferWaitingPage.js
+++ b/app/containers/transfer/YoroiTransferWaitingPage.js
@@ -5,6 +5,7 @@ import { defineMessages, intlShape } from 'react-intl';
 import type { TransferStatusT } from '../../types/TransferTypes';
 import { TransferStatus } from '../../types/TransferTypes';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
+import Dialog from '../../components/widgets/Dialog';
 
 import AnnotatedLoader from '../../components/transfer/AnnotatedLoader';
 
@@ -43,10 +44,12 @@ export default class YoroiTransferWaitingPage extends Component<Props> {
     const { status } = this.props;
 
     return (
-      <AnnotatedLoader
-        title={intl.formatMessage(messages.title)}
-        details={this.getMessage(intl, status)}
-      />
+      <Dialog>
+        <AnnotatedLoader
+          title={intl.formatMessage(messages.title)}
+          details={this.getMessage(intl, status)}
+        />
+      </Dialog>
     );
   }
 

--- a/app/containers/transfer/YoroiTransferWaitingPage.js
+++ b/app/containers/transfer/YoroiTransferWaitingPage.js
@@ -44,7 +44,9 @@ export default class YoroiTransferWaitingPage extends Component<Props> {
     const { status } = this.props;
 
     return (
-      <Dialog>
+      <Dialog
+        closeOnOverlayClick={false}
+      >
         <AnnotatedLoader
           title={intl.formatMessage(messages.title)}
           details={this.getMessage(intl, status)}

--- a/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletRestoreDialogContainer.js
@@ -234,8 +234,10 @@ export default class WalletRestoreDialogContainer extends Component<Props> {
             title={intl.formatMessage(globalMessages.pdfGenDone)}
             text={intl.formatMessage(messages.walletUpgradeNoop)}
             classicTheme={profile.isClassicTheme}
-            closeLabel={intl.formatMessage(globalMessages.continue)}
-            onClose={walletRestoreActions.startRestore.trigger}
+            closeInfo={{
+              closeLabel: intl.formatMessage(globalMessages.continue),
+              onClose: walletRestoreActions.startRestore.trigger,
+            }}
           />
         );
       }

--- a/chrome/constants.js
+++ b/chrome/constants.js
@@ -8,7 +8,7 @@ import {
 import { SEIZA_URL, SEIZA_FOR_YOROI_URL } from './manifestEnvs';
 
 export const Version = {
-  Shelley: '2.6.2',
+  Shelley: '2.6.3',
   Byron: '1.10.0',
 };
 

--- a/features/yoroi-transfer.feature
+++ b/features/yoroi-transfer.feature
@@ -92,11 +92,11 @@ Feature: Transfer Yoroi Wallet funds
     Then I should see on the Yoroi transfer summary screen:
     | fromAddress                                                 | amount           |
     | Ae2tdPwUPEYx2dK1AMzRN1GqNd2eY7GCd7Z6aikMPJL3EkqqugoFQComQnV | 1234567898765    |
-    Then I navigate to wallet transactions screen
-    Then I am on the Yoroi Transfer start screen
+    When I confirm Yoroi transfer funds
+    Then I should see the Yoroi transfer success screen
 
   @it-82
-  Scenario: User can transfer funds from another Yoroi paper wallet (IT-82)
+  Scenario: User can tryeah ansfer funds from another Yoroi paper wallet (IT-82)
     # The recovery phrase and its balance(s) are defined in 
     # /features/mock-chain/TestWallets.js and
     # /features/mock-chain/mockImporter.js


### PR DESCRIPTION
To avoid the user switching wallets in the middle of a transfer wallet process, we put all the contents of the "Transfer wallet" screens inside dialogs.

TODO:
- [x] Get rid of 3 second "success" screen for Yoroi transfers
- [x] Update storybook to get the design reviewed
- [x] fix E2E tests

Here are the pages that got changes:

- Unmangle dialog
- Wallet upgrade
- Daedalus transfer
- Yoroi transfer
- Delegation Tx (only success case)