### PR TITLE
Fix misc UI bugs on receive page

### DIFF
--- a/app/components/wallet/layouts/ReceiveWithNavigation.js
+++ b/app/components/wallet/layouts/ReceiveWithNavigation.js
@@ -10,14 +10,14 @@ export type Props = {|
   +children?: Node,
   +setFilter: AddressFilterKind => void,
   +activeFilter: AddressFilterKind,
-  +addressStores: Array<{|
+  +addressStores: $ReadOnlyArray<{
     +isActiveStore: boolean,
-    +isHidden: boolean,
     +setAsActiveStore: void => void,
     +name: AddressTypeName,
     +validFilters: Array<AddressFilterKind>,
     +wasExecuted: boolean,
-  |}>;
+    ...,
+  }>;
 |};
 
 @observer

--- a/app/components/wallet/layouts/ReceiveWithNavigation.scss
+++ b/app/components/wallet/layouts/ReceiveWithNavigation.scss
@@ -1,6 +1,7 @@
 .component {
-  height: 78vh;
   display: flex;
+  overflow: hidden;
+  height: 100%;
 }
 
 .navigation {

--- a/app/components/wallet/navigation/ReceiveNavigation.js
+++ b/app/components/wallet/navigation/ReceiveNavigation.js
@@ -19,17 +19,18 @@ import classNames from 'classnames';
 import { Tooltip } from 'react-polymorph/lib/components/Tooltip';
 import { TooltipSkin } from 'react-polymorph/lib/skins/simple/TooltipSkin';
 
-export type Props = {|
-  +setFilter: AddressFilterKind => void,
-  +activeFilter: AddressFilterKind,
-  +addressStores: Array<{|
+type AddressStoreSubset = {
     +isActiveStore: boolean,
-    +isHidden: boolean,
     +setAsActiveStore: void => void,
     +name: AddressTypeName,
     +validFilters: Array<AddressFilterKind>,
     +wasExecuted: boolean,
-  |}>;
+    ...,
+};
+export type Props = {|
+  +setFilter: AddressFilterKind => void,
+  +activeFilter: AddressFilterKind,
+  +addressStores: $ReadOnlyArray<AddressStoreSubset>;
 |};
 
 @observer
@@ -93,7 +94,7 @@ export default class ReceiveNavigation extends Component<Props> {
         activeHeader={stores.some(address => address.isActiveStore)}
       >
         {stores.map(type => (
-          !type.isHidden && <ReceiveNavButton
+          <ReceiveNavButton
             key={type.name.subgroup}
             className={classNames([type.name.subgroup, type.name.group])}
             icon={
@@ -113,7 +114,7 @@ export default class ReceiveNavigation extends Component<Props> {
 
   createAccordions: void => Node = () => {
     // we use an array instead of a map to maintain the order of stores
-    const groups: Array<$PropertyType<Props, 'addressStores'>> = [];
+    const groups: Array<Array<AddressStoreSubset>> = [];
 
     for (const store of this.props.addressStores) {
       const existingGroup = groups.find(

--- a/app/components/wallet/navigation/ReceiveNavigation.scss
+++ b/app/components/wallet/navigation/ReceiveNavigation.scss
@@ -21,12 +21,14 @@
   display: flex;
   flex-direction: column;
   justify-content: start;
+  overflow: overlay;
 }
 .filterSection {
   padding-top: 20px;
   padding-bottom: 40px;
   height: 240px; 
   box-shadow: inset 0 -1px 12px 0 rgba(255,255,255,0.5), inset 0 2px 4px 0 rgba(56,57,61,0.2);
+  overflow: overlay;
 }
 .filterButton {
   display: block;

--- a/app/containers/wallet/Receive.js
+++ b/app/containers/wallet/Receive.js
@@ -72,7 +72,11 @@ export default class Receive extends Component<Props> {
     const { addresses } = this.generated.stores;
     return (
       <ReceiveWithNavigation
-        addressStores={addresses.getStoresForWallet(publicDeriver)}
+        addressStores={
+          addresses
+            .getStoresForWallet(publicDeriver)
+            .filter(store => !store.isHidden)
+        }
         setFilter={filter => this.generated.actions.addresses.setFilter.trigger(filter)}
         activeFilter={this.generated.stores.addresses.addressFilter}
       >

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -103,8 +103,7 @@ export default class WalletReceivePage extends Component<Props> {
 
     if (
       addressTypeStore == null ||
-      !addressTypeStore.wasExecuted ||
-      addressTypeStore.all.length === 0
+      !addressTypeStore.wasExecuted
     ) {
       return (
         <VerticallyCenteredLayout>

--- a/chrome/constants.js
+++ b/chrome/constants.js
@@ -7,8 +7,8 @@ import {
 } from '../scripts/connections';
 
 export const Version = {
-  Shelley: '2.7.12',
-  Byron: '1.10.6',
+  Shelley: '2.7.13',
+  Byron: '1.10.7',
 };
 
 export function genCSP(request: {|


### PR DESCRIPTION
Notably it fixes:

- Address book shows a permanent spinner when the address book is empty
- Hidden address types would cause a permanent spinner
- Receive page had two scroll bars on small screen sizes.