### PR TITLE
Improve debugging of migration

### DIFF
--- a/app/api/ada/lib/storage/adaMigration.js
+++ b/app/api/ada/lib/storage/adaMigration.js
@@ -46,6 +46,7 @@ export async function migrateToLatest(
   localStorageApi: LocalStorageApi,
   persistentDb: lf$Database,
 ): Promise<boolean> {
+  // recall: last launch was only added in Yoroi 1.4.0 and returns 0.0.0 before that
   let lastLaunchVersion = await localStorageApi.getLastLaunchVersion();
   Logger.info(`Starting migration for ${lastLaunchVersion}`);
   /**

--- a/app/api/ada/lib/storage/database/index.js
+++ b/app/api/ada/lib/storage/database/index.js
@@ -140,18 +140,13 @@ export async function importOldDb(
   // we need to delete the database before we import
   // because indexedDB uses schema versions
   // and you can't import an old schema.
-  console.log(1);
   await oldDb.delete();
-  console.log(2);
   const schemaBuilder = schema.create(data.name, data.version);
-  console.log(3);
 
   const db = await schemaBuilder.connect({
     storeType: schema.DataStoreType.INDEXED_DB,
   });
-  console.log(4);
   await db.import(data);
-  console.log(5);
 
   return db;
 }

--- a/app/api/ada/lib/storage/database/index.js
+++ b/app/api/ada/lib/storage/database/index.js
@@ -35,9 +35,10 @@ import environment from '../../../../../environment';
 
 // global var from window.indexedDB
 declare var indexedDB: IDBFactory;
+const schemaName = 'yoroi-schema';
 
 const deleteDb = () => new Promise(resolve => {
-  const deleteRequest = indexedDB.deleteDatabase('yoroi-schema');
+  const deleteRequest = indexedDB.deleteDatabase(schemaName);
   deleteRequest.onsuccess = () => resolve();
   deleteRequest.onerror = () => resolve();
 });
@@ -131,23 +132,26 @@ export const loadLovefieldDB = async (
   return db;
 };
 
-const schemaName = 'yoroi-schema';
-
 /** deletes the old database and returns the new database to use */
 export async function importOldDb(
+  oldDb: lf$Database,
   data: lf$lovefieldExport,
 ): Promise<lf$Database> {
   // we need to delete the database before we import
   // because indexedDB uses schema versions
   // and you can't import an old schema.
-  await deleteDb();
+  console.log(1);
+  await oldDb.delete();
+  console.log(2);
   const schemaBuilder = schema.create(data.name, data.version);
+  console.log(3);
 
   const db = await schemaBuilder.connect({
     storeType: schema.DataStoreType.INDEXED_DB,
-    onUpgrade,
   });
+  console.log(4);
   await db.import(data);
+  console.log(5);
 
   return db;
 }

--- a/app/api/ada/lib/storage/database/index.js
+++ b/app/api/ada/lib/storage/database/index.js
@@ -179,6 +179,7 @@ async function onUpgrade(
   rawDb: lf$raw$BackStore,
 ): Promise<void> {
   const version = rawDb.getVersion();
+  console.log(`Starting IndexedDB migration for version ${version}`);
   if (version === 0) {
     // defaults to 0 when first time launching ever
     return;

--- a/app/api/common/index.js
+++ b/app/api/common/index.js
@@ -36,7 +36,6 @@ import type {
   GetBalanceRequest, GetBalanceResponse,
 } from './types';
 import LocalStorageApi from '../localStorage/index';
-import { clear } from '../ada/lib/storage/database/index';
 import type {
   IRenameFunc, IRenameRequest, IRenameResponse,
   IChangePasswordRequestFunc, IChangePasswordRequest, IChangePasswordResponse,
@@ -224,14 +223,6 @@ export default class CommonApi {
       localstorageApi,
       persistentDb,
     );
-  }
-
-  async importLocalDatabase(
-    db: lf$Database,
-    data: {...},
-  ): Promise<void> {
-    await clear(db);
-    await db.import(data);
   }
 
   async exportLocalDatabase(

--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -98,7 +98,9 @@ export default class LoadingStore extends Store {
   importOldDatabase: (
     lf$lovefieldExport,
   ) => Promise<void> = async (data) => {
-    await importOldDb(data);
+    const db = this.loadPersistentDbRequest.result;
+    if (db == null) throw new Error(`${nameof(this.importOldDatabase)} db not loaded yet`);
+    await importOldDb(db, data);
     window.location.reload();
   }
 

--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -1,5 +1,5 @@
 // @flow
-import type { lf$Database, } from 'lovefield';
+import type { lf$Database, lf$lovefieldExport, } from 'lovefield';
 import { schema, } from 'lovefield';
 import { action, observable, computed, when, runInAction } from 'mobx';
 import { pathToRegexp } from 'path-to-regexp';
@@ -16,13 +16,12 @@ import type { MigrationRequest } from '../../api';
 import { migrate } from '../../api';
 import { Logger, stringifyError } from '../../utils/logging';
 import { closeOtherInstances } from '../../utils/tabManager';
-import { loadLovefieldDB, } from '../../api/ada/lib/storage/database/index';
+import { loadLovefieldDB, importOldDb, } from '../../api/ada/lib/storage/database/index';
 import { tryAddressToKind } from '../../api/ada/lib/storage/bridge/utils';
 import { CoreAddressTypes } from '../../api/ada/lib/storage/database/primitives/enums';
 import { ApiOptions, getApiMeta } from '../../api/common/utils';
 import { isWithinSupply } from '../../utils/validations';
 import { networks } from '../../api/ada/lib/storage/database/prepackaged/networks';
-
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
 /** Load dependencies before launching the app */
@@ -94,6 +93,13 @@ export default class LoadingStore extends Store {
           });
         }
       });
+  }
+
+  importOldDatabase: (
+    lf$lovefieldExport,
+  ) => Promise<void> = async (data) => {
+    await importOldDb(data);
+    window.location.reload();
   }
 
   @computed get isLoading(): boolean {

--- a/app/stores/toplevel/WalletSettingsStore.js
+++ b/app/stores/toplevel/WalletSettingsStore.js
@@ -234,9 +234,13 @@ export default class WalletSettingsStore extends Store {
         : undefined
     }).promise;
     // note: it's possible some other function was waiting for a DB lock
