### PR TITLE
Add YOROI as default pool

### DIFF
--- a/app/config/stringConfig.js
+++ b/app/config/stringConfig.js
@@ -3,3 +3,5 @@
 export const Bech32Prefix = Object.freeze({
   ADDRESS: 'addr',
 });
+
+export const YoroiPoolId = 'df1750df9b2df285fcfb50f4740657a18ee3af42727d410c37b86207';

--- a/app/containers/wallet/staking/CardanoStakingPage.js
+++ b/app/containers/wallet/staking/CardanoStakingPage.js
@@ -36,6 +36,7 @@ import type { ReputationObject, } from '../../../api/jormungandr/lib/state-fetch
 import config from '../../../config';
 import { handleExternalLinkClick } from '../../../utils/routing';
 import { WalletTypeOption, } from '../../../api/ada/lib/storage/models/ConceptualWallet/interfaces';
+import { YoroiPoolId } from '../../../config/stringConfig';
 
 export type GeneratedData = typeof CardanoStakingPage.prototype.generated;
 
@@ -58,6 +59,10 @@ export default class CardanoStakingPage extends Component<Props> {
     this.generated.actions.ada.delegationTransaction.reset.trigger({ justTransaction: false });
     this.generated.actions.ada.delegationTransaction.setPools.trigger([]);
     this.generated.stores.delegation.poolInfoQuery.reset();
+  }
+
+  async componentDidMount() {
+    await this.generated.actions.ada.delegationTransaction.setPools.trigger([YoroiPoolId]);
   }
 
   render(): Node {

--- a/app/stores/ada/AdaDelegationStore.js
+++ b/app/stores/ada/AdaDelegationStore.js
@@ -30,9 +30,10 @@ import {
   genToRelativeSlotNumber,
   genTimeToSlot,
 } from '../../api/ada/lib/storage/bridge/timeUtils';
-import { isCardanoHaskell, getCardanoHaskellBaseConfig } from '../../api/ada/lib/storage/database/prepackaged/networks';
+import { networks, isCardanoHaskell, getCardanoHaskellBaseConfig } from '../../api/ada/lib/storage/database/prepackaged/networks';
 import type { DelegationRequests, RewardHistoryForWallet } from '../toplevel/DelegationStore';
 import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
+import { YoroiPoolId } from '../../config/stringConfig';
 
 export default class AdaDelegationStore extends Store {
 
@@ -232,6 +233,13 @@ export default class AdaDelegationStore extends Store {
         }
         if (asGetStakingKey(selected) != null) {
           await this.refreshDelegation(selected);
+          if (selected.getParent().getNetworkInfo().NetworkId === networks.ByronMainnet.NetworkId) {
+            // we want to always cache the Yoroi pool info on mainnet
+            await this.updatePoolInfo({
+              network: networks.ByronMainnet,
+              allPoolIds: [YoroiPoolId],
+            });
+          }
         }
       },
     );


### PR DESCRIPTION
As you can see from the gif, if you just press "next", then YOROI is selected. However, if you modify the field, you can delegate to a different pool

![yoroi-default](https://user-images.githubusercontent.com/2608559/89797002-5146dd80-db65-11ea-81d4-abb759dca786.gif)
