### PR TITLE
Misc fixes to build system

### DIFF
--- a/app/containers/wallet/staking/StakingPage.stories.js
+++ b/app/containers/wallet/staking/StakingPage.stories.js
@@ -209,7 +209,7 @@ export const Frame = () => {
       ...lookup,
     }),
     (<StakingPage
-      urlTemplate="no-frame-when-testing"
+      urlTemplate="localhost://no-frame-when-testing"
       generated={genBaseProps({
         wallet,
         lookup,
@@ -236,7 +236,7 @@ export const PendingTransaction = () => {
       ...lookup,
     }),
     (<StakingPage
-      urlTemplate="no-frame-when-testing"
+      urlTemplate="localhost://no-frame-when-testing"
       generated={genBaseProps({
         wallet,
         lookup,
@@ -264,7 +264,7 @@ export const TransactionIsExecuting = () => {
       ...lookup,
     }),
     (<StakingPage
-      urlTemplate="no-frame-when-testing"
+      urlTemplate="localhost://no-frame-when-testing"
       generated={genBaseProps({
         wallet,
         lookup,
@@ -296,7 +296,7 @@ export const TransactionError = () => {
       ...lookup,
     }),
     (<StakingPage
-      urlTemplate="no-frame-when-testing"
+      urlTemplate="localhost://no-frame-when-testing"
       generated={genBaseProps({
         wallet,
         lookup,
@@ -347,7 +347,7 @@ export const Transaction = () => {
       ...lookup,
     }),
     (<StakingPage
-      urlTemplate="no-frame-when-testing"
+      urlTemplate="localhost://no-frame-when-testing"
       generated={genBaseProps({
         wallet,
         lookup,
@@ -395,7 +395,7 @@ export const DelegationSuccess = () => {
       ...lookup,
     }),
     (<StakingPage
-      urlTemplate="no-frame-when-testing"
+      urlTemplate="localhost://no-frame-when-testing"
       generated={genBaseProps({
         wallet,
         lookup,

--- a/chrome/constants.js
+++ b/chrome/constants.js
@@ -51,13 +51,20 @@ export function genCSP(request: {|
   frameSrc.push(SEIZA_URL);
   frameSrc.push('https://connect.trezor.io/');
   frameSrc.push('https://emurgo.github.io/yoroi-extension-ledger-bridge');
+
+  // unsafe-eval is unfortunately needed to compile WebAssembly in the browser
+  // it may be removed if wasm-eval is ever standardized https://github.com/w3c/webappsec-csp/pull/293
+  const evalSrc = "'unsafe-eval'";
+
+  // unsafe-inline is unfortunately required by style-loader (even in production builds)
+  const evalStyle = "'unsafe-inline'";
   return [
     `default-src 'self' ${defaultSrc.join(' ')};`,
     `frame-src ${frameSrc.join(' ')};`,
-    `script-src 'self' 'unsafe-eval' ${scriptSrc.join(' ')} blob:;`,
+    `script-src 'self' ${evalSrc} ${scriptSrc.join(' ')} blob:;`,
     `object-src 'self' ${objectSrc.join(' ')};`,
     `connect-src ${connectSrc.join(' ')};`,
-    `style-src * 'unsafe-inline' 'self' ${styleSrc.join(' ')} blob:;`,
+    `style-src * ${evalStyle} 'self' ${styleSrc.join(' ')} blob:;`,
     `img-src 'self' ${imgSrc.join(' ')} data:;`,
   ].join(' ');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10467,9 +10467,9 @@
       "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
     },
     "d3-format": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.2.tgz",
-      "integrity": "sha512-gco1Ih54PgMsyIXgttLxEhNy/mXxq8+rLnCb5shQk+P5TsiySrwWU5gpB4zen626J4LIwBxHvDChyA8qDm57ww=="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.3.tgz",
+      "integrity": "sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ=="
     },
     "d3-interpolate": {
       "version": "1.4.0",
@@ -10511,9 +10511,9 @@
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "d3-time-format": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.2.tgz",
-      "integrity": "sha512-pweL2Ri2wqMY+wlW/wpkl8T3CUzKAha8S9nmiQlMABab8r5MJN0PD1V4YyRNVaKQfeh4Z0+VO70TLw6ESVOYzw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
+      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
       "requires": {
         "d3-time": "1"
       }
@@ -19584,9 +19584,9 @@
       "dev": true
     },
     "math-expression-evaluator": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-      "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz",
+      "integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ=="
     },
     "md5": {
       "version": "2.2.1",
@@ -23267,21 +23267,28 @@
       }
     },
     "recharts": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.6.2.tgz",
-      "integrity": "sha512-NqVN8Hq5wrrBthTxQB+iCnZjup1dc+AYRIB6Q9ck9UjdSJTt4PbLepGpudQEYJEN5iIpP/I2vThC4uiTJa7xUQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.8.5.tgz",
+      "integrity": "sha512-tM9mprJbXVEBxjM7zHsIy6Cc41oO/pVYqyAsOHLxlJrbNBuLs0PHB3iys2M+RqCF0//k8nJtZF6X6swSkWY3tg==",
       "requires": {
         "classnames": "^2.2.5",
-        "core-js": "^2.5.1",
+        "core-js": "^2.6.10",
         "d3-interpolate": "^1.3.0",
         "d3-scale": "^2.1.0",
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.5",
         "prop-types": "^15.6.0",
         "react-resize-detector": "^2.3.0",
-        "react-smooth": "^1.0.0",
+        "react-smooth": "^1.0.5",
         "recharts-scale": "^0.4.2",
         "reduce-css-calc": "^1.3.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        }
       }
     },
     "recharts-scale": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:shelley": "npm run dev:build -- --env 'shelley-testnet'",
     "dev:nightly": "npm run dev:build -- --env 'shelley-testnet' --nightly",
     "dev:mock-backend": "babel-node scripts/startWithMockServer.js",
-    "prod:build": "rimraf build/ && babel-node scripts/build --type=prod",
+    "prod:build": "rimraf build/ && NODE_ENV=production babel-node scripts/build --type=prod",
     "prod:compress": "babel-node scripts/compress",
     "prod:unsigned": "npm run prod:build -- --env ${CARDANO_NETWORK:-testnet} && npm run prod:compress -- --env ${CARDANO_NETWORK:-testnet} --app-id yoroi-${CARDANO_NETWORK:-testnet} --zip-only --codebase https://yoroiwallet.com/dw/yoroi-${CARDANO_NETWORK:-testnet}-extension.crx",
     "prod:nightly": "npm run prod:build -- --env 'shelley-testnet' --nightly && npm run -s prod:compress -- --env 'shelley-testnet' --app-id 'yoroi-nightly' --zip-only --codebase 'https://yoroiwallet.com/dw/yoroi-nightly-extension.crx' --key \"'${YOROI_NIGHTLY_PEM:-./nightly-key.pem}'\"",
@@ -37,6 +37,7 @@
     "translations:manage": "node ./translations/translation-runner.js",
     "translations:purge": "rimraf ./translations/messages",
     "storybook:watch": "NODE_ENV=storybook start-storybook -p 6006",
+    "storybook:build": "NODE_ENV=storybook build-storybook",
     "storybook:screenshots": "rimraf ./__screenshots__/ && storycap http://localhost:6006",
     "storybook:publish": "npm run storybook:build && netlify deploy --dir=storybook-static --prod"
   },

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "react-polymorph": "git+https://github.com/rcmorano/react-polymorph-fix.git",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
-    "recharts": "1.6.2",
+    "recharts": "1.8.5",
     "ringbufferjs": "1.1.0",
     "route-parser": "0.0.5",
     "semver": "7.1.3",

--- a/webpack/commonConfig.js
+++ b/webpack/commonConfig.js
@@ -51,7 +51,7 @@ const plugins = (folder /*: string */, networkName /*: string */) => {
   ];
 };
 
-const rules = [
+const rules /*: boolean => Array<*> */ = (isDev) => [
   // Pdfjs Worker webpack config, reference to issue: https://github.com/mozilla/pdf.js/issues/7612#issuecomment-315179422
   {
     test: /pdf\.worker(\.min)?\.js$/,
@@ -67,7 +67,7 @@ const rules = [
         loader: 'css-loader',
         options: {
           importLoaders: 1,
-          sourceMap: true,
+          sourceMap: isDev,
           modules: {
             mode: 'local',
             localIdentName: '[name]__[local]___[hash:base64:5]',
@@ -91,7 +91,7 @@ const rules = [
       {
         loader: 'css-loader',
         options: {
-          sourceMap: true,
+          sourceMap: isDev,
           modules: {
             mode: 'global',
           },
@@ -110,7 +110,7 @@ const rules = [
         loader: 'css-loader',
         options: {
           importLoaders: 1,
-          sourceMap: true,
+          sourceMap: isDev,
           modules: {
             mode: 'local',
             localIdentName: '[name]_[local]',

--- a/webpack/devConfig.js
+++ b/webpack/devConfig.js
@@ -53,7 +53,6 @@ const baseDevConfig = (
     ...commonConfig.plugins('dev', networkName),
     new webpack.DefinePlugin(commonConfig.definePlugin(networkName, false, isNightly)),
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoEmitOnErrorsPlugin(),
     new webpack.IgnorePlugin(/[^/]+\/[\S]+.prod$/),
     new webpack.DefinePlugin({
       __HOST__: `'${host}'`,

--- a/webpack/devConfig.js
+++ b/webpack/devConfig.js
@@ -62,7 +62,7 @@ const baseDevConfig = (
   ],
   module: {
     rules: [
-      ...commonConfig.rules,
+      ...commonConfig.rules(true),
       {
         test: /\.js$/,
         loader: 'babel-loader?cacheDirectory',

--- a/webpack/prodConfig.js
+++ b/webpack/prodConfig.js
@@ -44,7 +44,6 @@ const baseProdConfig = (env /*: EnvParams */) => ({
       true,
       JSON.parse(env.nightly)
     )),
-    new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.IgnorePlugin(/[^/]+\/[\S]+.dev$/),
   ],
   module: {

--- a/webpack/prodConfig.js
+++ b/webpack/prodConfig.js
@@ -49,7 +49,7 @@ const baseProdConfig = (env /*: EnvParams */) => ({
   ],
   module: {
     rules: [
-      ...commonConfig.rules,
+      ...commonConfig.rules(false),
       {
         test: /\.js$/,
         loader: 'babel-loader',


### PR DESCRIPTION
A few different things in this:

1) Adds `localhost` as a prefix to the `uriTemplate` in storybook to make sure loading Seiza fails in storybook builds even when hosted on different websites (relative path made it try to load Seiza URLs relative to whatever host we use)

2) Document the CSP policy for awareness

3) Properly specify `production` on production builds. Makes the build more optimized and removes a bunch of hot reload stuff that was getting included in production builds.

4) Bumps `recharts` to fix an issue with one of its dependencies

5) Don't build sourcemaps for CSS on production builds (in practice I don't think this makes any impact)

6) Removes `OccurrenceOrderPlugin` and `NoEmitOnErrorsPlugin` which were only required for hot-reload on old versions of Webpack

TODO: possibly update dom-walk if my PR gets accepted there