-    // and so it may fail if it runs now since underlying data was deleted
-    // to avoid this causing an issue, we just refresh the page
+    //       and so it may fail if it runs now since underlying data was deleted
+    //       to avoid this causing an issue, we just refresh the page
     // note: redirect logic will handle going to the right page after reloading
+    // note: there is a slight gap between the removeWallet releasing the DB lock
+    //       and actually reloading the page.
+    //       theoretically, a crash could happen in between these
+    //       but the chance is low and we need to release the DB lock to commit the deletion
     window.location.reload();
   };
 }

--- a/features/migration.feature
+++ b/features/migration.feature
@@ -23,7 +23,7 @@ Feature: Migration
     And Last launch version is updated
 
   @it-85
-  Scenario Outline: Version set on first launch (IT-85)
+  Scenario Outline: Upgrade from first version ever (IT-85)
     Then I am on the language selection screen
     # make sure all major functionality work
     # even if user hasn't launched Yoroi since the very first version
@@ -60,3 +60,25 @@ Feature: Migration
     Examples:
       | amount              | fee       |
       | 1.000000            | 0.168801  |
+
+  @it-116
+  Scenario: Upgrade from version that adds bip44 support (IT-116)
+    Then I am on the language selection screen
+    # make sure all major functionality work
+    # even if user hasn't launched Yoroi since the very first version
+    Given I import a snapshot named historical-versions/1_4_0/software
+    Then I accept uri registration
+    Then I should see the summary screen
+    Then I should see a plate EDAO-9229
+    # make sure tx screen is right
+    When I see the transactions summary
+    Then I should see that the number of transactions is 1
+    And I should see 1 successful transactions
+    # make sure receive screen is right
+    And I go to the receive screen
+    And I should see the addresses exactly list them
+    | address                                                     |
+    | Ae2tdPwUPEZB9632b4TZwNoVAhCAFaHD5DZhbanUJyYPoP6kJxJpNcaAaQU |
+    | Ae2tdPwUPEZ8jH9Me4vbUFwpjUmNxmW34MfEi3HsiNuQPYn5sDU9V53rJFc |
+    | Ae2tdPwUPEYwqhm4h1XJ1YkKhYY4tgymXmGLA1UoRySc8zTG2wAfbBijXz3 |
+    | Ae2tdPwUPEYx2dK1AMzRN1GqNd2eY7GCd7Z6aikMPJL3EkqqugoFQComQnV |

