### PR TITLE
ITN withdrawal claim page

### DIFF
--- a/app/api/ada/index.test.js
+++ b/app/api/ada/index.test.js
@@ -67,7 +67,7 @@ test('Restore wallet for transfer', async () => {
     rootPk: generateWalletRootKey(recoveryPhrase),
     checkAddressesInUse,
     accountIndex: HARD_DERIVATION_START + 0,
-    transferSource: TransferSource.BYRON,
+    transferSource: TransferSource.BIP44,
     network: networks.ByronMainnet,
   });
 

--- a/app/api/ada/transactions/byron/yoroiTransfer.js
+++ b/app/api/ada/transactions/byron/yoroiTransfer.js
@@ -65,7 +65,7 @@ export async function buildYoroiTransferTx(payload: {|
       }: BaseSignRequest<RustModule.WalletV4.TransactionBuilder>),
       payload.keyLevel,
       payload.signingKey,
-      [],
+      () => [],
       undefined,
     );
 
@@ -83,7 +83,7 @@ export async function buildYoroiTransferTx(payload: {|
       receiver: outputAddr,
     };
   } catch (error) {
-    Logger.error(`transfer::buildTransferTx ${stringifyError(error)}`);
+    Logger.error(`transfer::${nameof(buildYoroiTransferTx)} ${stringifyError(error)}`);
     if (error instanceof LocalizableError) {
       throw error;
     }

--- a/app/api/ada/transactions/shelley/transactions.js
+++ b/app/api/ada/transactions/shelley/transactions.js
@@ -191,6 +191,10 @@ export function newAdaUnsignedTx(
     keyDeposit: RustModule.WalletV4.BigNum,
   |},
   certificates: $ReadOnlyArray<RustModule.WalletV4.Certificate>,
+  withdrawals: $ReadOnlyArray<{|
+    address: RustModule.WalletV4.RewardAddress,
+    amount: RustModule.WalletV4.BigNum,
+  |}>,
 ): V4UnsignedTxAddressedUtxoResponse {
   const addressingMap = new Map<RemoteUnspentOutput, AddressedUtxo>();
   for (const utxo of allUtxos) {
@@ -208,7 +212,8 @@ export function newAdaUnsignedTx(
     Array.from(addressingMap.keys()),
     absSlotNumber,
     protocolParams,
-    certificates
+    certificates,
+    withdrawals
   );
 
   const addressedUtxos = unsignedTxResponse.senderUtxos.map(
@@ -247,6 +252,10 @@ export function newAdaUnsignedTxFromUtxo(
     keyDeposit: RustModule.WalletV4.BigNum,
   |},
   certificates: $ReadOnlyArray<RustModule.WalletV4.Certificate>,
+  withdrawals: $ReadOnlyArray<{|
+    address: RustModule.WalletV4.RewardAddress,
+    amount: RustModule.WalletV4.BigNum,
+  |}>,
 ): V4UnsignedTxUtxoResponse {
   const txBuilder = RustModule.WalletV4.TransactionBuilder.new(
     protocolParams.linearFee,
@@ -260,6 +269,19 @@ export function newAdaUnsignedTxFromUtxo(
       RustModule.WalletV4.Certificates.new()
     );
     txBuilder.set_certs(certsWasm);
+  }
+  if (withdrawals.length > 0) {
+    const withdrawalWasm = withdrawals.reduce(
+      (withs, withdrawal) => {
+        withs.insert(
+          withdrawal.address,
+          withdrawal.amount,
+        );
+        return withs;
+      },
+      RustModule.WalletV4.Withdrawals.new()
+    );
+    txBuilder.set_withdrawals(withdrawalWasm);
   }
   txBuilder.set_ttl(absSlotNumber.plus(defaultTtlOffset).toNumber());
   {
@@ -277,28 +299,36 @@ export function newAdaUnsignedTxFromUtxo(
     }
   }
 
-  let currentInputSum = new BigNumber(0);
+  // pick inputs
   const usedUtxos: Array<RemoteUnspentOutput> = [];
-  // add utxos until we have enough to send the transaction
-  for (const utxo of utxos) {
-    usedUtxos.push(utxo);
-    currentInputSum = currentInputSum.plus(utxo.amount);
-    addUtxoInput(txBuilder, utxo);
-    const output = new BigNumber(
-      txBuilder.get_explicit_output().checked_add(txBuilder.estimate_fee()).to_str()
-    );
-
-    if (currentInputSum.gte(output)) {
-      break;
-    }
-  }
-  // check to see if we have enough balance in the wallet to cover the transaction
   {
-    const output = new BigNumber(
-      txBuilder.get_explicit_output().checked_add(txBuilder.estimate_fee()).to_str()
-    );
-    if (currentInputSum.lt(output)) {
+    // recall: we might have some implicit input to start with from deposit refunds
+    let currentInputSum = new BigNumber(txBuilder.get_explicit_input().to_str());
+
+    if (utxos.length === 0) {
       throw new NotEnoughMoneyToSendError();
+    }
+    // add utxos until we have enough to send the transaction
+    for (const utxo of utxos) {
+      usedUtxos.push(utxo); // note: this ensure we have at least one UTXO in the tx
+      currentInputSum = currentInputSum.plus(utxo.amount);
+      addUtxoInput(txBuilder, utxo);
+      const output = new BigNumber(
+        txBuilder.get_explicit_output().checked_add(txBuilder.estimate_fee()).to_str()
+      );
+
+      if (currentInputSum.gte(output)) {
+        break;
+      }
+    }
+    // check to see if we have enough balance in the wallet to cover the transaction
+    {
+      const output = new BigNumber(
+        txBuilder.get_explicit_output().checked_add(txBuilder.estimate_fee()).to_str()
+      );
+      if (currentInputSum.lt(output)) {
+        throw new NotEnoughMoneyToSendError();
+      }
     }
   }
 

--- a/app/api/ada/transactions/shelley/transactions.test.js
+++ b/app/api/ada/transactions/shelley/transactions.test.js
@@ -282,7 +282,7 @@ describe('Create signed transactions', () => {
       signRequest,
       Bip44DerivationLevels.ACCOUNT.level,
       accountPrivateKey,
-      [],
+      () => [],
       undefined,
     );
     const witnesses = signedTx.witness_set();
@@ -365,7 +365,7 @@ describe('Create signed transactions', () => {
       signRequest,
       Bip44DerivationLevels.ACCOUNT.level,
       accountPrivateKey,
-      [],
+      () => [],
       undefined,
     );
     const witnesses = signedTx.witness_set();
@@ -425,7 +425,10 @@ describe('Create signed transactions', () => {
       signRequest,
       Bip44DerivationLevels.ACCOUNT.level,
       accountPrivateKey,
-      [stakingKey],
+      (txHash) => [RustModule.WalletV4.make_vkey_witness(
+        txHash,
+        stakingKey,
+      )],
       undefined,
     );
     const witnesses = signedTx.witness_set();
@@ -497,7 +500,10 @@ describe('Create signed transactions', () => {
       signRequest,
       Bip44DerivationLevels.ACCOUNT.level,
       accountPrivateKey,
-      [stakingKey],
+      (txHash) => [RustModule.WalletV4.make_vkey_witness(
+        txHash,
+        stakingKey,
+      )],
       undefined,
     );
     const witnesses = signedTx.witness_set();

--- a/app/components/wallet/WalletRestoreVerifyDialog.js
+++ b/app/components/wallet/WalletRestoreVerifyDialog.js
@@ -126,7 +126,7 @@ export default class WalletRestoreVerifyDialog extends Component<Props> {
     notification: ?Notification,
   ): Node {
     return (
-      <div>
+      <div key={title}>
         <h2 className={styles.addressLabel}>
           {title}
         </h2>

--- a/app/containers/transfer/WalletTransferPage.js
+++ b/app/containers/transfer/WalletTransferPage.js
@@ -72,7 +72,7 @@ export default class WalletTransferPage extends Component<Props> {
           onByron={() => actions.dialogs.open.trigger({ dialog: ByronEraOptionDialogContainer })}
           onShelleyItn={() => this.generated.actions.yoroiTransfer
             .startTransferFunds.trigger({
-              source: TransferSource.JORMUNGANDR_UTXO
+              source: TransferSource.CHIMERIC_ACCOUNT
             })
           }
         />

--- a/app/containers/transfer/YoroiPlatePage.js
+++ b/app/containers/transfer/YoroiPlatePage.js
@@ -47,16 +47,13 @@ export default class YoroiPlatePage extends Component<Props> {
       if (yoroiTransfer.transferKind === TransferKind.PAPER) {
         return { type: 'bip44', extra: 'paper', length: 21 };
       }
-      if (yoroiTransfer.transferSource === TransferSource.BYRON) {
+      if (yoroiTransfer.transferSource === TransferSource.BIP44) {
         return { type: 'bip44', extra: undefined, length: 15 };
       }
-      if (yoroiTransfer.transferSource === TransferSource.JORMUNGANDR_UTXO) {
+      if (yoroiTransfer.transferSource === TransferSource.CIP1852) {
         return { type: 'cip1852', extra: undefined, length: 15 };
       }
-      if (yoroiTransfer.transferSource === TransferSource.JORMUNGANDR_CHIMERIC_ACCOUNT) {
-        return { type: 'cip1852', extra: undefined, length: 15 };
-      }
-      if (yoroiTransfer.transferSource === TransferSource.SHELLEY) {
+      if (yoroiTransfer.transferSource === TransferSource.CHIMERIC_ACCOUNT) {
         return { type: 'cip1852', extra: undefined, length: 15 };
       }
       throw new Error(`${nameof(YoroiPlatePage)} unknown mode`);

--- a/app/containers/transfer/YoroiTransferPage.stories.js
+++ b/app/containers/transfer/YoroiTransferPage.stories.js
@@ -121,7 +121,7 @@ const genBaseProps: {|
             ? TransferKind.NORMAL
             : request.transferKind,
           transferSource: request.transferSource == null
-            ? TransferSource.BYRON
+            ? TransferSource.BIP44
             : request.transferSource,
           recoveryPhrase: request.yoroiTransfer.recoveryPhrase == null
             ? ''

--- a/app/containers/transfer/options/ByronEraOptionDialogContainer.js
+++ b/app/containers/transfer/options/ByronEraOptionDialogContainer.js
@@ -34,13 +34,13 @@ export default class ByronEraOptionDialogContainer extends Component<Props> {
 
   startTransferIcarusFunds: void => void = () => {
     this.generated.actions.yoroiTransfer.startTransferFunds.trigger({
-      source: TransferSource.BYRON
+      source: TransferSource.BIP44
     });
   }
 
   startTransferYoroiPaperFunds: void => void = () => {
     this.generated.actions.yoroiTransfer.startTransferPaperFunds.trigger({
-      source: TransferSource.BYRON
+      source: TransferSource.BIP44
     });
   }
 

--- a/app/stores/ada/AdaDelegationTransactionStore.js
+++ b/app/stores/ada/AdaDelegationTransactionStore.js
@@ -6,7 +6,7 @@ import Store from '../base/Store';
 import LocalizedRequest from '../lib/LocalizedRequest';
 import type {
   CreateDelegationTxFunc,
-  SignAndBroadcastDelegationTxRequest, SignAndBroadcastDelegationTxResponse,
+  SignAndBroadcastRequest, SignAndBroadcastResponse,
 } from '../../api/ada';
 import { buildRoute } from '../../utils/routing';
 import { ROUTES } from '../../routes-config';
@@ -23,6 +23,7 @@ import {
 import {
   getRegistrationHistory,
 } from '../../api/ada/lib/storage/bridge/delegationUtils';
+import { genOwnStakingKey } from '../../api/ada/index';
 
 export default class AdaDelegationTransactionStore extends Store {
 
@@ -166,6 +167,10 @@ export default class AdaDelegationTransactionStore extends Store {
       broadcastRequest: {
         publicDeriver: basePubDeriver,
         signRequest: result.signTxRequest.self(),
+        getStakingWitnesses: async () => await genOwnStakingKey({
+          publicDeriver: basePubDeriver,
+          password: request.password,
+        }),
         password: request.password,
         sendTx: this.stores.substores.ada.stateFetchStore.fetcher.sendTx,
       },
@@ -186,10 +191,10 @@ export default class AdaDelegationTransactionStore extends Store {
   }
 
   sendAndRefresh: {|
-    broadcastRequest: SignAndBroadcastDelegationTxRequest,
+    broadcastRequest: SignAndBroadcastRequest,
     refreshWallet: () => Promise<void>,
-  |} => Promise<SignAndBroadcastDelegationTxResponse> = async (request) => {
-    const result = await this.api.ada.signAndBroadcastDelegationTx(
+  |} => Promise<SignAndBroadcastResponse> = async (request) => {
+    const result = await this.api.ada.signAndBroadcast(
       request.broadcastRequest
     );
     try {

--- a/app/stores/ada/AdaWalletRestoreStore.js
+++ b/app/stores/ada/AdaWalletRestoreStore.js
@@ -106,7 +106,7 @@ export default class AdaWalletRestoreStore extends Store {
     }
 
     this.actions.yoroiTransfer.startTransferFunds.trigger({
-      source: TransferSource.BYRON,
+      source: TransferSource.BIP44,
     });
     this.actions.yoroiTransfer.setupTransferFundsWithMnemonic.trigger({
       recoveryPhrase: phrase

--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -19,6 +19,7 @@ import { ROUTES } from '../../routes-config';
 import { buildCheckAndCall } from '../lib/check';
 import { getApiForNetwork, ApiOptions } from '../../api/common/utils';
 import type { ISignRequest } from '../../api/common/lib/transactions/ISignRequest';
+import { genOwnStakingKey } from '../../api/ada/index';
 
 export default class AdaWalletsStore extends Store {
 
@@ -62,6 +63,7 @@ export default class AdaWalletsStore extends Store {
       broadcastRequest: async () => await this.api.ada.signAndBroadcast({
         publicDeriver: withSigning,
         password: transactionDetails.password,
+        getStakingWitnesses: () => Promise.resolve(() => []),
         signRequest: signRequest.self(),
         sendTx: this.stores.substores.ada.stateFetchStore.fetcher.sendTx,
       }),

--- a/app/stores/ada/AdaYoroiTransferStore.js
+++ b/app/stores/ada/AdaYoroiTransferStore.js
@@ -6,7 +6,7 @@ import Request from '../lib/LocalizedRequest';
 import type {
   TransferTx,
 } from '../../types/TransferTypes';
-import { TransferKind, } from '../../types/TransferTypes';
+import { TransferKind, TransferSource, } from '../../types/TransferTypes';
 import { yoroiTransferTxFromAddresses } from '../../api/ada/transactions/transfer/legacyYoroi';
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 import { generateWalletRootKey, generateLedgerWalletRootKey, } from '../../api/ada/lib/cardanoCrypto/cryptoWallet';
@@ -14,6 +14,7 @@ import {
   HARD_DERIVATION_START,
   WalletTypePurpose,
   CoinTypes,
+  ChainDerivations,
 } from '../../config/numbersConfig';
 import type { RestoreWalletForTransferResponse, RestoreWalletForTransferFunc } from '../../api/ada/index';
 import {
@@ -58,11 +59,45 @@ export default class AdaYoroiTransferStore extends Store {
     updateStatusCallback: void => void,
     getDestinationAddress: void => Promise<string>,
   |} => Promise<TransferTx> = async (request) => {
+    if (this.stores.yoroiTransfer.transferSource === TransferSource.BIP44) {
+      return this.generateTransferTxForByron(request);
+    }
+    if (this.stores.yoroiTransfer.transferSource === TransferSource.CHIMERIC_ACCOUNT) {
+      return this.generateTransferTxForByron(request);
+    }
+    throw new Error(`${nameof(AdaYoroiTransferStore)}::${nameof(this.generateTransferTxFromMnemonic)} unknown restore type ${this.stores.yoroiTransfer.transferSource}`);
+  }
+
+  generateTransferTxForRewardAccount: {|
+    recoveryPhrase: string,
+    updateStatusCallback: void => void,
+    getDestinationAddress: void => Promise<string>,
+  |} => Promise<TransferTx> = async (request) => {
+    const rootPk = this.stores.yoroiTransfer.transferKind === TransferKind.LEDGER
+      ? generateLedgerWalletRootKey(request.recoveryPhrase)
+      : generateWalletRootKey(request.recoveryPhrase);
+
+    const accountIndex = 0 + HARD_DERIVATION_START; // TODO: don't hardcode index
+    const stakeKey = rootPk
+      .derive(WalletTypePurpose.BIP44)
+      .derive(CoinTypes.CARDANO)
+      .derive(accountIndex)
+      .derive(ChainDerivations.CHIMERIC_ACCOUNT)
+      .derive(0);
+
+    throw new Error(`${nameof(this.generateTransferTxForRewardAccount)} Not supported yet`);
+  }
+
+  generateTransferTxForByron: {|
+    recoveryPhrase: string,
+    updateStatusCallback: void => void,
+    getDestinationAddress: void => Promise<string>,
+  |} => Promise<TransferTx> = async (request) => {
     // 1) get receive address
     const destinationAddress = await request.getDestinationAddress();
 
     // 2) Perform restoration
-    const accountIndex = 0 + HARD_DERIVATION_START;
+    const accountIndex = 0 + HARD_DERIVATION_START; // TODO: don't hardcode index
     const { masterKey, addresses } = await this._restoreWalletForTransfer(
       request.recoveryPhrase,
       accountIndex,

--- a/app/stores/ada/AdaYoroiTransferStore.js
+++ b/app/stores/ada/AdaYoroiTransferStore.js
@@ -72,18 +72,18 @@ export default class AdaYoroiTransferStore extends Store {
     recoveryPhrase: string,
     updateStatusCallback: void => void,
     getDestinationAddress: void => Promise<string>,
-  |} => Promise<TransferTx> = async (request) => {
-    const rootPk = this.stores.yoroiTransfer.transferKind === TransferKind.LEDGER
-      ? generateLedgerWalletRootKey(request.recoveryPhrase)
-      : generateWalletRootKey(request.recoveryPhrase);
+  |} => Promise<TransferTx> = async (_request) => {
+    // const rootPk = this.stores.yoroiTransfer.transferKind === TransferKind.LEDGER
+    //   ? generateLedgerWalletRootKey(request.recoveryPhrase)
+    //   : generateWalletRootKey(request.recoveryPhrase);
 
-    const accountIndex = 0 + HARD_DERIVATION_START; // TODO: don't hardcode index
-    const stakeKey = rootPk
-      .derive(WalletTypePurpose.BIP44)
-      .derive(CoinTypes.CARDANO)
-      .derive(accountIndex)
-      .derive(ChainDerivations.CHIMERIC_ACCOUNT)
-      .derive(0);
+    // const accountIndex = 0 + HARD_DERIVATION_START; // TODO: don't hardcode index
+    // const stakeKey = rootPk
+    //   .derive(WalletTypePurpose.BIP44)
+    //   .derive(CoinTypes.CARDANO)
+    //   .derive(accountIndex)
+    //   .derive(ChainDerivations.CHIMERIC_ACCOUNT)
+    //   .derive(0);
 
     throw new Error(`${nameof(this.generateTransferTxForRewardAccount)} Not supported yet`);
   }

--- a/app/stores/jormungandr/JormungandrWalletRestoreStore.js
+++ b/app/stores/jormungandr/JormungandrWalletRestoreStore.js
@@ -97,7 +97,7 @@ export default class JormungandrWalletRestoreStore extends Store {
     }
 
     this.actions.yoroiTransfer.startTransferFunds.trigger({
-      source: TransferSource.BYRON,
+      source: TransferSource.BIP44,
     });
     this.actions.yoroiTransfer.setupTransferFundsWithMnemonic.trigger({
       recoveryPhrase: phrase

--- a/app/stores/jormungandr/JormungandrYoroiTransferStore.js
+++ b/app/stores/jormungandr/JormungandrYoroiTransferStore.js
@@ -68,15 +68,10 @@ export default class JormungandrYoroiTransferStore extends Store {
 
     request.updateStatusCallback();
 
-    const sourceIsJormungandrWallet = (
-      this.stores.yoroiTransfer.transferSource === TransferSource.JORMUNGANDR_UTXO ||
-      this.stores.yoroiTransfer.transferSource === TransferSource.JORMUNGANDR_CHIMERIC_ACCOUNT
-    );
-
     // 3) Calculate private keys for restored wallet utxo
     const accountKey = RustModule.WalletV3.Bip32PrivateKey
       .from_bytes(Buffer.from(masterKey, 'hex'))
-      .derive(sourceIsJormungandrWallet
+      .derive(this.stores.yoroiTransfer.transferSource === TransferSource.CIP1852
         ? WalletTypePurpose.CIP1852
         : WalletTypePurpose.BIP44)
       .derive(CoinTypes.CARDANO)
@@ -98,7 +93,7 @@ export default class JormungandrYoroiTransferStore extends Store {
       signingKey: accountKey,
       getUTXOsForAddresses:
         this.stores.substores.jormungandr.stateFetchStore.fetcher.getUTXOsForAddresses,
-      useLegacyWitness: !sourceIsJormungandrWallet,
+      useLegacyWitness: this.stores.yoroiTransfer.transferSource === TransferSource.BIP44,
       genesisHash: config.ChainNetworkId,
       feeConfig: config.LinearFee,
     });

--- a/app/stores/toplevel/YoroiTransferStore.js
+++ b/app/stores/toplevel/YoroiTransferStore.js
@@ -37,7 +37,7 @@ export default class YoroiTransferStore extends Store {
   @observable transferTx: ?TransferTx = null;
   @observable recoveryPhrase: string = '';
   @observable transferKind: TransferKindType = TransferKind.NORMAL;
-  @observable transferSource: TransferSourceType = TransferSource.BYRON;
+  @observable transferSource: TransferSourceType = TransferSource.BIP44;
 
   // eslint-disable-next-line no-restricted-syntax
   _asyncErrorWrapper: (<PT, RT>(
@@ -121,7 +121,7 @@ export default class YoroiTransferStore extends Store {
   _startTransferLegacyHardwareFunds: TransferKindType => void = (kind) => {
     runInAction(() => {
       this.transferKind = kind;
-      this.transferSource = TransferSource.BYRON;
+      this.transferSource = TransferSource.BIP44;
     });
     this._updateStatus(TransferStatus.HARDWARE_DISCLAIMER);
   }
@@ -289,7 +289,7 @@ export default class YoroiTransferStore extends Store {
     this.transferFundsRequest.reset();
     this.recoveryPhrase = '';
     this.transferKind = TransferKind.NORMAL;
-    this.transferSource = TransferSource.BYRON;
+    this.transferSource = TransferSource.BIP44;
   }
 
   _checkAndTransfer: {|

--- a/app/types/TransferTypes.js
+++ b/app/types/TransferTypes.js
@@ -29,10 +29,9 @@ export type TransferTx = {|
 |}
 
 export const TransferSource = Object.freeze({
-  BYRON: 0,
-  JORMUNGANDR_UTXO: 1,
-  JORMUNGANDR_CHIMERIC_ACCOUNT: 2,
-  SHELLEY: 3,
+  BIP44: 0,
+  CIP1852: 1,
+  CHIMERIC_ACCOUNT: 2,
 });
 export type TransferSourceType = $Values<typeof TransferSource>;
 


### PR DESCRIPTION
Technically speaking, you don't need this claim page to get your ITN withdrawals in Yoroi. In fact, it's almost debateable we should even provide an explicit ITN withdrawal page since it's kind of nightmarish for hardware wallets.

So in this PR, I just do all the API-side work to support withdrawal transactions since we need it for proper reward claiming later and it's useful to have the tx generation code stable now so we can easily reuse this in Yoroi Mobile