### PR TITLE
fix resync button

### DIFF
--- a/app/components/wallet/settings/ResyncBlock.js
+++ b/app/components/wallet/settings/ResyncBlock.js
@@ -8,6 +8,7 @@ import { observer } from 'mobx-react';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { ButtonSkin } from 'react-polymorph/lib/skins/simple/ButtonSkin';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
+import globalMessages from '../../../i18n/global-messages';
 
 export const messages: * = defineMessages({
   titleLabel: {
@@ -17,10 +18,6 @@ export const messages: * = defineMessages({
   resyncExplanation: {
     id: 'wallet.settings.resync.explanation',
     defaultMessage: '!!!If you are experiencing issues with your wallet, or think you have an incorrect balance or transaction history, you can delete the local data stored by Yoroi and resync with the blockchain.',
-  },
-  resyncButtonLabel: {
-    id: 'wallet.settings.resync.buttonLabel',
-    defaultMessage: '!!!Resync wallet',
   },
 });
 
@@ -52,7 +49,7 @@ export default class ResyncBlock extends Component<Props> {
 
         <Button
           className={buttonClassNames}
-          label={this.context.intl.formatMessage(messages.resyncButtonLabel)}
+          label={this.context.intl.formatMessage(globalMessages.resyncButtonLabel)}
           skin={ButtonSkin}
           onClick={this.props.openDialog}
         />

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -629,6 +629,10 @@ const globalMessages: * = defineMessages({
     id: 'global.labels.keyRegistrationPointer',
     defaultMessage: '!!!Key registration pointer',
   },
+  resyncButtonLabel: {
+    id: 'wallet.settings.resync.buttonLabel',
+    defaultMessage: '!!!Resync wallet',
+  },
 });
 export default globalMessages;
 

--- a/features/step_definitions/settings-ui-steps.js
+++ b/features/step_definitions/settings-ui-steps.js
@@ -124,6 +124,10 @@ When(/^I click on remove wallet$/, async function () {
   await this.click('.removeWallet');
 });
 
+When(/^I click on resync wallet$/, async function () {
+  await this.click('.resyncButton');
+});
+
 Then(/^I click on the checkbox$/, async function () {
   await this.click('.DangerousActionDialog_checkbox > .SimpleCheckbox_root');
 });

--- a/features/tx-history.feature
+++ b/features/tx-history.feature
@@ -65,6 +65,20 @@ Feature: Txs History
     Then I see the transactions summary
     And I should see that the number of transactions is 3
 
+  @it-139
+  Scenario: Open the tx history of an already loaded wallet (IT-139)
+    Given There is a Byron wallet stored named simple-pending-wallet
+    Then I see the transactions summary
+    And I should see that the number of transactions is 3
+    Then I navigate to the general settings screen
+    And I click on secondary menu "wallet" item
+    When I click on resync wallet
+    Then I click on the checkbox
+    And I click the next button
+    Then I navigate to wallet transactions screen
+    # should be same number of transactions after the resync
+    And I should see that the number of transactions is 3
+
   @it-96
   Scenario: Tx from other client updates tx history (IT-96)
     Given There is a Byron wallet stored named many-tx-wallet


### PR DESCRIPTION
Previous release of Yoroi broke the resync button. This PR fixes it and adds a test to avoid this happening again in the future.