--- a/features/migration.feature
+++ b/features/migration.feature
@@ -28,7 +28,7 @@ Feature: Migration
     # make sure all major functionality work
     # even if user hasn't launched Yoroi since the very first version
     Given I import a snapshot named historical-versions/1_0_4/software
-    Then I select the most complex level simplest level
+    Then I select the most complex level
     Then I accept uri registration
     Then I should see the summary screen
     Then I should see a plate EDAO-9229
@@ -61,12 +61,13 @@ Feature: Migration
       | amount              | fee       |
       | 1.000000            | 0.168801  |
 
-  @it-116
-  Scenario: Upgrade from version that adds bip44 support (IT-116)
+  @it-140
+  Scenario: Upgrade from version that adds bip44 support (IT-140)
     Then I am on the language selection screen
     # make sure all major functionality work
     # even if user hasn't launched Yoroi since the very first version
     Given I import a snapshot named historical-versions/1_4_0/software
+    Then I select the most complex level
     Then I accept uri registration
     Then I should see the summary screen
     Then I should see a plate EDAO-9229

--- a/features/step_definitions/common-steps.js
+++ b/features/step_definitions/common-steps.js
@@ -403,12 +403,11 @@ async function importIndexedDB(client, importDir: string) {
     return;
   }
   await client.driver.executeAsyncScript((data, done) => {
-    window.yoroi.api.common.importLocalDatabase(
-      window.yoroi.stores.loading.loadPersitentDbRequest.result,
+    window.yoroi.stores.loading.importLocalDatabase(
       data
     )
       .then(done)
-      .catch(err => { console.log(err); throw err; });
+      .catch(err => done(err));
   }, JSON.parse(indexedDBData));
 }
 

--- a/features/step_definitions/common-steps.js
+++ b/features/step_definitions/common-steps.js
@@ -168,6 +168,10 @@ async function inputMnemonicForWallet(
   await customWorld.waitUntilText('.NavPlate_name', truncateLongName(walletName));
 }
 
