### PR TITLE
Just-in-time load Trezor iframe

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,7 @@ module.exports = {
     'no-plusplus': 0,
     'no-bitwise': 0,
     'no-underscore-dangle': 0,
-    'no-console': 0,
+    'no-console': 1,
     'no-mixed-operators': 0,
     'no-multi-assign': 0,
     'no-undef-init': 0, // need this to improve Flow type inference
@@ -101,8 +101,12 @@ module.exports = {
     'no-lone-blocks': 0,
     'max-classes-per-file': 0,
     'no-floating-promise/no-floating-promise': 2,
-    "flowtype/no-primitive-constructor-types": 2,
-    "flowtype/no-dupe-keys": 2,
+    'flowtype/no-primitive-constructor-types': 2,
+    'flowtype/no-dupe-keys': 2,
+    'no-restricted-properties': [
+      2,
+      { object: 'TrezorConnect', message: 'Use TrezorWrapper instead to minimize Trezor iframe lifespan', },
+    ],
   },
   plugins: [
     'import',

--- a/app/api/ada/lib/storage/database/utils.js
+++ b/app/api/ada/lib/storage/database/utils.js
@@ -184,6 +184,7 @@ export async function raii<T>(
     return result;
   } catch (e) {
     const tableNames = tables.map(table => table.getName()).join('\n');
+    // eslint-disable-next-line no-console
     console.error('rolling back Lovefield query for\n' + tableNames + ' with error ' + JSON.stringify(e));
     await tx.rollback();
     throw e;

--- a/app/stores/ada/HWVerifyAddressStore.js
+++ b/app/stores/ada/HWVerifyAddressStore.js
@@ -7,7 +7,7 @@ import {
 } from '../../utils/hwConnectHandler';
 
 import LedgerConnect from 'yoroi-extension-ledger-connect-handler';
-import TrezorConnect from 'trezor-connect';
+import { wrapWithFrame } from '../lib/TrezorWrapper';
 
 import LocalizableError from '../../i18n/LocalizableError';
 
@@ -88,10 +88,10 @@ export default class AddressesStore extends Store {
     address: string
   ): Promise<void> => {
     try {
-      await TrezorConnect.cardanoGetAddress({
+      await wrapWithFrame(trezor => trezor.cardanoGetAddress({
         path,
         address,
-      });
+      }));
     } catch (error) {
       Logger.error('AddressStore::trezorVerifyAddress::error: ' + stringifyError(error));
       this._setError(trezorErrorToLocalized(error));

--- a/app/stores/ada/TrezorSendStore.js
+++ b/app/stores/ada/TrezorSendStore.js
@@ -1,12 +1,12 @@
 // @flow
 import { action, observable } from 'mobx';
-import TrezorConnect from 'trezor-connect';
 import type { CardanoSignTransaction$ } from 'trezor-connect/lib/types/cardano';
 
 import Store from '../base/Store';
 import environment from '../../environment';
 import LocalizedRequest from '../lib/LocalizedRequest';
 
+import { wrapWithFrame } from '../lib/TrezorWrapper';
 import type {
   CreateTrezorSignTxDataFunc,
   BroadcastTrezorSignedTxResponse,
@@ -80,9 +80,9 @@ export default class TrezorSendStore extends Store {
 
       const trezorSignTxDataResp = await this.createTrezorSignTxDataRequest.promise;
 
-      const trezorSignTxResp = await TrezorConnect.cardanoSignTransaction(
+      const trezorSignTxResp = await wrapWithFrame(trezor => trezor.cardanoSignTransaction(
         { ...trezorSignTxDataResp.trezorSignTxPayload }
-      );
+      ));
 
       if (trezorSignTxResp && trezorSignTxResp.payload && trezorSignTxResp.payload.error != null) {
         // this Error will be converted to LocalizableError()

--- a/app/stores/lib/TrezorWrapper.js
+++ b/app/stores/lib/TrezorWrapper.js
@@ -1,0 +1,20 @@
+// @flow
+
+import TrezorConnect from 'trezor-connect';
+
+/* eslint-disable no-restricted-properties */
+
+// TODO: explain why we want this file
+
+export async function wrapWithFrame<T>(
+  func: (typeof TrezorConnect) => Promise<T>
+): Promise<T> {
+  await TrezorConnect.init({});
+  const result = await func(TrezorConnect);
+  await TrezorConnect.dispose();
+  return result;
+}
+
+export function wrapWithoutFrame<T>(func: (typeof TrezorConnect) => T): T {
+  return func(TrezorConnect);
+}

--- a/features/mock-chain/mockServer.js
+++ b/features/mock-chain/mockServer.js
@@ -182,6 +182,7 @@ export function getMockServer(
     installCoinPriceRequestHandlers(server);
 
     MockServer = server.listen(Ports.DevBackendServe, () => {
+      // eslint-disable-next-line no-console
       console.log(`JSON Server is running at ${Ports.DevBackendServe}`);
     });
   }

--- a/features/mock-trezor-connect/index.js
+++ b/features/mock-trezor-connect/index.js
@@ -17,13 +17,13 @@ import type {
 const UI_EVENT: 'UI_EVENT' = 'UI_EVENT';
 const DEVICE_EVENT: 'DEVICE_EVENT' = 'DEVICE_EVENT';
 
-class TrezorConnect {
+class MockTrezorConnect {
 
   static deviceEventListeners: Array<DeviceMessage => void> = [];
   static uiEventListeners: Array<UiMessage => void> = [];
 
   static cardanoGetAddress: CardanoGetAddress = async (_params) => {
-    TrezorConnect.mockConnectDevice();
+    MockTrezorConnect.mockConnectDevice();
     const result = ({
       success: (true: true),
       payload: {
@@ -36,7 +36,7 @@ class TrezorConnect {
   };
 
   static cardanoGetPublicKey: CardanoGetPublicKey = async (_params) => {
-    TrezorConnect.mockConnectDevice();
+    MockTrezorConnect.mockConnectDevice();
     const result = ({
       success: (true: true),
       payload: {
@@ -57,7 +57,7 @@ class TrezorConnect {
   };
 
   static cardanoSignTransaction: CardanoSignTransaction = async (_params) => {
-    TrezorConnect.mockConnectDevice();
+    MockTrezorConnect.mockConnectDevice();
     const result = ({
       success: (true: true),
       payload: {
@@ -72,6 +72,9 @@ class TrezorConnect {
   }
 
   static init = async (_settings: Settings): Promise<void> => {
+  }
+
+  static dispose = (): void => {
   }
 
   static on: EventListener = (type, fn): void => {
@@ -139,6 +142,6 @@ class TrezorConnect {
   }
 }
 
-export default TrezorConnect;
+export default MockTrezorConnect;
 
 export { UI_EVENT, DEVICE_EVENT, };


### PR DESCRIPTION
We used to keep the Trezor iframe once it's been loaded since loading the iframe can take ~1sec. However, this doesn't make as much sense since we have multiwallet support where other wallets may not be Trezor devices.