### PR TITLE
Use path for Ledger upgrade transactions

### DIFF
--- a/app/actions/common/yoroi-transfer-actions.js
+++ b/app/actions/common/yoroi-transfer-actions.js
@@ -1,6 +1,9 @@
 // @flow
 import { AsyncAction, Action } from '../lib/Action';
 import type { RestoreModeType } from './wallet-restore-actions';
+import type {
+  Address, Addressing
+} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 
 export default class YoroiTransferActions {
   startTransferFunds: Action<{|
@@ -15,12 +18,12 @@ export default class YoroiTransferActions {
     paperPassword: string,
   |}> = new Action();
   checkAddresses: AsyncAction<{|
-    getDestinationAddress: void => Promise<string>,
+    getDestinationAddress: void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>,
   |}> = new AsyncAction();
   backToUninitialized: Action<void> = new Action();
   transferFunds: AsyncAction<{|
     next: void => Promise<void>,
-    getDestinationAddress: void => Promise<string>,
+    getDestinationAddress: void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>,
     rebuildTx: boolean,
   |}> = new AsyncAction();
   cancelTransferFunds: Action<void> = new Action();

--- a/app/api/ada/transactions/shelley/transactions.test.js
+++ b/app/api/ada/transactions/shelley/transactions.test.js
@@ -627,7 +627,9 @@ describe('Create sendAll unsigned TX from UTXO', () => {
       const sampleUtxos = genSampleUtxos();
       const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[1], sampleUtxos[2]];
       const sendAllResponse = sendAllUnsignedTxFromUtxo(
-        byronAddrToHex('Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4'),
+        {
+          address: byronAddrToHex('Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4')
+        },
         utxos,
         new BigNumber(0),
         getProtocolParams(),
@@ -648,7 +650,9 @@ describe('Create sendAll unsigned TX from UTXO', () => {
 
   it('Should fail due to insufficient funds (no inputs)', () => {
     expect(() => sendAllUnsignedTxFromUtxo(
-      byronAddrToHex('Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4'),
+      {
+        address: byronAddrToHex('Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4'),
+      },
       [],
       new BigNumber(0),
       getProtocolParams(),
@@ -659,7 +663,9 @@ describe('Create sendAll unsigned TX from UTXO', () => {
     const sampleUtxos = genSampleUtxos();
     const utxos: Array<RemoteUnspentOutput> = [sampleUtxos[0]];
     expect(() => sendAllUnsignedTxFromUtxo(
-      byronAddrToHex('Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4'),
+      {
+        address: byronAddrToHex('Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4'),
+      },
       utxos,
       new BigNumber(0),
       getProtocolParams(),

--- a/app/api/ada/transactions/transfer/legacyDaedalus.js
+++ b/app/api/ada/transactions/transfer/legacyDaedalus.js
@@ -20,6 +20,9 @@ import type {
 import { RustModule } from '../../lib/cardanoCrypto/rustLoader';
 import type { AddressKeyMap } from '../types';
 import { buildDaedalusTransferTx } from '../byron/daedalusTransfer';
+import type {
+  Address, Addressing,
+} from '../../lib/storage/models/PublicDeriver/interfaces';
 
 /**
  * Go through the whole UTXO and find the addresses that belong to the user along with the keys
@@ -67,7 +70,10 @@ export async function toSenderUtxos(payload: {|
 
 export async function daedalusTransferTxFromAddresses(payload: {|
   addressKeys: AddressKeyMap,
-  outputAddr: string,
+  outputAddr: {|
+    ...Address,
+    ...InexactSubset<Addressing>,
+  |},
   getUTXOsForAddresses: AddressUtxoFunc,
   absSlotNumber: BigNumber,
   protocolParams: {|

--- a/app/api/ada/transactions/transfer/legacyDaedalus.test.js
+++ b/app/api/ada/transactions/transfer/legacyDaedalus.test.js
@@ -98,7 +98,9 @@ describe('Byron era tx format tests', () => {
     const transferInfo = await daedalusTransferTxFromAddresses({
       addressKeys: addressMap,
       getUTXOsForAddresses: (_addresses) => Promise.resolve([utxo]),
-      outputAddr: outAddress,
+      outputAddr: {
+        address: outAddress
+      },
       absSlotNumber: new BigNumber(1),
       protocolParams: getProtocolParams(),
     });
@@ -155,7 +157,9 @@ describe('Byron era tx format tests', () => {
     expect(daedalusTransferTxFromAddresses({
       addressKeys: addressMap,
       getUTXOsForAddresses: (_addresses) => Promise.resolve([utxo]),
-      outputAddr: outAddress,
+      outputAddr: {
+        address: outAddress
+      },
       absSlotNumber: new BigNumber(1),
       protocolParams: getProtocolParams(),
     })).rejects.toThrow(NotEnoughMoneyToSendError);
@@ -191,7 +195,9 @@ describe('Byron era tx format tests', () => {
     const transferInfo = await daedalusTransferTxFromAddresses({
       addressKeys: addressMap,
       getUTXOsForAddresses: (_addresses) => Promise.resolve(utxo),
-      outputAddr: outAddress,
+      outputAddr: {
+        address: outAddress
+      },
       absSlotNumber: new BigNumber(1),
       protocolParams: getProtocolParams(),
     });

--- a/app/api/ada/transactions/transfer/legacyYoroi.js
+++ b/app/api/ada/transactions/transfer/legacyYoroi.js
@@ -16,7 +16,10 @@ import { toSenderUtxos } from './utils';
 
 export async function yoroiTransferTxFromAddresses(payload: {|
   addresses: Array<{| ...Address, ...Addressing |}>,
-  outputAddr: string,
+  outputAddr: {|
+    ...Address,
+    ...InexactSubset<Addressing>,
+  |},
   keyLevel: number,
   signingKey: RustModule.WalletV4.Bip32PrivateKey,
   getUTXOsForAddresses: AddressUtxoFunc,

--- a/app/api/ada/transactions/transfer/legacyYoroi.test.js
+++ b/app/api/ada/transactions/transfer/legacyYoroi.test.js
@@ -119,7 +119,9 @@ describe('Haskell Shelley era tx format tests', () => {
       getUTXOsForAddresses: (_addresses) => Promise.resolve([utxo]),
       keyLevel: Bip44DerivationLevels.ACCOUNT.level,
       signingKey: accountPrivateKey,
-      outputAddr: outAddress,
+      outputAddr: {
+        address: outAddress
+      },
       absSlotNumber: new BigNumber(1),
       protocolParams: getProtocolParams(),
     });

--- a/app/containers/transfer/UpgradeTxDialogContainer.js
+++ b/app/containers/transfer/UpgradeTxDialogContainer.js
@@ -99,7 +99,7 @@ export default class UpgradeTxDialogContainer extends Component<Props> {
     }
 
     return {
-      recoveredBalance: tentativeTx.totalInput(true),
+      recoveredBalance: tentativeTx.totalOutput(true).plus(tentativeTx.fee(true)),
       fee: tentativeTx.fee(true),
       senders: tentativeTx
         .uniqueSenderAddresses(),

--- a/app/containers/transfer/YoroiTransferPage.js
+++ b/app/containers/transfer/YoroiTransferPage.js
@@ -38,6 +38,9 @@ import WithdrawalTxDialogContainer from './WithdrawalTxDialogContainer';
 import type { GeneratedData as WithdrawalTxDialogContainerData } from './WithdrawalTxDialogContainer';
 import { genAddressLookup } from '../../stores/stateless/addressStores';
 import type { IAddressTypeStore, IAddressTypeUiSubset } from '../../stores/stateless/addressStores';
+import type {
+  Address, Addressing
+} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 
 // Stay this long on the success page, then jump to the wallet transactions page
 const SUCCESS_PAGE_STAY_TIME = 5 * 1000;
@@ -299,7 +302,7 @@ export default class YoroiTransferPage extends Component<InjectedOrGenerated<Gen
         |},
         checkAddresses: {|
           trigger: (params: {|
-            getDestinationAddress: void => Promise<string>
+            getDestinationAddress: void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>
           |}) => Promise<void>
         |},
         setupTransferFundsWithMnemonic: {|
@@ -318,7 +321,7 @@ export default class YoroiTransferPage extends Component<InjectedOrGenerated<Gen
         |},
         transferFunds: {|
           trigger: (params: {|
-            getDestinationAddress: void => Promise<string>,
+            getDestinationAddress: void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>,
             next: void => Promise<void>,
             rebuildTx: boolean
           |}) => Promise<void>
@@ -352,7 +355,7 @@ export default class YoroiTransferPage extends Component<InjectedOrGenerated<Gen
         error: ?LocalizableError,
         nextInternalAddress: (
           PublicDeriver<>
-        ) => void => Promise<string>,
+        ) => void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>,
         recoveryPhrase: string,
         status: TransferStatusT,
         transferTx: ?TransferTx,

--- a/app/containers/transfer/YoroiTransferPage.stories.js
+++ b/app/containers/transfer/YoroiTransferPage.stories.js
@@ -43,6 +43,9 @@ import type { TransferStatusT, TransferTx } from '../../types/TransferTypes';
 import LocalizableError from '../../i18n/LocalizableError';
 import type { IAddressTypeStore, IAddressTypeUiSubset } from '../../stores/stateless/addressStores';
 import { allAddressSubgroups } from '../../stores/stateless/addressStores';
+import type {
+  Address, Addressing
+} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 
 export default {
   title: `${__filename.split('.')[0]}`,
@@ -73,7 +76,9 @@ const genBaseProps: {|
       +status: TransferStatusT,
       +error: ?LocalizableError,
       +transferTx: ?TransferTx,
-      +nextInternalAddress: PublicDeriver<> => (void => Promise<string>),
+      +nextInternalAddress: (
+        PublicDeriver<>
+       ) => (void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>),
       +recoveryPhrase: string,
     |}>,
   |},
@@ -119,7 +124,9 @@ const genBaseProps: {|
       status: TransferStatus.UNINITIALIZED,
       error: undefined,
       transferTx: undefined,
-      nextInternalAddress: (_publicDeriver) => (async () => 'Ae2tdPwUPEZ5PxKxoyZDgjsKgMWMpTRa4PH3sVgARSGBsWwNBH3qg7cMFsP'),
+      nextInternalAddress: (_publicDeriver) => (async () => ({
+        address: 'Ae2tdPwUPEZ5PxKxoyZDgjsKgMWMpTRa4PH3sVgARSGBsWwNBH3qg7cMFsP'
+      })),
       recoveryPhrase: '',
       ...request.yoroiTransfer,
     },

--- a/app/stores/ada/AdaWalletRestoreStore.js
+++ b/app/stores/ada/AdaWalletRestoreStore.js
@@ -9,6 +9,9 @@ import {
 } from '../lib/check';
 import { ApiOptions, getApiForNetwork } from '../../api/common/utils';
 import { ApiMethodNotYetImplementedError } from '../lib/Request';
+import type {
+  Address, Addressing
+} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 
 export default class AdaWalletRestoreStore extends Store {
 
@@ -42,7 +45,7 @@ export default class AdaWalletRestoreStore extends Store {
     });
   }
 
-  _getFirstCip1852InternalAddr: void => string = () => {
+  _getFirstCip1852InternalAddr: void => {| ...Address, ...InexactSubset<Addressing> |} = () => {
     throw new ApiMethodNotYetImplementedError();
     // const phrase = this.stores.walletRestore.recoveryResult?.phrase;
     // if (phrase == null) {

--- a/app/stores/ada/AdaYoroiTransferStore.js
+++ b/app/stores/ada/AdaYoroiTransferStore.js
@@ -30,6 +30,9 @@ import {
 import {
   asGetAllUtxos, asHasUtxoChains,
 } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
+import type {
+  Address, Addressing
+} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 
 export default class AdaYoroiTransferStore extends Store {
 
@@ -80,7 +83,7 @@ export default class AdaYoroiTransferStore extends Store {
   generateTransferTxFromMnemonic: {|
     recoveryPhrase: string,
     updateStatusCallback: void => void,
-    getDestinationAddress: void => Promise<string>,
+    getDestinationAddress: void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>,
   |} => Promise<TransferTx> = async (request) => {
     if (!this.stores.yoroiTransfer.mode) {
       throw new Error(`${nameof(AdaYoroiTransferStore)}::${nameof(this.generateTransferTxFromMnemonic)} no mode specified`);
@@ -97,7 +100,7 @@ export default class AdaYoroiTransferStore extends Store {
   generateTransferTxForRewardAccount: {|
     recoveryPhrase: string,
     updateStatusCallback: void => void,
-    getDestinationAddress: void => Promise<string>,
+    getDestinationAddress: void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>,
   |} => Promise<TransferTx> = async (request) => {
     const { createWithdrawalTx } = this.stores.substores.ada.delegationTransaction;
     createWithdrawalTx.reset();
@@ -168,7 +171,7 @@ export default class AdaYoroiTransferStore extends Store {
   generateTransferTxForByron: {|
     recoveryPhrase: string,
     updateStatusCallback: void => void,
-    getDestinationAddress: void => Promise<string>,
+    getDestinationAddress: void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>,
   |} => Promise<TransferTx> = async (request) => {
     // 1) get receive address
     const destinationAddress = await request.getDestinationAddress();

--- a/app/stores/jormungandr/JormungandrDaedalusTransferStore.js
+++ b/app/stores/jormungandr/JormungandrDaedalusTransferStore.js
@@ -20,7 +20,7 @@ export default class JormungandrDaedalusTransferStore extends Store {
     ).reduce((acc, next) => Object.assign(acc, next), {});
     return await daedalusTransferTxFromAddresses({
       addressKeys: request.addressKeys,
-      outputAddr: request.outputAddr,
+      outputAddr: request.outputAddr.address,
       getUTXOsForAddresses:
         this.stores.substores.ada.stateFetchStore.fetcher.getUTXOsForAddresses,
       genesisHash: config.ChainNetworkId,

--- a/app/stores/jormungandr/JormungandrWalletRestoreStore.js
+++ b/app/stores/jormungandr/JormungandrWalletRestoreStore.js
@@ -22,6 +22,9 @@ import {
   buildCheckAndCall,
 } from '../lib/check';
 import { ApiOptions, getApiForNetwork } from '../../api/common/utils';
+import type {
+  Address, Addressing
+} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 
 export default class JormungandrWalletRestoreStore extends Store {
 
@@ -55,7 +58,7 @@ export default class JormungandrWalletRestoreStore extends Store {
     });
   }
 
-  _getFirstCip1852InternalAddr: void => string = () => {
+  _getFirstCip1852InternalAddr: void => {| ...Address, ...InexactSubset<Addressing> |} = () => {
     const phrase = this.stores.walletRestore.recoveryResult?.phrase;
     if (phrase == null) {
       throw new Error(`${nameof(this._getFirstCip1852InternalAddr)} no recovery phrase set. Should never happen`);
@@ -82,7 +85,9 @@ export default class JormungandrWalletRestoreStore extends Store {
       environment.getDiscriminant(),
     );
     const internalAddrHash = Buffer.from(internalAddr.as_bytes()).toString('hex');
-    return internalAddrHash;
+    return {
+      address: internalAddrHash,
+    };
   }
 
   _restoreToDb: void => Promise<void> = async () => {

--- a/app/stores/jormungandr/JormungandrYoroiTransferStore.js
+++ b/app/stores/jormungandr/JormungandrYoroiTransferStore.js
@@ -21,6 +21,9 @@ import {
 import {
   getJormungandrBaseConfig,
 } from '../../api/ada/lib/storage/database/prepackaged/networks';
+import type {
+  Address, Addressing
+} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 
 export default class JormungandrYoroiTransferStore extends Store {
 
@@ -57,7 +60,7 @@ export default class JormungandrYoroiTransferStore extends Store {
   generateTransferTxFromMnemonic: {|
     recoveryPhrase: string,
     updateStatusCallback: void => void,
-    getDestinationAddress: void => Promise<string>,
+    getDestinationAddress: void => Promise<{| ...Address, ...InexactSubset<Addressing> |}>,
   |} => Promise<TransferTx> = async (request) => {
     // 1) get receive address
     const destinationAddress = await request.getDestinationAddress();
@@ -96,7 +99,7 @@ export default class JormungandrYoroiTransferStore extends Store {
 
     const transferTx = await yoroiTransferTxFromAddresses({
       addresses,
-      outputAddr: destinationAddress,
+      outputAddr: destinationAddress.address,
       keyLevel: Bip44DerivationLevels.ACCOUNT.level,
       signingKey: accountKey,
       getUTXOsForAddresses:

--- a/app/stores/toplevel/DaedalusTransferStore.js
+++ b/app/stores/toplevel/DaedalusTransferStore.js
@@ -33,6 +33,9 @@ import { getApiForNetwork } from '../../api/common/utils';
 import type { AddressKeyMap } from '../../api/ada/transactions/types';
 import { isCardanoHaskell } from '../../api/ada/lib/storage/database/prepackaged/networks';
 import { normalizeToBase58 } from '../../api/ada/lib/storage/bridge/utils';
+import type {
+  Address, Addressing
+} from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 
 declare var CONFIG: ConfigType;
 const websocketUrl = CONFIG.network.websocketUrl;
@@ -41,7 +44,7 @@ const WS_CODE_NORMAL_CLOSURE = 1000;
 
 export type BuildTxFunc = {|
   addressKeys: AddressKeyMap,
-  outputAddr: string,
+  outputAddr: {| ...Address, ...InexactSubset<Addressing> |},
 |} => Promise<TransferTx>;
 
 export default class DaedalusTransferStore extends Store {
@@ -111,7 +114,10 @@ export default class DaedalusTransferStore extends Store {
     if (nextInternal.addressInfo == null) {
       throw new Error(`${nameof(this._setupTransferWebSocket)} no internal addresses left. Should never happen`);
     }
-    const nextInternalAddress = nextInternal.addressInfo.addr.Hash;
+    const nextInternalAddress = {
+      address: nextInternal.addressInfo.addr.Hash,
+      addressing: nextInternal.addressInfo.addressing,
+    };
 
     this._updateStatus(TransferStatus.RESTORING_ADDRESSES);
     runInAction(() => {

--- a/stories/helpers/StoryWrapper.js
+++ b/stories/helpers/StoryWrapper.js
@@ -31,10 +31,11 @@ import { getVarsForTheme } from '../../app/stores/toplevel/ProfileStore';
 import { withKnobs, select, boolean } from '@storybook/addon-knobs';
 import { addDecorator } from '@storybook/react';
 
-import LocalizableError from '../../app/i18n/LocalizableError';
+import LocalizableError, { UnexpectedError } from '../../app/i18n/LocalizableError';
 import globalMessages from '../../app/i18n/global-messages';
 import { ledgerErrors } from '../../app/domain/LedgerLocalizedError';
 import type { UnitOfAccountSettingType } from '../../app/types/unitOfAccountType';
+import { IncorrectVersionError, IncorrectDeviceError } from '../../app/domain/ExternalDeviceCommon';
 
 /**
  * This whole file is meant to mirror code in App.js
@@ -239,6 +240,9 @@ export const ledgerErrorCases: {|
   UserRejected: LocalizableError,
   Locked: LocalizableError,
   NotAllowed: LocalizableError,
+  Unexpected: LocalizableError,
+  IncorrectSerial: LocalizableError,
+  IncorrectVersion: LocalizableError,
 |} = Object.freeze({
   None: undefined,
   U2fTimeout: new LocalizableError(globalMessages.ledgerError101),
@@ -247,6 +251,15 @@ export const ledgerErrorCases: {|
   UserRejected: new LocalizableError(ledgerErrors.cancelOnLedgerConnectError102),
   Locked: new LocalizableError(ledgerErrors.deviceLockedError103),
   NotAllowed: new LocalizableError(ledgerErrors.deviceLockedError104),
+  Unexpected: new UnexpectedError(),
+  IncorrectSerial: new IncorrectDeviceError({
+    expectedDeviceId: '707fa118bf6b83',
+    responseDeviceId: '118db063477019',
+  }),
+  IncorrectVersion: new IncorrectVersionError({
+    supportedVersions: `2.0.4`,
+    responseVersion: '2.0.3',
+  }),
 });
 
 export const mockLedgerMeta = {


### PR DESCRIPTION
Currently when you do an upgrade transaction for Ledger from Byron -> Shelley, Ledger doesn't recognize the destination address as belonging to you. This PR passes the path along the pipeline to that Ledger is properly aware it's a change address.

It would be useful in the future to add a "verify address" next to it on the transfer page also.