+Then(/^I pause the test to debug$/, async function () {
+  await this.waitForElement('.element_that_does_not_exist');
+});
+
 Given(/^There is a Shelley wallet stored named ([^"]*)$/, async function (walletName) {
   const restoreInfo = testWallets[walletName];
   expect(restoreInfo).to.not.equal(undefined);
@@ -390,17 +394,22 @@ async function importLocalStorage(client, importDir: string) {
 
 async function importIndexedDB(client, importDir: string) {
   const indexedDBPath = `${importDir}/indexedDB.json`;
+
+  let indexedDBData;
   try {
-    const indexedDBData = fs.readFileSync(indexedDBPath).toString();
-    await client.driver.executeAsyncScript((data, done) => {
-      window.yoroi.api.common.importLocalDatabase(
-        window.yoroi.stores.loading.loadPersistentDbRequest.result,
-        data
-      )
-        .then(done)
-        .catch(err => done(err));
-    }, JSON.parse(indexedDBData));
-  } catch (e) {} // eslint-disable-line no-empty
+    // some tests check for behavior based on local storage only and don't require IndexedDb
+    indexedDBData = fs.readFileSync(indexedDBPath).toString();
+  } catch (e) {
+    return;
+  }
+  await client.driver.executeAsyncScript((data, done) => {
+    window.yoroi.api.common.importLocalDatabase(
+      window.yoroi.stores.loading.loadPersitentDbRequest.result,
+      data
+    )
+      .then(done)
+      .catch(err => { console.log(err); throw err; });
+  }, JSON.parse(indexedDBData));
 }
 
 let capturedDbState = undefined;

--- a/features/step_definitions/common-steps.js
+++ b/features/step_definitions/common-steps.js
@@ -403,7 +403,7 @@ async function importIndexedDB(client, importDir: string) {
     return;
   }
   await client.driver.executeAsyncScript((data, done) => {
-    window.yoroi.stores.loading.importLocalDatabase(
+    window.yoroi.stores.loading.importOldDatabase(
       data
     )
       .then(done)

--- a/features/step_definitions/general-settings-steps.js
+++ b/features/step_definitions/general-settings-steps.js
@@ -56,7 +56,7 @@ Then(/^The selected level is "([^"]*)"$/, async function (level) {
   await this.waitUntilText('.currentLevel', level.toUpperCase());
 });
 
-Then(/^I select the most complex level simplest level$/, async function () {
+Then(/^I select the most complex level$/, async function () {
   await this.waitForElement('.ComplexityLevelForm_submitButton');
   const levels = await this.driver.findElements(By.css('.ComplexityLevelForm_submitButton'));
   await levels[levels.length - 1].click(); // choose most complex level for tests

--- a/features/yoroi_snapshots/historical-versions/1_0_4/software/indexedDB.json
+++ b/features/yoroi_snapshots/historical-versions/1_0_4/software/indexedDB.json
@@ -1,0 +1,581 @@
+{
+	"name": "yoroi-schema",
+	"version": 1,
+	"tables": {
+		"Txs": [],
+		"Addresses": [{
+			"id": "Ae2tdPwUPEYx2dK1AMzRN1GqNd2eY7GCd7Z6aikMPJL3EkqqugoFQComQnV",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYx2dK1AMzRN1GqNd2eY7GCd7Z6aikMPJL3EkqqugoFQComQnV",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 0
+			}
+		}, {
+			"id": "Ae2tdPwUPEYwqhm4h1XJ1YkKhYY4tgymXmGLA1UoRySc8zTG2wAfbBijXz3",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYwqhm4h1XJ1YkKhYY4tgymXmGLA1UoRySc8zTG2wAfbBijXz3",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 1
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ8jH9Me4vbUFwpjUmNxmW34MfEi3HsiNuQPYn5sDU9V53rJFc",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ8jH9Me4vbUFwpjUmNxmW34MfEi3HsiNuQPYn5sDU9V53rJFc",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 2
+			}
+		}, {
+			"id": "Ae2tdPwUPEZB9632b4TZwNoVAhCAFaHD5DZhbanUJyYPoP6kJxJpNcaAaQU",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZB9632b4TZwNoVAhCAFaHD5DZhbanUJyYPoP6kJxJpNcaAaQU",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 3
+			}
+		}, {
+			"id": "Ae2tdPwUPEYyBqQPRPXZ4jnA5CfDwaN69pWMVDQfWtCDjNN536YMSCQuhoE",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYyBqQPRPXZ4jnA5CfDwaN69pWMVDQfWtCDjNN536YMSCQuhoE",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 4
+			}
+		}, {
+			"id": "Ae2tdPwUPEZLDoMwgk5as7qJLqSMFCd9WzGrayGw7EvpbcRveanbDzPu8ji",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZLDoMwgk5as7qJLqSMFCd9WzGrayGw7EvpbcRveanbDzPu8ji",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 5
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ6c5ifXBqJzMpEH79rEYUKAd8Nq8qkLWW2ZMC2cVtNYpy3oHi",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ6c5ifXBqJzMpEH79rEYUKAd8Nq8qkLWW2ZMC2cVtNYpy3oHi",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 6
+			}
+		}, {
+			"id": "Ae2tdPwUPEZBPFaDHQHfdLTRvk5gNpfN8WN3tidZFC5NWPa8mnb98TmzuQu",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZBPFaDHQHfdLTRvk5gNpfN8WN3tidZFC5NWPa8mnb98TmzuQu",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 7
+			}
+		}, {
+			"id": "Ae2tdPwUPEZK6z7VnGXwX3M38UbJ1vdCLMxG9i3UHun9CQKf81LZRcZU8Vv",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZK6z7VnGXwX3M38UbJ1vdCLMxG9i3UHun9CQKf81LZRcZU8Vv",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 8
+			}
+		}, {
+			"id": "Ae2tdPwUPEZG2dUqHJPRqHvVhCk6kNhTCbVZpwFvcRQXfwQptJKydHQkuLX",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZG2dUqHJPRqHvVhCk6kNhTCbVZpwFvcRQXfwQptJKydHQkuLX",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 9
+			}
+		}, {
+			"id": "Ae2tdPwUPEZKNa3MrV4HSecSMvy6nL1zEaAgZaB8Ay65bpttBXfQ58FDGNz",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZKNa3MrV4HSecSMvy6nL1zEaAgZaB8Ay65bpttBXfQ58FDGNz",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 10
+			}
+		}, {
+			"id": "Ae2tdPwUPEYyDhnfE2KNL6aZgQ3CWgdBcSZuRX95V2QkMNKRYRyzeyV2u97",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYyDhnfE2KNL6aZgQ3CWgdBcSZuRX95V2QkMNKRYRyzeyV2u97",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 11
+			}
+		}, {
+			"id": "Ae2tdPwUPEYyD234GE7NYv1fM6NuKzHcw6nhN1znwnuzQoeddB2BtrFB9CR",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYyD234GE7NYv1fM6NuKzHcw6nhN1znwnuzQoeddB2BtrFB9CR",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 12
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ1tzFmVkFpcU4Cp7nzxsmaTZ4q9uQySvg8vRM7GKSCHNQBm8z",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ1tzFmVkFpcU4Cp7nzxsmaTZ4q9uQySvg8vRM7GKSCHNQBm8z",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 13
+			}
+		}, {
+			"id": "Ae2tdPwUPEZFmiKViAhbQf6UNwXbqLYqX69m1WpckVutU1fE3TDWSAR5skH",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZFmiKViAhbQf6UNwXbqLYqX69m1WpckVutU1fE3TDWSAR5skH",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 14
+			}
+		}, {
+			"id": "Ae2tdPwUPEZFQnBCd8ksX3gEw4nngVzPA49WvyBYUN9vAp2Px4fwW1bGqnQ",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZFQnBCd8ksX3gEw4nngVzPA49WvyBYUN9vAp2Px4fwW1bGqnQ",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 15
+			}
+		}, {
+			"id": "Ae2tdPwUPEZNA4uwtFjtr3ijF9nmHnvTWWzr7nM2nQLchieh2ktw6Re2zfK",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZNA4uwtFjtr3ijF9nmHnvTWWzr7nM2nQLchieh2ktw6Re2zfK",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 16
+			}
+		}, {
+			"id": "Ae2tdPwUPEZNM43x2gF7GsgD3oHYRKKpaKkVNXfeB3GMprbqdq663xziRrp",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZNM43x2gF7GsgD3oHYRKKpaKkVNXfeB3GMprbqdq663xziRrp",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 17
+			}
+		}, {
+			"id": "Ae2tdPwUPEYzQDVaWXsyZ6bxMRmhUvPgQxR3kmz3kHWgYpKbYAgvJbx4UgP",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYzQDVaWXsyZ6bxMRmhUvPgQxR3kmz3kHWgYpKbYAgvJbx4UgP",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 18
+			}
+		}, {
+			"id": "Ae2tdPwUPEZKFp9HiCZtjddZNiYmqkCjMAPFkxJyZ7KEFLqgNRTgDry6DVz",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZKFp9HiCZtjddZNiYmqkCjMAPFkxJyZ7KEFLqgNRTgDry6DVz",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 19
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ5MSivgBzeEHcKDXfxhESgUgeDz9Yjamb4z5nLixDg6NJfxEN",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ5MSivgBzeEHcKDXfxhESgUgeDz9Yjamb4z5nLixDg6NJfxEN",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 20
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ6gEQGmmdVfxc9ezQjdREcdsSDMK7aVXgQRDP9dnXu2NpvtPM",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ6gEQGmmdVfxc9ezQjdREcdsSDMK7aVXgQRDP9dnXu2NpvtPM",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 21
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ6gEQGmmdVfxc9ezQjdREcdsSDMK7aVXgQRDP9dnXu2NpvtPM",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ6gEQGmmdVfxc9ezQjdREcdsSDMK7aVXgQRDP9dnXu2NpvtPM",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 22
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ9zFrm3tDW7vLUYS9BoLAJUjnoWKKRf9WKXV5fowsuZyNEdji",
+			"type": "External",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ9zFrm3tDW7vLUYS9BoLAJUjnoWKKRf9WKXV5fowsuZyNEdji",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 0,
+				"index": 23
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ9poP7YtDsbc5XGDsnhpRzuuLr71YCyqPt2ASgah8fNXC8kJR",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ9poP7YtDsbc5XGDsnhpRzuuLr71YCyqPt2ASgah8fNXC8kJR",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 24
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ5rztvUbgShhYvhYK8Pvc64JdZVk1xpGZFtRFuxMrRSaZ2njp",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ5rztvUbgShhYvhYK8Pvc64JdZVk1xpGZFtRFuxMrRSaZ2njp",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 1
+			}
+		}, {
+			"id": "Ae2tdPwUPEYxZg7jStmYTTyqq2J5XZuL15yLsnN2r7YizxzYDYYDVAGth8s",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYxZg7jStmYTTyqq2J5XZuL15yLsnN2r7YizxzYDYYDVAGth8s",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 2
+			}
+		}, {
+			"id": "Ae2tdPwUPEZMadc7nSvi2QTKCFXr3BxmsSbQ7rEXrCGoV8jVJTFZpGqSZ2Q",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZMadc7nSvi2QTKCFXr3BxmsSbQ7rEXrCGoV8jVJTFZpGqSZ2Q",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 3
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ65tCAaRB6h3MnJhsUh4nn4R7bUJe9S49tFcew6cjbhJFE7kV",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ65tCAaRB6h3MnJhsUh4nn4R7bUJe9S49tFcew6cjbhJFE7kV",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 4
+			}
+		}, {
+			"id": "Ae2tdPwUPEYwVZkgyLcL4m8Pvy2pm1bF9fESicmY5TJQWGxK6vFGS1121b5",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYwVZkgyLcL4m8Pvy2pm1bF9fESicmY5TJQWGxK6vFGS1121b5",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 5
+			}
+		}, {
+			"id": "Ae2tdPwUPEYysBd4G5T2hQVbWjyRx86rcqJaouHRwQimWD75HL2uMcKTXPw",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYysBd4G5T2hQVbWjyRx86rcqJaouHRwQimWD75HL2uMcKTXPw",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 6
+			}
+		}, {
+			"id": "Ae2tdPwUPEZDZcHsJ9zP5Es7U9C2gVBLTnwwLdYEn5fXtGAfbn8PvRLMNSW",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZDZcHsJ9zP5Es7U9C2gVBLTnwwLdYEn5fXtGAfbn8PvRLMNSW",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 7
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ39EMkiJfLS8NTmTNjcX1pt76EuoWWzBocfpDkMpkDbq3XNiW",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ39EMkiJfLS8NTmTNjcX1pt76EuoWWzBocfpDkMpkDbq3XNiW",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 8
+			}
+		}, {
+			"id": "Ae2tdPwUPEZJoQaVLYrxkjqqGKau7kThsnjnjWiyHpZMRNgZKHNLsG1oQrx",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZJoQaVLYrxkjqqGKau7kThsnjnjWiyHpZMRNgZKHNLsG1oQrx",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 9
+			}
+		}, {
+			"id": "Ae2tdPwUPEZBMSdjaHv8wfUSBMT7L6DQLFt7ziQEBzYufVyjtx9io2SdmAE",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZBMSdjaHv8wfUSBMT7L6DQLFt7ziQEBzYufVyjtx9io2SdmAE",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 10
+			}
+		}, {
+			"id": "Ae2tdPwUPEZJw8pyKMjdKPE7qTyeVDDv3J8M5C8y5VcV5k7t9ebuJRQPUjP",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZJw8pyKMjdKPE7qTyeVDDv3J8M5C8y5VcV5k7t9ebuJRQPUjP",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 11
+			}
+		}, {
+			"id": "Ae2tdPwUPEYyYqRnAAtR2vJ4qbLNJGkjQxYcyHhrAnx7sjTW51TaCfpGqqL",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEYyYqRnAAtR2vJ4qbLNJGkjQxYcyHhrAnx7sjTW51TaCfpGqqL",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 12
+			}
+		}, {
+			"id": "Ae2tdPwUPEZNFhejg6xH5sR9G5FmJukPMXDzpSTbhL3BoxdGJ1uww6JXmA3",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZNFhejg6xH5sR9G5FmJukPMXDzpSTbhL3BoxdGJ1uww6JXmA3",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 13
+			}
+		}, {
+			"id": "Ae2tdPwUPEZBGBtFyH7shMs3JassiAmyyaCdeiZK6eGPFr4mGNjFhFrSRzJ",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZBGBtFyH7shMs3JassiAmyyaCdeiZK6eGPFr4mGNjFhFrSRzJ",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 14
+			}
+		}, {
+			"id": "Ae2tdPwUPEZL2aV78FnKTX3h57fJey4HNLN41nnThZ9PEhhW7RUkudotgJp",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZL2aV78FnKTX3h57fJey4HNLN41nnThZ9PEhhW7RUkudotgJp",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 15
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ1aSQcvxkjztJNiBHkKQTe7qAKM1Cfa9oZLf1uhgNSX5UPVQz",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ1aSQcvxkjztJNiBHkKQTe7qAKM1Cfa9oZLf1uhgNSX5UPVQz",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 16
+			}
+		}, {
+			"id": "Ae2tdPwUPEZGoWKTtgbieyQhLrqB4towV38uig94U6mbiBBpKNj297HQU2Q",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZGoWKTtgbieyQhLrqB4towV38uig94U6mbiBBpKNj297HQU2Q",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 17
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ2HHU7fNgeTQx8NYVAWduQ1GagMtkX8mpQrhnf2mXpoCYiEqY",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ2HHU7fNgeTQx8NYVAWduQ1GagMtkX8mpQrhnf2mXpoCYiEqY",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 18
+			}
+		}, {
+			"id": "Ae2tdPwUPEZ4ktKQUMMFNVYhx43rUEaa4x9mFyWD7Ja9P7SbHaTteNWPekS",
+			"type": "Internal",
+			"value": {
+				"cadAmount": {
+					"getCCoin": "0"
+				},
+				"cadId": "Ae2tdPwUPEZ4ktKQUMMFNVYhx43rUEaa4x9mFyWD7Ja9P7SbHaTteNWPekS",
+				"cadIsUsed": false,
+				"account": 0,
+				"change": 1,
+				"index": 19
+			}
+		}],
+		"TxAddresses": []
+	}
+}

