### PR TITLE
Fix dropdown wallet switch on byron wallets

### DIFF
--- a/app/Routes.js
+++ b/app/Routes.js
@@ -170,6 +170,10 @@ const WalletsSubpages = (stores, actions) => (
         />
       </>)
     }
+    <Route
+      path={ROUTES.WALLETS.SWITCH}
+      component={(_props) => <></> /* this is a temporary state as the wallet is switching wallets. Faster than user can really notice or skipped entirely */}
+    />
     <Redirect to={ROUTES.WALLETS.TRANSACTIONS} />
   </Switch>
 );

--- a/features/step_definitions/main-ui-steps.js
+++ b/features/step_definitions/main-ui-steps.js
@@ -58,3 +58,18 @@ Then(/^I should see my balance hidden$/, async function () {
   await this.waitForElement('.NavWalletDetails_amount');
   await this.waitUntilContainsText('.NavWalletDetails_amount', '***');
 });
+
+Then(/^I switch to "([^"]*)" from the dropdown$/, async function (walletName) {
+  await this.click('.NavDropdown_toggle');
+  const wallets = await this.driver.findElements(By.xpath("//button[contains(@class, 'NavDropdownRow_head')]"));
+  for (const wallet of wallets) {
+    const nameElem = await wallet.findElement(By.css('.NavPlate_name'));
+    const foundName = await nameElem.getText();
+    console.log(foundName);
+    if (walletName === foundName) {
+      await wallet.click();
+      return;
+    }
+  }
+  throw new Error(`No wallet found with name ${walletName}`);
+});

--- a/features/wallet-restoration.feature
+++ b/features/wallet-restoration.feature
@@ -317,3 +317,16 @@ Feature: Restore Wallet
     # check removing didn't affect other wallets
     Then I compare to DB state snapshot
     And I should see the Create wallet screen
+
+  @it-117
+  Scenario: Switch wallets (IT-117)
+    # wallet 1
+    Given There is a wallet stored named many-tx-wallet
+    # prep adding 2nd wallet
+    Then I unselect the wallet
+    And I click to add an additional wallet
+    # wallet 2 (same as wallet 1)
+    Given There is a wallet stored named small-single-tx
+    # switch to wallet #1
+    Then I switch to "many-tx-wallet" from the dropdown
+    Then I should see the opened wallet with name "many-tx-wallet"


### PR DESCRIPTION
Switch wallets from the dropdown on Shelley works fine but for some reason in Byron it didn't work. It seems this is caused by some compiler optimization that just happens to trigger for Byron.
Need to fix it and add an E2E test for the fix