### PR TITLE
Store network information for each wallet

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -181,7 +181,7 @@ import type {
   IsValidMnemonicResponse,
   RestoreWalletRequest, RestoreWalletResponse,
 } from '../common/types';
-import { getApiForCoinType } from '../common/utils';
+import { getApiForNetwork } from '../common/utils';
 import { CoreAddressTypes } from './lib/storage/database/primitives/enums';
 
 declare var CONFIG: ConfigType;
@@ -622,7 +622,7 @@ export default class AdaApi {
         return WalletTransaction.fromAnnotatedTx({
           tx,
           addressLookupMap: fetchedTxs.addressLookupMap,
-          api: getApiForCoinType(request.publicDeriver.getParent().getCoinType()),
+          api: getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo()),
         });
       });
       return {

--- a/app/api/ada/lib/storage/bridge/walletBuilder/byron.js
+++ b/app/api/ada/lib/storage/bridge/walletBuilder/byron.js
@@ -39,7 +39,7 @@ import type { AddByHashFunc } from '../../../../../common/lib/storage/bridge/has
 import { rawGenAddByHash } from '../../../../../common/lib/storage/bridge/hashMapper';
 import { addByronAddress } from '../../../../restoration/byron/scan';
 import { KeyKind } from '../../../../../common/lib/crypto/keys/types';
-
+import { networks } from '../../database/prepackagedNetworks';
 
 // TODO: maybe move this inside walletBuilder somehow so it's all done in the same transaction
 /**
@@ -159,7 +159,7 @@ export async function createStandardBip44Wallet(request: {|
       )
       .addConceptualWallet(
         _finalState => ({
-          CoinType: CoinTypes.CARDANO,
+          NetworkId: networks.ByronMainnet.NetworkId,
           Name: request.walletName,
         })
       )
@@ -254,7 +254,7 @@ export async function createHardwareWallet(request: {
       )
       .addConceptualWallet(
         _finalState => ({
-          CoinType: CoinTypes.CARDANO,
+          NetworkId: networks.ByronMainnet.NetworkId,
           Name: request.walletName,
         })
       )
@@ -359,7 +359,7 @@ export async function migrateFromStorageV1(request: {
       )
       .addConceptualWallet(
         _finalState => ({
-          CoinType: CoinTypes.CARDANO,
+          NetworkId: networks.ByronMainnet.NetworkId,
           Name: request.walletName,
         })
       )
@@ -413,7 +413,7 @@ export async function migrateFromStorageV1(request: {
       )
       .addConceptualWallet(
         _finalState => ({
-          CoinType: CoinTypes.CARDANO,
+          NetworkId: networks.ByronMainnet.NetworkId,
           Name: request.walletName,
         })
       )

--- a/app/api/ada/lib/storage/bridge/walletBuilder/shelley.js
+++ b/app/api/ada/lib/storage/bridge/walletBuilder/shelley.js
@@ -41,6 +41,7 @@ import {
   addShelleyChimericAccountAddress,
 } from '../../../../restoration/shelley/scan';
 import { KeyKind } from '../../../../../common/lib/crypto/keys/types';
+import { networks } from '../../database/prepackagedNetworks';
 
 // TODO: maybe move this inside walletBuilder somehow so it's all done in the same transaction
 /**
@@ -198,7 +199,7 @@ export async function createStandardCip1852Wallet(request: {|
       )
       .addConceptualWallet(
         _finalState => ({
-          CoinType: CoinTypes.CARDANO,
+          NetworkId: networks.JormungandrMainnet.NetworkId,
           Name: request.walletName,
         })
       )

--- a/app/api/ada/lib/storage/database/prepackagedNetworks.js
+++ b/app/api/ada/lib/storage/database/prepackagedNetworks.js
@@ -1,0 +1,34 @@
+// @flow
+
+import {
+  CoinTypes,
+} from '../../../../../config/numbersConfig';
+import { Network } from '@coinbarn/ergo-ts';
+
+export const CardanoForks = Object.freeze({
+  Haskell: 0,
+  Jormungandr: 1,
+});
+export const ErgoForks = Object.freeze({
+  Primary: 0,
+});
+export const networks = Object.freeze({
+  ByronMainnet: {
+    NetworkId: 0,
+    NetworkMagic: '764824073',
+    CoinType: CoinTypes.CARDANO,
+    Fork: CardanoForks.Haskell,
+  },
+  JormungandrMainnet: {
+    NetworkId: 1,
+    NetworkMagic: '8e4d2a343f3dcf9330ad9035b3e8d168e6728904262f2c434a4f8f934ec7b676',
+    CoinType: CoinTypes.CARDANO,
+    Fork: CardanoForks.Jormungandr,
+  },
+  ErgoMainnet: {
+    NetworkId: 2,
+    NetworkMagic: (Network.Mainnet.toString(): string),
+    CoinType: CoinTypes.ERGO,
+    Fork: ErgoForks.Primary,
+  },
+});

--- a/app/api/ada/lib/storage/database/primitives/api/read.js
+++ b/app/api/ada/lib/storage/database/primitives/api/read.js
@@ -20,6 +20,7 @@ import type {
   CertificateRow,
   CertificateAddressRow,
   CertificatePart,
+  NetworkRow,
 } from '../tables';
 import type {
   TxStatusCodesType,
@@ -31,7 +32,7 @@ import * as Tables from '../tables';
 import {
   digestForHash,
 } from './utils';
-import { getRowFromKey, getRowIn, StaleStateError, } from '../../utils';
+import { getAll, getRowFromKey, getRowIn, StaleStateError, } from '../../utils';
 
 export class GetEncryptionMeta {
   static ownTables: {|
@@ -1063,5 +1064,25 @@ export class GetCertificates {
         ])
     );
     return certByTxId;
+  }
+}
+
+export class GetNetworks {
+  static ownTables: {|
+    Network: typeof Tables.NetworkSchema,
+  |} = Object.freeze({
+    [Tables.NetworkSchema.name]: Tables.NetworkSchema,
+  });
+  static depTables: {||} = Object.freeze({});
+
+  static async get(
+    db: lf$Database,
+    tx: lf$Transaction,
+  ): Promise<$ReadOnlyArray<$ReadOnly<NetworkRow>>> {
+    const rows = await getAll<NetworkRow>(
+      db, tx,
+      GetNetworks.ownTables[Tables.NetworkSchema.name].name,
+    );
+    return rows;
   }
 }

--- a/app/api/ada/lib/storage/database/primitives/api/write.js
+++ b/app/api/ada/lib/storage/database/primitives/api/write.js
@@ -18,6 +18,7 @@ import type {
   CertificateInsert, CertificateRow,
   CertificateAddressInsert, CertificateAddressRow,
   DbBlock,
+  NetworkInsert, NetworkRow,
 } from '../tables';
 import type {
   CoreAddressT,
@@ -30,6 +31,7 @@ import {
   addNewRowToTable,
   removeFromTableBatch,
   addBatchToTable,
+  addOrReplaceRows,
   addOrReplaceRow,
   getRowIn,
   StaleStateError,
@@ -596,5 +598,28 @@ export class FreeBlocks {
       blockTableMeta.properties.BlockId,
       freeableBlocks.map(row => row.BlockId)
     );
+  }
+}
+
+export class ModifyNetworks {
+  static ownTables: {|
+    Network: typeof Tables.NetworkSchema,
+  |} = Object.freeze({
+    [Tables.NetworkSchema.name]: Tables.NetworkSchema,
+  });
+  static depTables: {||} = Object.freeze({});
+
+  static async upsert(
+    db: lf$Database,
+    tx: lf$Transaction,
+    rows: $ReadOnlyArray<NetworkInsert>,
+  ): Promise<void> {
+    const result = await addOrReplaceRows<NetworkInsert, NetworkRow>(
+      db, tx,
+      rows,
+      ModifyNetworks.ownTables[Tables.NetworkSchema.name].name,
+    );
+
+    return result;
   }
 }

--- a/app/api/ada/lib/storage/database/utils.js
+++ b/app/api/ada/lib/storage/database/utils.js
@@ -10,6 +10,13 @@ import type {
 import { size } from 'lodash';
 import ExtendableError from 'es6-error';
 
+export async function promisifyDbCall(request: IDBRequest): Promise<void> {
+  return await new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject();
+  });
+}
+
 export async function getAll<Row>(
   db: lf$Database,
   tx: lf$Transaction,

--- a/app/api/ada/lib/storage/database/walletTypes/core/tables.js
+++ b/app/api/ada/lib/storage/database/walletTypes/core/tables.js
@@ -3,12 +3,10 @@
 import { Type, ConstraintAction, } from 'lovefield';
 import type { lf$schema$Builder } from 'lovefield';
 import { KeyDerivationSchema } from '../../primitives/tables';
-import type { CoinTypesT } from '../../../../../../../config/numbersConfig';
 
 export type ConceptualWalletInsert = {|
-  CoinType: CoinTypesT,
   Name: string,
-  // NetworkId: number, // TODO
+  NetworkId: number,
 |};
 export type ConceptualWalletRow = {|
   ConceptualWalletId: number,
@@ -21,8 +19,8 @@ export const ConceptualWalletSchema: {|
   name: 'ConceptualWallet',
   properties: {
     ConceptualWalletId: 'ConceptualWalletId',
-    CoinType: 'CoinType',
     Name: 'Name',
+    NetworkId: 'NetworkId',
   }
 };
 
@@ -115,7 +113,7 @@ export const populateWalletDb = (schemaBuilder: lf$schema$Builder) => {
   // ConceptualWallet Table
   schemaBuilder.createTable(ConceptualWalletSchema.name)
     .addColumn(ConceptualWalletSchema.properties.ConceptualWalletId, Type.INTEGER)
-    .addColumn(ConceptualWalletSchema.properties.CoinType, Type.INTEGER)
+    .addColumn(ConceptualWalletSchema.properties.NetworkId, Type.INTEGER)
     .addColumn(ConceptualWalletSchema.properties.Name, Type.STRING)
     .addPrimaryKey(
       ([ConceptualWalletSchema.properties.ConceptualWalletId]: Array<string>),

--- a/app/api/ada/lib/storage/models/ConceptualWallet/index.js
+++ b/app/api/ada/lib/storage/models/ConceptualWallet/index.js
@@ -22,7 +22,9 @@ import { ModifyConceptualWallet, } from '../../database/walletTypes/core/api/wri
 import type { HwWalletMetaRow, ConceptualWalletRow } from '../../database/walletTypes/core/tables';
 import { GetConceptualWallet } from '../../database/walletTypes/core/api/read';
 import Config from '../../../../../../config';
-import type { CoinTypesT } from '../../../../../../config/numbersConfig';
+import type {
+  NetworkRow,
+} from '../../database/primitives/tables';
 
 /** Snapshot of a ConceptualWallet in the database */
 export class ConceptualWallet implements IConceptualWallet, IRename {
@@ -35,14 +37,14 @@ export class ConceptualWallet implements IConceptualWallet, IRename {
   #protocolMagic: string;
   walletType: WalletType;
   hardwareInfo: ?$ReadOnly<HwWalletMetaRow>;
-  coinType: CoinTypesT;
+  networkInfo: $ReadOnly<NetworkRow>;
 
   constructor(data: IConceptualWalletConstructor): IConceptualWallet {
     this.db = data.db;
     this.#conceptualWalletId = data.conceptualWalletId;
     this.walletType = data.walletType;
     this.hardwareInfo = data.hardwareInfo;
-    this.coinType = data.coinType;
+    this.networkInfo = data.networkInfo;
     return this;
   }
 
@@ -50,16 +52,12 @@ export class ConceptualWallet implements IConceptualWallet, IRename {
     return this.db;
   }
 
-  getCoinType(): CoinTypesT {
-    return this.coinType;
+  getNetworkInfo(): $ReadOnly<NetworkRow> {
+    return this.networkInfo;
   }
 
   getConceptualWalletId(): number {
     return this.#conceptualWalletId;
-  }
-
-  getProtocolMagic(): string {
-    return this.#protocolMagic;
   }
 
   getWalletType: void => WalletType = () => {

--- a/app/api/ada/lib/storage/models/ConceptualWallet/interfaces.js
+++ b/app/api/ada/lib/storage/models/ConceptualWallet/interfaces.js
@@ -22,14 +22,14 @@ import {
 
 import type {
   KeyRow,
-  KeyDerivationRow
+  KeyDerivationRow,
+  NetworkRow,
 } from '../../database/primitives/tables';
 
 import type {
   IChangePasswordRequest, IChangePasswordRequestFunc,
   RawVariation, RawTableVariation,
 } from '../common/interfaces';
-import type { CoinTypesT } from '../../../../../../config/numbersConfig';
 
 export const WalletTypeOption = Object.freeze({
   WEB_WALLET: 0,
@@ -42,7 +42,7 @@ export type IConceptualWalletConstructor = {|
   conceptualWalletId: number,
   walletType: WalletType,
   hardwareInfo: ?$ReadOnly<HwWalletMetaRow>,
-  coinType: CoinTypesT,
+  networkInfo: $ReadOnly<NetworkRow>,
 |};
 
 export interface IConceptualWallet {
@@ -51,8 +51,7 @@ export interface IConceptualWallet {
   getHwWalletMeta(): ?$ReadOnly<HwWalletMetaRow>;
   getDb(): lf$Database;
   getConceptualWalletId(): number;
-  getProtocolMagic(): string;
-  getCoinType(): CoinTypesT;
+  getNetworkInfo(): $ReadOnly<NetworkRow>;
   rawRemove(db: lf$Database, tx: lf$Transaction): Promise<void>
 }
 

--- a/app/api/ada/lib/storage/models/PublicDeriver/traits.js
+++ b/app/api/ada/lib/storage/models/PublicDeriver/traits.js
@@ -2018,7 +2018,7 @@ export async function addTraitsForBip44Child(
   ...AddBip44TraitsResponse,
   pathToPublic: Array<number>,
 |}> {
-  const traitFunc = traitFuncLookup[request.conceptualWallet.getCoinType().toString()];
+  const traitFunc = traitFuncLookup[request.conceptualWallet.getNetworkInfo().CoinType.toString()];
   const { finalClass } = await traitFunc(request);
 
   let pathToPublic;

--- a/app/api/ada/lib/storage/tests/__snapshots__/adaMigration.test.js.snap
+++ b/app/api/ada/lib/storage/tests/__snapshots__/adaMigration.test.js.snap
@@ -47,9 +47,9 @@ Array [
   Object {
     "ConceptualWallet": Array [
       Object {
-        "CoinType": 2147485463,
         "ConceptualWalletId": 1,
         "Name": "Yoroi-Ledger",
+        "NetworkId": 0,
       },
     ],
   },
@@ -466,9 +466,9 @@ Array [
   Object {
     "ConceptualWallet": Array [
       Object {
-        "CoinType": 2147485463,
         "ConceptualWalletId": 1,
         "Name": "Wallet",
+        "NetworkId": 0,
       },
     ],
   },
@@ -885,9 +885,9 @@ Array [
   Object {
     "ConceptualWallet": Array [
       Object {
-        "CoinType": 2147485463,
         "ConceptualWalletId": 1,
         "Name": "Trezorro",
+        "NetworkId": 0,
       },
     ],
   },

--- a/app/api/ada/lib/storage/tests/__snapshots__/index.test.js.snap
+++ b/app/api/ada/lib/storage/tests/__snapshots__/index.test.js.snap
@@ -664,9 +664,9 @@ Object {
   ],
   "ConceptualWallet": Array [
     Object {
-      "CoinType": 2147485463,
       "ConceptualWalletId": 1,
       "Name": "My Test Wallet",
+      "NetworkId": 0,
     },
   ],
   "EncryptionMeta": Array [
@@ -1060,6 +1060,26 @@ Object {
       "LastSyncInfoId": 2,
       "SlotNum": null,
       "Time": null,
+    },
+  ],
+  "Network": Array [
+    Object {
+      "CoinType": 2147485463,
+      "Fork": 0,
+      "NetworkId": 0,
+      "NetworkMagic": "764824073",
+    },
+    Object {
+      "CoinType": 2147485463,
+      "Fork": 1,
+      "NetworkId": 1,
+      "NetworkMagic": "8e4d2a343f3dcf9330ad9035b3e8d168e6728904262f2c434a4f8f934ec7b676",
+    },
+    Object {
+      "CoinType": 2147484077,
+      "Fork": 0,
+      "NetworkId": 2,
+      "NetworkMagic": "0",
     },
   ],
   "PriceData": Array [],

--- a/app/api/common/index.js
+++ b/app/api/common/index.js
@@ -35,7 +35,7 @@ import type {
   TransactionExportDataFormat,
   TransactionExportFileType
 } from '../export';
-import { getApiForCoinType } from './utils';
+import { getApiForNetwork } from './utils';
 import type { GetBalanceRequest, GetBalanceResponse } from './types';
 
 // getWallets
@@ -228,7 +228,7 @@ export default class CommonApi {
         return WalletTransaction.fromAnnotatedTx({
           tx,
           addressLookupMap: fetchedTxs.addressLookupMap,
-          api: getApiForCoinType(request.publicDeriver.getParent().getCoinType()),
+          api: getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo()),
         });
       });
       return mappedTransactions;

--- a/app/api/common/utils.js
+++ b/app/api/common/utils.js
@@ -1,9 +1,9 @@
 // @flow
 
-import type { CoinTypesT } from '../../config/numbersConfig';
 import { CoinTypes } from '../../config/numbersConfig';
 import { getAdaCurrencyMeta } from '../ada/currencyInfo';
 import { getErgoCurrencyMeta } from '../ergo/currencyInfo';
+import type { NetworkRow } from '../ada/lib/storage/database/primitives/tables';
 
 export const ApiOptions = Object.freeze({
   ada: 'ada',
@@ -11,14 +11,14 @@ export const ApiOptions = Object.freeze({
 });
 export type ApiOptionType = $Values<typeof ApiOptions>;
 
-export const getApiForCoinType: CoinTypesT => ApiOptionType = (type) => {
-  if (type === CoinTypes.CARDANO) {
+export const getApiForNetwork: $ReadOnly<NetworkRow> => ApiOptionType = (type) => {
+  if (type.CoinType === CoinTypes.CARDANO) {
     return ApiOptions.ada;
   }
-  if (type === CoinTypes.ERGO) {
+  if (type.CoinType === CoinTypes.ERGO) {
     return ApiOptions.ergo;
   }
-  throw new Error(`${nameof(getApiForCoinType)} missing entry for coin type ${type}`);
+  throw new Error(`${nameof(getApiForNetwork)} missing entry for type ${JSON.stringify(type)}`);
 };
 
 export type SelectedApiType = {|

--- a/app/api/ergo/index.js
+++ b/app/api/ergo/index.js
@@ -28,7 +28,7 @@ import { ConceptualWallet } from '../ada/lib/storage/models/ConceptualWallet/ind
 import type { IHasLevels } from '../ada/lib/storage/models/ConceptualWallet/interfaces';
 import type { TransactionExportRow } from '../export';
 import WalletTransaction from '../../domain/WalletTransaction';
-import { getApiForCoinType } from '../common/utils';
+import { getApiForNetwork } from '../common/utils';
 import {
   GenericApiError,
   WalletAlreadyRestoredError,
@@ -134,7 +134,7 @@ export default class ErgoApi {
         return WalletTransaction.fromAnnotatedTx({
           tx,
           addressLookupMap: fetchedTxs.addressLookupMap,
-          api: getApiForCoinType(request.publicDeriver.getParent().getCoinType()),
+          api: getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo()),
         });
       });
       return {

--- a/app/api/ergo/lib/walletBuilder/builder.js
+++ b/app/api/ergo/lib/walletBuilder/builder.js
@@ -37,6 +37,7 @@ import { rawGenAddByHash } from '../../../common/lib/storage/bridge/hashMapper';
 import { addErgoP2PK } from '../restoration/scan';
 import { decode } from 'bs58check';
 import { KeyKind } from '../../../common/lib/crypto/keys/types';
+import { networks } from '../../../ada/lib/storage/database/prepackagedNetworks';
 
 // TODO: maybe move this inside walletBuilder somehow so it's all done in the same transaction
 /**
@@ -157,7 +158,7 @@ export async function createStandardBip44Wallet(request: {|
       )
       .addConceptualWallet(
         _finalState => ({
-          CoinType: CoinTypes.ERGO,
+          NetworkId: networks.ErgoMainnet.NetworkId,
           Name: request.walletName,
         })
       )

--- a/app/containers/NavBarContainer.js
+++ b/app/containers/NavBarContainer.js
@@ -25,7 +25,7 @@ import type { ConceptualWalletSettingsCache } from '../stores/toplevel/WalletSet
 import type { PublicKeyCache } from '../stores/toplevel/WalletStore';
 import type { TxRequests } from '../stores/toplevel/TransactionsStore';
 import type { IGetPublic } from '../api/ada/lib/storage/models/PublicDeriver/interfaces';
-import { getApiForCoinType, getApiMeta } from '../api/common/utils';
+import { getApiForNetwork, getApiMeta } from '../api/common/utils';
 import type { SelectedApiType } from '../api/common/utils';
 
 const messages = defineMessages({
@@ -61,7 +61,7 @@ export default class NavBarContainer extends Component<Props> {
   }
 
   getMeta: PublicDeriver<> => $PropertyType<SelectedApiType, 'meta'> = (publicDeriver) => {
-    const apiMeta = getApiMeta(getApiForCoinType(publicDeriver.getParent().getCoinType()))?.meta;
+    const apiMeta = getApiMeta(getApiForNetwork(publicDeriver.getParent().getNetworkInfo()))?.meta;
     if (apiMeta == null) throw new Error(`${nameof(NavBarContainer)} no API selected`);
     return apiMeta;
   }

--- a/app/containers/settings/categories/BlockchainSettingsPage.js
+++ b/app/containers/settings/categories/BlockchainSettingsPage.js
@@ -22,6 +22,7 @@ import {
 } from '../../../api/ada/lib/storage/models/PublicDeriver/index';
 import NoWalletMessage from '../../../components/wallet/settings/NoWalletMessage';
 import { CoinTypes, } from '../../../config/numbersConfig';
+import { CardanoForks } from '../../../api/ada/lib/storage/database/prepackagedNetworks';
 
 const currencyLabels = defineMessages({
   USD: {
@@ -75,7 +76,7 @@ export default class BlockchainSettingsPage extends Component<InjectedOrGenerate
     if (walletsStore.selected == null) {
       return (<NoWalletMessage />);
     }
-    const coinType = walletsStore.selected.getParent().getCoinType();
+    const networkInfo = walletsStore.selected.getParent().getNetworkInfo();
 
     const profileStore = this.generated.stores.profile;
     const coinPriceStore = this.generated.stores.coinPriceStore;
@@ -86,7 +87,8 @@ export default class BlockchainSettingsPage extends Component<InjectedOrGenerate
     const explorerOptions = getExplorers();
 
     const uriSettings = (
-      coinType === CoinTypes.CARDANO &&
+      networkInfo.CoinType === CoinTypes.CARDANO &&
+      networkInfo.Fork === CardanoForks.Haskell &&
       !environment.isJormungandr() &&
       this.generated.canRegisterProtocol()
     )

--- a/app/containers/wallet/MyWalletsPage.js
+++ b/app/containers/wallet/MyWalletsPage.js
@@ -39,7 +39,7 @@ import type { DelegationRequests } from '../../stores/ada/DelegationStore';
 import type { PublicKeyCache } from '../../stores/toplevel/WalletStore';
 import type { TxRequests } from '../../stores/toplevel/TransactionsStore';
 import type { IGetPublic } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
-import { getApiForCoinType, getApiMeta } from '../../api/common/utils';
+import { getApiForNetwork, getApiMeta } from '../../api/common/utils';
 
 const messages = defineMessages({
   walletSumInfo: {
@@ -88,7 +88,7 @@ export default class MyWalletsPage extends Component<Props> {
     const walletBalances = wallets.map(wallet => {
       const balanceResult = stores.transactions
         .getTxRequests(wallet).requests.getBalanceRequest.result;
-      const apiMeta = getApiMeta(getApiForCoinType(wallet.getParent().getCoinType()))?.meta;
+      const apiMeta = getApiMeta(getApiForNetwork(wallet.getParent().getNetworkInfo()))?.meta;
       if (apiMeta == null) throw new Error(`${nameof(MyWalletsPage)} no API selected`);
       const amountPerUnit = new BigNumber(10).pow(apiMeta.decimalPlaces);
       return balanceResult?.dividedBy(amountPerUnit);
@@ -162,7 +162,7 @@ export default class MyWalletsPage extends Component<Props> {
     const settingsCache = this.generated.stores.walletSettings
       .getConceptualWalletSettingsCache(parent);
 
-    const apiMeta = getApiMeta(getApiForCoinType(publicDeriver.getParent().getCoinType()))?.meta;
+    const apiMeta = getApiMeta(getApiForNetwork(publicDeriver.getParent().getNetworkInfo()))?.meta;
     if (apiMeta == null) throw new Error(`${nameof(MyWalletsPage)} no API selected`);
     const amountPerUnit = new BigNumber(10).pow(apiMeta.decimalPlaces);
 
@@ -223,7 +223,7 @@ export default class MyWalletsPage extends Component<Props> {
   createSubrow: PublicDeriver<> => Node = (publicDeriver) => {
     const { intl } = this.context;
 
-    const apiMeta = getApiMeta(getApiForCoinType(publicDeriver.getParent().getCoinType()))?.meta;
+    const apiMeta = getApiMeta(getApiForNetwork(publicDeriver.getParent().getNetworkInfo()))?.meta;
     if (apiMeta == null) throw new Error(`${nameof(MyWalletsPage)} no API selected`);
 
     // TODO: replace with wallet addresses
@@ -292,7 +292,7 @@ export default class MyWalletsPage extends Component<Props> {
     if (balanceResult == null) {
       return null;
     }
-    const apiMeta = getApiMeta(getApiForCoinType(publicDeriver.getParent().getCoinType()))?.meta;
+    const apiMeta = getApiMeta(getApiForNetwork(publicDeriver.getParent().getNetworkInfo()))?.meta;
     if (apiMeta == null) throw new Error(`${nameof(MyWalletsPage)} no API selected`);
     const amountPerUnit = new BigNumber(10).pow(apiMeta.decimalPlaces);
     return balanceResult.accountPart.dividedBy(amountPerUnit);

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -32,7 +32,7 @@ import LocalizableError from '../../i18n/LocalizableError';
 import type { ExplorerType } from '../../domain/Explorer';
 import type { Notification } from '../../types/notificationType';
 import type { UnitOfAccountSettingType } from '../../types/unitOfAccountType';
-import { getApiForCoinType, getApiMeta } from '../../api/common/utils';
+import { getApiForNetwork, getApiMeta } from '../../api/common/utils';
 import { isWithinSupply } from '../../utils/validations';
 import { Logger, } from '../../utils/logging';
 import type { AddressSubgroupMeta, IAddressTypeUiSubset, IAddressTypeStore } from '../../stores/stateless/addressStores';
@@ -91,7 +91,7 @@ export default class WalletReceivePage extends Component<Props> {
     const publicDeriver = this.generated.stores.wallets.selected;
     if (!publicDeriver) throw new Error(`Active wallet required for ${nameof(WalletReceivePage)}.`);
 
-    const selectedApiType = getApiForCoinType(publicDeriver.getParent().getCoinType());
+    const selectedApiType = getApiForNetwork(publicDeriver.getParent().getNetworkInfo());
     const apiMeta = getApiMeta(selectedApiType)?.meta;
     if (apiMeta == null) throw new Error(`${nameof(WalletReceivePage)} no API selected`);
 

--- a/app/containers/wallet/WalletSendPage.js
+++ b/app/containers/wallet/WalletSendPage.js
@@ -37,7 +37,7 @@ import type { ExplorerType } from '../../domain/Explorer';
 import type { UnitOfAccountSettingType } from '../../types/unitOfAccountType';
 import LocalizableError from '../../i18n/LocalizableError';
 import type { BaseSignRequest } from '../../api/ada/transactions/types';
-import { ApiOptions, getApiForCoinType, getApiMeta } from '../../api/common/utils';
+import { ApiOptions, getApiForNetwork, getApiMeta } from '../../api/common/utils';
 import { isWithinSupply } from '../../utils/validations';
 import { formattedWalletAmount } from '../../utils/formatters';
 
@@ -104,7 +104,7 @@ export default class WalletSendPage extends Component<InjectedOrGenerated<Genera
     // we disable in the non-ADA case instead of throwing an error
     // since the Wallets page should take care of correctly redirecting away from the send page
     // for currency types that don't support it.
-    const selectedApiType = getApiForCoinType(publicDeriver.getParent().getCoinType());
+    const selectedApiType = getApiForNetwork(publicDeriver.getParent().getNetworkInfo());
     if (selectedApiType !== ApiOptions.ada) {
       return true;
     }
@@ -254,7 +254,7 @@ export default class WalletSendPage extends Component<InjectedOrGenerated<Genera
   hardwareWalletDoConfirmation: (() => Node) = () => {
     const publicDeriver = this.generated.stores.wallets.selected;
     if (!publicDeriver) throw new Error(`Active wallet required for ${nameof(this.webWalletDoConfirmation)}.`);
-    const selectedApiType = getApiForCoinType(publicDeriver.getParent().getCoinType());
+    const selectedApiType = getApiForNetwork(publicDeriver.getParent().getNetworkInfo());
     const apiMeta = getApiMeta(selectedApiType)?.meta;
     if (apiMeta == null) throw new Error(`${nameof(this.hardwareWalletDoConfirmation)} no API selected`);
 

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -41,7 +41,7 @@ import type {
   GetTransactionsRequestOptions
 } from '../../api/common/index';
 import type { UnconfirmedAmount } from '../../types/unconfirmedAmountType';
-import { getApiForCoinType, getApiMeta } from '../../api/common/utils';
+import { getApiForNetwork, getApiMeta } from '../../api/common/utils';
 import { addressSubgroupName, addressGroupName, AddressSubgroup } from '../../types/AddressFilterTypes';
 import type { IAddressTypeStore, IAddressTypeUiSubset } from '../../stores/stateless/addressStores';
 import { routeForStore, allAddressSubgroups, } from '../../stores/stateless/addressStores';
@@ -85,7 +85,7 @@ export default class WalletSummaryPage extends Component<InjectedOrGenerated<Gen
     }
 
     const apiMeta = getApiMeta(
-      getApiForCoinType(publicDeriver.getParent().getCoinType())
+      getApiForNetwork(publicDeriver.getParent().getNetworkInfo())
     )?.meta;
     if (apiMeta == null) throw new Error(`${nameof(WalletSummaryPage)} no API selected`);
 

--- a/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
+++ b/app/containers/wallet/dialogs/WalletSendConfirmationDialogContainer.js
@@ -21,7 +21,7 @@ import { RustModule } from '../../../api/ada/lib/cardanoCrypto/rustLoader';
 import LocalizableError from '../../../i18n/LocalizableError';
 import { PublicDeriver } from '../../../api/ada/lib/storage/models/PublicDeriver/index';
 import type { ExplorerType } from '../../../domain/Explorer';
-import { ApiOptions, getApiForCoinType, getApiMeta } from '../../../api/common/utils';
+import { ApiOptions, getApiForNetwork, getApiMeta } from '../../../api/common/utils';
 
 export type GeneratedData = typeof WalletSendConfirmationDialogContainer.prototype.generated;
 
@@ -41,7 +41,7 @@ type Props = {|
 export default class WalletSendConfirmationDialogContainer extends Component<Props> {
 
   getApiType: PublicDeriver<> => 'ada' = (publicDeriver) => {
-    const selectedApiType = getApiForCoinType(publicDeriver.getParent().getCoinType());
+    const selectedApiType = getApiForNetwork(publicDeriver.getParent().getNetworkInfo());
     if (selectedApiType !== ApiOptions.ada) {
       throw new Error(`${nameof(WalletSendConfirmationDialogContainer)} sending only supported for ADA`);
     }

--- a/app/containers/wallet/staking/SeizaFetcher.js
+++ b/app/containers/wallet/staking/SeizaFetcher.js
@@ -29,7 +29,7 @@ import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import type {
   CreateDelegationTxFunc,
 } from '../../../api/ada/index';
-import { getApiForCoinType, getApiMeta } from '../../../api/common/utils';
+import { getApiForNetwork, getApiMeta } from '../../../api/common/utils';
 
 declare var CONFIG: ConfigType;
 
@@ -143,7 +143,7 @@ export default class SeizaFetcher extends Component<Props> {
       return null;
     }
 
-    const apiMeta = getApiMeta(getApiForCoinType(selectedWallet.getParent().getCoinType()))?.meta;
+    const apiMeta = getApiMeta(getApiForNetwork(selectedWallet.getParent().getNetworkInfo()))?.meta;
     if (apiMeta == null) throw new Error(`${nameof(SeizaFetcher)} no API selected`);
     const amountPerUnit = new BigNumber(10).pow(apiMeta.decimalPlaces);
 

--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -52,7 +52,7 @@ import type { Notification } from '../../../types/notificationType';
 
 import globalMessages from '../../../i18n/global-messages';
 import { computed, observable, runInAction } from 'mobx';
-import { getApiForCoinType, getApiMeta } from '../../../api/common/utils';
+import { getApiForNetwork, getApiMeta } from '../../../api/common/utils';
 import type { SelectedApiType, } from '../../../api/common/utils';
 import { getUnmangleAmounts, } from '../../../stores/stateless/mangledAddresses';
 import type { IAddressTypeStore, IAddressTypeUiSubset } from '../../../stores/stateless/addressStores';
@@ -209,7 +209,7 @@ export default class StakingDashboardPage extends Component<Props> {
 
   generatePopupDialog: PublicDeriver<> => (null | Node) = (publicDeriver) => {
     const apiMeta = getApiMeta(
-      getApiForCoinType(publicDeriver.getParent().getCoinType())
+      getApiForNetwork(publicDeriver.getParent().getNetworkInfo())
     )?.meta;
     if (apiMeta == null) throw new Error(`${nameof(StakingDashboardPage)} no API selected`);
 
@@ -621,7 +621,7 @@ export default class StakingDashboardPage extends Component<Props> {
     const balance = txRequests.requests.getBalanceRequest.result;
 
     const apiMeta = getApiMeta(
-      getApiForCoinType(request.publicDeriver.getParent().getCoinType())
+      getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo())
     )?.meta;
     if (apiMeta == null) throw new Error(`${nameof(StakingDashboardPage)} no API selected`);
     const amountPerUnit = new BigNumber(10).pow(apiMeta.decimalPlaces);
@@ -678,7 +678,7 @@ export default class StakingDashboardPage extends Component<Props> {
     request
   ) => {
     const apiMeta = getApiMeta(
-      getApiForCoinType(request.publicDeriver.getParent().getCoinType())
+      getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo())
     )?.meta;
     if (apiMeta == null) throw new Error(`${nameof(StakingDashboardPage)} no API selected`);
     const amountPerUnit = new BigNumber(10).pow(apiMeta.decimalPlaces);

--- a/app/containers/wallet/staking/StakingPage.js
+++ b/app/containers/wallet/staking/StakingPage.js
@@ -18,7 +18,7 @@ import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import { PublicDeriver } from '../../../api/ada/lib/storage/models/PublicDeriver/index';
 import type { DelegationRequests } from '../../../stores/ada/DelegationStore';
 import type { TxRequests } from '../../../stores/toplevel/TransactionsStore';
-import { getApiForCoinType, getApiMeta } from '../../../api/common/utils';
+import { getApiForNetwork, getApiMeta } from '../../../api/common/utils';
 
 export type GeneratedData = typeof StakingPage.prototype.generated;
 
@@ -89,7 +89,7 @@ export default class StakingPage extends Component<Props> {
     const balance = txRequests.requests.getBalanceRequest.result;
     if (balance != null) {
       const apiMeta = getApiMeta(
-        getApiForCoinType(publicDeriver.getParent().getCoinType())
+        getApiForNetwork(publicDeriver.getParent().getNetworkInfo())
       )?.meta;
       if (apiMeta == null) throw new Error(`${nameof(StakingPage)} no API selected`);
       const amountPerUnit = new BigNumber(10).pow(apiMeta.decimalPlaces);

--- a/app/stores/ada/AdaTimeStore.js
+++ b/app/stores/ada/AdaTimeStore.js
@@ -147,7 +147,7 @@ export default class AdaTimeStore extends Store {
 
     const selected = this.stores.wallets.selected;
     if (selected == null) return;
-    if (selected.getParent().getCoinType() !== CoinTypes.CARDANO) {
+    if (selected.getParent().getNetworkInfo().CoinType !== CoinTypes.CARDANO) {
       return;
     }
 
@@ -177,7 +177,7 @@ export default class AdaTimeStore extends Store {
     // Get current public deriver
     const publicDeriver = this.stores.wallets.selected;
     if (!publicDeriver) return undefined;
-    if (publicDeriver.getParent().getCoinType() !== CoinTypes.CARDANO) {
+    if (publicDeriver.getParent().getNetworkInfo().CoinType !== CoinTypes.CARDANO) {
       return;
     }
 

--- a/app/stores/ada/DelegationStore.js
+++ b/app/stores/ada/DelegationStore.js
@@ -256,7 +256,7 @@ export default class DelegationStore extends Store {
         }
         const selected = this.stores.wallets.selected;
         if (selected == null) return;
-        if (selected.getParent().getCoinType() !== CoinTypes.CARDANO) {
+        if (selected.getParent().getNetworkInfo().CoinType !== CoinTypes.CARDANO) {
           return;
         }
         if (asGetStakingKey(selected) != null) {

--- a/app/stores/stateless/addressStores.js
+++ b/app/stores/stateless/addressStores.js
@@ -78,7 +78,7 @@ function matchCoinType(
   publicDeriver: PublicDeriver<>,
   match: CoinTypesT => boolean
 ): boolean {
-  return match(publicDeriver.parent.getCoinType());
+  return match(publicDeriver.parent.getNetworkInfo().CoinType);
 }
 
 const standardFilter = [

--- a/app/stores/stateless/topbarCategories.js
+++ b/app/stores/stateless/topbarCategories.js
@@ -62,7 +62,7 @@ export const SUMMARY: TopbarCategory = registerCategory({
   icon: transactionsIcon,
   label: messages.transactions,
   isVisible: request => (
-    request.selected.getParent().getCoinType() !== CoinTypes.ERGO
+    request.selected.getParent().getNetworkInfo().CoinType !== CoinTypes.ERGO
   ),
 });
 export const SEND: TopbarCategory = registerCategory({
@@ -71,7 +71,7 @@ export const SEND: TopbarCategory = registerCategory({
   icon: sendIcon,
   label: messages.send,
   isVisible: request => {
-    if (request.selected.getParent().getCoinType() !== CoinTypes.ERGO) {
+    if (request.selected.getParent().getNetworkInfo().CoinType !== CoinTypes.ERGO) {
       return true;
     }
     return false;

--- a/app/stores/toplevel/AddressesStore.js
+++ b/app/stores/toplevel/AddressesStore.js
@@ -19,7 +19,7 @@ import type {
 import {
   Logger,
 } from '../../utils/logging';
-import { getApiForCoinType } from '../../api/common/utils';
+import { getApiForNetwork } from '../../api/common/utils';
 import type { AddressFilterKind, StandardAddress, AddressTypeName, } from '../../types/AddressFilterTypes';
 import { AddressFilter, } from '../../types/AddressFilterTypes';
 import {
@@ -132,8 +132,7 @@ export default class AddressesStore extends Store {
     storeName: AddressTypeName,
     type: CoreAddressT,
   |} => Promise<$ReadOnlyArray<$ReadOnly<StandardAddress>>> = async (request) => {
-    const { coinType } = request.publicDeriver.getParent();
-    const apiType = getApiForCoinType(coinType);
+    const apiType = getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo());
 
     const withUtxos = asGetAllUtxos(request.publicDeriver);
     if (withUtxos == null) {
@@ -182,8 +181,7 @@ export default class AddressesStore extends Store {
     type: CoreAddressT,
     chainsRequest: IHasUtxoChainsRequest,
   |}=> Promise<$ReadOnlyArray<$ReadOnly<StandardAddress>>> = async (request) => {
-    const { coinType } = request.publicDeriver.getParent();
-    const apiType = getApiForCoinType(coinType);
+    const apiType = getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo());
 
     const withHasUtxoChains = asHasUtxoChains(
       request.publicDeriver
@@ -210,8 +208,7 @@ export default class AddressesStore extends Store {
     storeName: AddressTypeName,
     addresses: $ReadOnlyArray<$ReadOnly<StandardAddress>>,
   |} => Promise<$ReadOnlyArray<$ReadOnly<StandardAddress>>> = async (request) => {
-    const { coinType } = request.publicDeriver.getParent();
-    const apiType = getApiForCoinType(coinType);
+    const apiType = getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo());
 
     return await this.stores.substores[apiType].addresses.storewiseFilter(request);
   }

--- a/app/stores/toplevel/TransactionsStore.js
+++ b/app/stores/toplevel/TransactionsStore.js
@@ -29,7 +29,7 @@ import type {
 } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 import { ConceptualWallet } from '../../api/ada/lib/storage/models/ConceptualWallet';
 import { digestForHash } from '../../api/ada/lib/storage/database/primitives/api/utils';
-import { getApiForCoinType, getApiMeta } from '../../api/common/utils';
+import { getApiForNetwork, getApiMeta } from '../../api/common/utils';
 import type { UnconfirmedAmount } from '../../types/unconfirmedAmountType';
 import LocalizedRequest from '../lib/LocalizedRequest';
 import LocalizableError, { UnexpectedError } from '../../i18n/LocalizableError';
@@ -134,7 +134,9 @@ export default class TransactionsStore extends Store {
       .getPublicDeriverSettingsCache(publicDeriver);
 
 
-    const api = getApiForCoinType(publicDeriver.getParent().getCoinType());
+    const api = getApiForNetwork(
+      publicDeriver.getParent().getNetworkInfo()
+    );
     const apiMeta = getApiMeta(api)?.meta;
     if (apiMeta == null) throw new Error(`${nameof(this.unconfirmedAmount)} no API selected`);
     const getUnitOfAccount = (timestamp: Date) => (!unitOfAccount.enabled
@@ -372,8 +374,7 @@ export default class TransactionsStore extends Store {
   |} => void = (
     request
   ) => {
-    const { coinType } = request.publicDeriver.getParent();
-    const apiType = getApiForCoinType(coinType);
+    const apiType = getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo());
 
     const foundRequest = find(
       this.transactionsRequests,
@@ -483,8 +484,7 @@ export default class TransactionsStore extends Store {
     const txStore = this.stores.transactions;
     const respTxRows = [];
 
-    const { coinType } = request.publicDeriver.getParent();
-    const apiType = getApiForCoinType(coinType);
+    const apiType = getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo());
 
     await txStore.getTransactionRowsToExportRequest.execute(async () => {
       const rows = await this.api[apiType].getTransactionRowsToExport({

--- a/app/stores/toplevel/WalletStore.js
+++ b/app/stores/toplevel/WalletStore.js
@@ -40,7 +40,7 @@ import { assuranceModes, } from '../../config/transactionAssuranceConfig';
 import type { WalletChecksum } from '@emurgo/cip4-js';
 import { legacyWalletChecksum } from '@emurgo/cip4-js';
 import { createDebugWalletDialog } from '../../containers/wallet/dialogs/DebugWalletDialogContainer';
-import { getApiForCoinType } from '../../api/common/utils';
+import { getApiForNetwork } from '../../api/common/utils';
 
 type GroupedWallets = {|
   publicDerivers: Array<PublicDeriver<>>;
@@ -332,8 +332,7 @@ export default class WalletStore extends Store {
   |} => void = (
     request
   ) => {
-    const { coinType } = request.publicDeriver.getParent();
-    const apiType = getApiForCoinType(coinType);
+    const apiType = getApiForNetwork(request.publicDeriver.getParent().getNetworkInfo());
 
     const stores = this.stores.substores[apiType];
     this.stores.addresses.addObservedWallet(request.publicDeriver);
@@ -352,8 +351,7 @@ export default class WalletStore extends Store {
   @action _setActiveWallet: {| wallet: PublicDeriver<> |} => void = (
     { wallet }
   ) => {
-    const { coinType } = wallet.getParent();
-    const apiType = getApiForCoinType(coinType);
+    const apiType = getApiForNetwork(wallet.getParent().getNetworkInfo());
     this.actions.profile.setSelectedAPI.trigger(apiType);
 
     this.selected = wallet;

--- a/stories/helpers/StoryWrapper.js
+++ b/stories/helpers/StoryWrapper.js
@@ -78,6 +78,7 @@ import BigNumber from 'bignumber.js';
 import { utxoToTxInput } from '../../app/api/ada/transactions/shelley/inputSelection';
 import { RustModule } from '../../app/api/ada/lib/cardanoCrypto/rustLoader';
 import { CoinTypes } from '../../app/config/numbersConfig';
+import { networks } from '../../app/api/ada/lib/storage/database/prepackagedNetworks';
 
 /**
  * This whole file is meant to mirror code in App.js
@@ -287,7 +288,7 @@ function genDummyWallet(): PublicDeriver<> {
       conceptualWalletId,
       walletType: WalletTypeOption.WEB_WALLET,
       hardwareInfo: null,
-      coinType: CoinTypes.CARDANO,
+      networkInfo: networks.JormungandrMainnet,
     },
     {
       ConceptualWalletId: conceptualWalletId,
@@ -410,7 +411,7 @@ function genSigningWallet(
         return WalletTypeOption.WEB_WALLET;
       })(),
       hardwareInfo,
-      coinType: CoinTypes.CARDANO,
+      networkInfo: networks.JormungandrMainnet,
     },
     {
       ConceptualWalletId: conceptualWalletId,
@@ -456,7 +457,7 @@ function genByronSigningWallet(
         return WalletTypeOption.WEB_WALLET;
       })(),
       hardwareInfo,
-      coinType: CoinTypes.CARDANO,
+      networkInfo: networks.ByronMainnet,
     },
     {
       ConceptualWalletId: conceptualWalletId,


### PR DESCRIPTION
We need to be able to differentiate between Jormungandr and Haskell Shelley -- which both use the exact same derivation path and coin type. The difference between them is the network magic.
This also applies if we even make new testnets off Haskell Shelley (like the Goguen testnet), etc.
To ship all currencies as part of one app, the network information needs to be saved (and we can get rid of the `isJormungandr` build flag after this)