--- a/features/yoroi_snapshots/historical-versions/1_4_0/software/localStorage.json
+++ b/features/yoroi_snapshots/historical-versions/1_4_0/software/localStorage.json
@@ -1,8 +1,8 @@
 {
-	"ACCOUNT": "{\"account\":0,\"root_cached_key\":\"b2938f29eb965952b03baaf010b0f5fe4a2c116a1e255274c9ace24deb72450ce1c045821c42ed11b33db3124b1551793e76b8ad187efb92b28969b92bb95964\",\"derivation_scheme\":\"V2\"}",
+	"ACCOUNT": "{\"account\":0,\"root_cached_key\":\"379781925856984b0938cfab3b847323cf4e5c784a56bc045e9e23e2ee60114bd039a78aa4e2021b08cdb89fdb56e9c3c05c93be40a002bf541b2ed408cb1e9b\",\"derivation_scheme\":\"V2\"}",
 	"test-TERMS-OF-USE-ACCEPTANCE": "true",
 	"LAST_BLOCK_NUMBER": "2917185",
 	"test-USER-LOCALE": "en-US",
-	"WALLET": "{\"adaWallet\":{\"cwAccountsNumber\":1,\"cwAmount\":{\"getCCoin\":\"4300447\"},\"cwId\":\"1\",\"cwMeta\":{\"cwAssurance\":\"CWANormal\",\"cwName\":\"Wallet\",\"cwUnit\":0},\"cwType\":\"CWTWeb\",\"cwPassphraseLU\":\"2019-07-31T15:50:53+03:00\"},\"masterKey\":\"95ea8677964056c827f1c47cfbfd0e1a9155df9c54286d307c4d4949320fee8e73200e23fcdaaa351621cf2d516eab90c26325f7ba48e20e1ea1feeb286a52e367976636ef654c43dc557b614dcbd9a21f0d92f8733c830b002ae8d175e4dd9d64ffa133a32a95d327b352ededcc1c59ce91dda8daec43c046ff8e021bc24267edc3618a591170d6e5f18c8ae91ec13ffe6a5d3e5ca9e15e93cc0c7d\",\"lastReceiveAddressIndex\":142}",
+	"WALLET": "{\"adaWallet\":{\"cwAccountsNumber\":1,\"cwAmount\":{\"getCCoin\":\"4300447\"},\"cwId\":\"1\",\"cwMeta\":{\"cwAssurance\":\"CWANormal\",\"cwName\":\"Wallet\",\"cwUnit\":0},\"cwType\":\"CWTWeb\",\"cwPassphraseLU\":\"2019-07-31T15:50:53+03:00\"},\"masterKey\":\"074976c245d6bbed70eae053adb91e295e601bf3fa8d9373ab5df79b09d80d296eceb0b74d4e394339982f37f327a3f4d6f121f40548f3ce65e11b8d0b79352d0c25bb739065ec728c87c8e964139200b0a3a3769281eb9bc74bb0c387ce0d6bf07d44ffd203ee56dfbd577ba84fa4c70f60e7458fffda0f0ff17f4ed3adbfa3570642672782eb5f514f2261ee12c642d45c856fd671244b1115a21d\",\"lastReceiveAddressIndex\":3}",
 	"test-LAST-LAUNCH-VER": "1.4.0"
 }

--- a/flow-typed/npm/lovefield_v2.x.x.js
+++ b/flow-typed/npm/lovefield_v2.x.x.js
@@ -7,6 +7,11 @@
  */
 
 declare module 'lovefield' {
+  declare type lf$lovefieldExport = {|
+    name: string,
+    version: number,
+    tables: {| [key: string]: Array<Object> |},
+  |}
   declare var lf: typeof npm$namespace$lf;
 
   declare var npm$namespace$lf: {
@@ -111,8 +116,8 @@ declare module 'lovefield' {
     delete(): lf$query$Delete;
     declare(): Promise<Object>;
     getSchema(): lf$schema$Database;
-    import(data: Object): Promise<void>;
-    export(): Promise<Object>;
+    import(data: lf$lovefieldExport): Promise<void>;
+    export(): Promise<lf$lovefieldExport>;
     insertOrReplace(): lf$query$Insert;
     insert(): lf$query$Insert;
     observe(query: lf$query$Select, callback: Function): void;


### PR DESCRIPTION
I noticed our tests for upgrading IndexedDB don't work anymore. These tests were historically not as important (and was even removed and left unused until now) because for Byron all IndexedDB state was derived from the local storage so it wasn't strictly necessary. Now that this is no longer the case, it'd be nice to bring these tests back but they no longer work because it wasn't compatible with IndexedDB's internal migration system (DB versioning).

You can tell by running test @IT-85 and checking the console error and you'll see the IndexedDB error https://google.github.io/lovefield/error_lookup/src/error_lookup.html?c=111

We can try and improve this by injecting the IndexedDB state without having to open the extension but this may be trickier to implement and may be browser-specific. Will have to investigate.