### PR TITLE
Withdraw from currently selected wallet

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -25,7 +25,6 @@ unnecessary-optional-chain=warn
 ambiguous-object-type=error
 unnecessary-invariant=warn
 deprecated-utility=error
-unsafe-addition=error
 # re-enable this if it's ever shipped as part of Flow
 # no-floating-promises=warn
 

--- a/app/actions/ada/delegation-transaction-actions.js
+++ b/app/actions/ada/delegation-transaction-actions.js
@@ -8,6 +8,9 @@ export default class DelegationTransactionActions {
     publicDeriver: PublicDeriver<>,
     poolRequest: string | void,
   |}> = new AsyncAction();
+  createWithdrawalTxForWallet: AsyncAction<{|
+    publicDeriver: PublicDeriver<>,
+  |}> = new AsyncAction();
   signTransaction: AsyncAction<{|
     password?: string,
     publicDeriver: PublicDeriver<>,

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -359,8 +359,7 @@ export type CreateDelegationTxRequest = {|
     IGetPublic & IGetAllUtxos & IHasUtxoChains & IGetStakingKey
   ),
   absSlotNumber: BigNumber,
-  // TODO: maybe this probably be a trait of public deriver instead?
-  computeRegistrationStatus: void => Promise<boolean>,
+  registrationStatus: boolean,
   poolRequest: void | string,
   valueInAccount: BigNumber,
 |};
@@ -381,7 +380,7 @@ export type CreateWithdrawalTxRequest = {|
   getAccountState: AccountStateFunc,
   withdrawals: Array<{|
     ...({| privateKey: RustModule.WalletV4.PrivateKey |} | {| ...Addressing |}),
-    rewardAddress: string, // address you're withdrawing from
+    rewardAddress: string, // address you're withdrawing from (hex)
     /**
      * you need to withdraw all ADA before deregistering
      * but you don't need to deregister in order to withdraw
@@ -1055,8 +1054,6 @@ export default class AdaApi {
     Logger.debug(`${nameof(AdaApi)}::${nameof(this.createDelegationTx)} called`);
 
     try {
-      const registrationStatus = await request.computeRegistrationStatus();
-
       const config = getCardanoHaskellBaseConfig(
         request.publicDeriver.getParent().getNetworkInfo()
       ).reduce((acc, next) => Object.assign(acc, next), {});
@@ -1090,7 +1087,7 @@ export default class AdaApi {
 
       const stakeDelegationCert = createCertificate(
         stakingKey,
-        registrationStatus,
+        request.registrationStatus,
         request.poolRequest
       );
 

--- a/app/api/ada/lib/state-fetch/types.js
+++ b/app/api/ada/lib/state-fetch/types.js
@@ -63,7 +63,7 @@ export type SendFunc = (body: SignedRequest) => Promise<SignedResponse>;
 export type RemoteTxState = 'Successful' | 'Failed' | 'Pending';
 
 export type RemoteTransactionShelley = {|
-  +ttl?: string,
+  +ttl: string,
   +fee: string,
   +certificates: $ReadOnlyArray<RemoteCertificate>,
   +withdrawals: Array<RemoteWithdrawal>,

--- a/app/api/ada/lib/storage/bridge/delegationUtils.js
+++ b/app/api/ada/lib/storage/bridge/delegationUtils.js
@@ -204,14 +204,26 @@ export async function getCurrentDelegation(
     allPoolIds: Array.from(seenPools)
   };
 }
-export async function getRegistrationHistory(
-  request: GetCurrentDelegationRequest,
-): Promise<{|
+
+export type GetRegistrationHistoryRequest = {|
   currEpoch: boolean,
   prevEpoch: boolean,
   prevPrevEpoch: boolean,
   fullHistory: Array<CertificateForKey>,
-|}> {
+|};
+export type GetRegistrationHistoryResponse = {|
+  currEpoch: boolean,
+  prevEpoch: boolean,
+  prevPrevEpoch: boolean,
+  fullHistory: Array<CertificateForKey>,
+|};
+export type GetRegistrationHistoryFunc = (
+  request: GetCurrentDelegationRequest
+) => Promise<GetRegistrationHistoryResponse>;
+
+export async function getRegistrationHistory(
+  request: GetCurrentDelegationRequest,
+): Promise<GetRegistrationHistoryResponse> {
   const delegations = await getCertificateHistory({
     publicDeriver: request.publicDeriver,
     stakingKeyAddressId: request.stakingKeyAddressId,

--- a/app/api/ada/lib/storage/bridge/tests/shelley.test.js
+++ b/app/api/ada/lib/storage/bridge/tests/shelley.test.js
@@ -117,6 +117,7 @@ const nextRegularSpend: number => RemoteTransaction = (purpose) => ({
   tx_ordinal: 0,
   epoch: 10,
   slot: 3651,
+  ttl: '99999999',
   inputs: [
     {
       // 'Ae2tdPwUPEZ6tzHKyuMLL6bh1au5DETgb53PTmJAN9aaCLtaUTWHvrS2mxo'

--- a/app/api/ada/lib/test-config.js
+++ b/app/api/ada/lib/test-config.js
@@ -12,8 +12,8 @@ const CONFIG: ConfigType = {
     simpleTemplate: '',
   },
   app: {
-    walletRefreshInterval: 10,
-    serverStatusRefreshInterval: 10,
+    walletRefreshInterval: 200000,
+    serverStatusRefreshInterval: 200000,
     logsBufferSize: 10,
     logsFileSuffix: 'log',
     addressRequestSize: 50,

--- a/app/api/common/lib/storage/bridge/delegationUtils.js
+++ b/app/api/common/lib/storage/bridge/delegationUtils.js
@@ -49,3 +49,12 @@ export type GetCurrentDelegationResponse = {|
 export type GetCurrentDelegationFunc = (
   request: GetCurrentDelegationRequest
 ) => Promise<GetCurrentDelegationResponse>;
+
+export type RewardHistoryRequest = string;
+export type RewardHistoryResponse = Array<[
+  number, // epoch
+  number, // amount
+]>;
+export type RewardHistoryFunc = (
+  request: RewardHistoryRequest
+) => Promise<RewardHistoryResponse>;

--- a/app/api/common/lib/storage/bridge/delegationUtils.js
+++ b/app/api/common/lib/storage/bridge/delegationUtils.js
@@ -38,6 +38,8 @@ export type CertificateForEpoch = {|
   pools: Array<PoolTuples>,
 |};
 export type GetCurrentDelegationResponse = {|
+  // careful: void -> never delegated at this time
+  // empty delegation -> undelegated at some point
   currEpoch: void | CertificateForEpoch,
   prevEpoch: void | CertificateForEpoch,
   prevPrevEpoch: void | CertificateForEpoch,

--- a/app/components/wallet/staking/dashboard/StakePool.js
+++ b/app/components/wallet/staking/dashboard/StakePool.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import jdenticon from 'jdenticon';
+import { toSvg } from 'jdenticon';
 import classnames from 'classnames';
 
 import { Button } from 'react-polymorph/lib/components/Button';
@@ -115,7 +115,7 @@ export default class StakePool extends Component<Props> {
 
     const { hash, poolName } = this.props;
 
-    const avatarSource = jdenticon.toSvg(hash, 36, { padding: 0 });
+    const avatarSource = toSvg(hash, 36, { padding: 0 });
 
     // Taken from Seiza (dangerouslyEmbedIntoDataURI())
     const avatar = `data:image/svg+xml;utf8,${encodeURIComponent(avatarSource)}`;

--- a/app/components/wallet/staking/dashboard/UpcomingRewards.js
+++ b/app/components/wallet/staking/dashboard/UpcomingRewards.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import type { Node } from 'react';
 import classnames from 'classnames';
 import { observer } from 'mobx-react';
-import jdenticon from 'jdenticon';
+import { toSvg } from 'jdenticon';
 import { defineMessages, intlShape } from 'react-intl';
 import globalMessages from '../../../../i18n/global-messages';
 import type { PoolTuples } from '../../../../api/jormungandr/lib/state-fetch/types';
@@ -150,7 +150,7 @@ export default class UpcomingRewards extends Component<Props> {
   }
 
   getAvatars: MiniPoolInfo => Node = (pool) => {
-    const avatarSource = jdenticon.toSvg(pool.id[0], 36, { padding: 0 });
+    const avatarSource = toSvg(pool.id[0], 36, { padding: 0 });
 
     // Taken from Seiza (dangerouslyEmbedIntoDataURI())
     const avatar = `data:image/svg+xml;utf8,${encodeURIComponent(avatarSource)}`;

--- a/app/components/wallet/staking/dashboard/UserSummary.js
+++ b/app/components/wallet/staking/dashboard/UserSummary.js
@@ -72,6 +72,7 @@ type Props = {|
     +primaryTicker: string,
     +decimalPlaces: number,
   |},
+  +withdrawRewards: void | (void => void),
 |};
 
 type State = {|
@@ -157,15 +158,28 @@ export default class UserSummary extends Component<Props, State> {
               <p className={styles.value}>
                 {totalRewards.ADA} {this.props.meta.primaryTicker}
               </p>
-              <span
-                className={styles.note}
-                role="button"
-                tabIndex={0}
-                onKeyPress={() => null}
-                onClick={this.props.openLearnMore}
-              >
-                {intl.formatMessage(messages.note)}
-              </span>
+              <div className={styles.sectionActions}>
+                {this.props.withdrawRewards != null && (
+                  <div
+                    className={styles.note}
+                    role="button"
+                    tabIndex={0}
+                    onKeyPress={() => null}
+                    onClick={this.props.withdrawRewards}
+                  >
+                    {intl.formatMessage(globalMessages.withdrawnLabel)}
+                  </div>
+                )}
+                <div
+                  className={styles.note}
+                  role="button"
+                  tabIndex={0}
+                  onKeyPress={() => null}
+                  onClick={this.props.openLearnMore}
+                >
+                  {intl.formatMessage(messages.note)}
+                </div>
+              </div>
             </>
           )
           : (<LoadingSpinner small />)

--- a/app/components/wallet/staking/dashboard/UserSummary.js
+++ b/app/components/wallet/staking/dashboard/UserSummary.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import type { Node } from 'react';
 import BigNumber from 'bignumber.js';
+import classnames from 'classnames';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape, FormattedMessage, } from 'react-intl';
 import type { $npm$ReactIntl$MessageDescriptor, $npm$ReactIntl$IntlFormat } from 'react-intl';
@@ -161,13 +162,13 @@ export default class UserSummary extends Component<Props, State> {
               <div className={styles.sectionActions}>
                 {this.props.withdrawRewards != null && (
                   <div
-                    className={styles.note}
+                    className={classnames([styles.note, 'withdrawButton'])}
                     role="button"
                     tabIndex={0}
                     onKeyPress={() => null}
                     onClick={this.props.withdrawRewards}
                   >
-                    {intl.formatMessage(globalMessages.withdrawnLabel)}
+                    {intl.formatMessage(globalMessages.withdrawLabel)}
                   </div>
                 )}
                 <div

--- a/app/components/wallet/staking/dashboard/UserSummary.scss
+++ b/app/components/wallet/staking/dashboard/UserSummary.scss
@@ -10,6 +10,10 @@
     padding: 20px 24px;
     flex: 1;
     border-right: 1px solid var(--theme-dashboard-card-vertical-separator-color);
+
+    .sectionActions {
+        flex: 1;
+    }
 }
 
 .header {
@@ -70,7 +74,6 @@
     font-size: 12px;
     line-height: 14px;
     color: var(--theme-dashboard-link-color);
-    float: right;
     margin-left: auto;
     margin-right: 0px;
     width: max-content;

--- a/app/containers/transfer/DeregisterDialogContainer.js
+++ b/app/containers/transfer/DeregisterDialogContainer.js
@@ -6,8 +6,9 @@ import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import globalMessages from '../../i18n/global-messages';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
-
+import type { ComplexityLevelType } from '../../types/complexityLevelType';
 import type { InjectedOrGenerated } from '../../types/injectedPropsType';
+import { ComplexityLevels } from '../../types/complexityLevelType';
 
 import DangerousActionDialog from '../../components/widgets/DangerousActionDialog';
 
@@ -54,6 +55,13 @@ export default class DeregisterDialogContainer extends Component<Props> {
   static contextTypes: {|intl: $npm$ReactIntl$IntlFormat|} = {
     intl: intlShape.isRequired,
   };
+
+  componentDidMount() {
+    this.generated.actions.ada.delegationTransaction.setShouldDeregister.trigger(false);
+    if (this.generated.stores.profile.selectedComplexityLevel !== ComplexityLevels.Advanced) {
+      this.props.onNext();
+    }
+  }
 
   @observable isChecked: boolean = false;
 
@@ -114,6 +122,9 @@ export default class DeregisterDialogContainer extends Component<Props> {
       |},
     |},
     stores: {|
+      profile: {|
+        selectedComplexityLevel: ?ComplexityLevelType,
+      |},
     |}
     |} {
     if (this.props.generated !== undefined) {
@@ -122,9 +133,13 @@ export default class DeregisterDialogContainer extends Component<Props> {
     if (this.props.stores == null || this.props.actions == null) {
       throw new Error(`${nameof(DeregisterDialogContainer)} no way to generated props`);
     }
-    const { actions, } = this.props;
+    const { actions, stores, } = this.props;
     return Object.freeze({
-      stores: Object.freeze({}),
+      stores: Object.freeze({
+        profile: {
+          selectedComplexityLevel: stores.profile.selectedComplexityLevel,
+        },
+      }),
       actions: {
         ada: {
           delegationTransaction: {

--- a/app/containers/transfer/DeregisterDialogContainer.js
+++ b/app/containers/transfer/DeregisterDialogContainer.js
@@ -17,6 +17,7 @@ export type GeneratedData = typeof DeregisterDialogContainer.prototype.generated
 type Props = {|
   ...InjectedOrGenerated<GeneratedData>,
   +onNext: void => void,
+  +alwaysShowDeregister: boolean,
 |};
 
 const dialogMessages = defineMessages({
@@ -58,7 +59,10 @@ export default class DeregisterDialogContainer extends Component<Props> {
 
   componentDidMount() {
     this.generated.actions.ada.delegationTransaction.setShouldDeregister.trigger(false);
-    if (this.generated.stores.profile.selectedComplexityLevel !== ComplexityLevels.Advanced) {
+    if (
+      this.props.alwaysShowDeregister === false &&
+      this.generated.stores.profile.selectedComplexityLevel !== ComplexityLevels.Advanced
+    ) {
       this.props.onNext();
     }
   }

--- a/app/containers/transfer/Transfer.mock.js
+++ b/app/containers/transfer/Transfer.mock.js
@@ -162,13 +162,6 @@ export const mockTransferProps: {
         ShelleyEraOptionDialogContainerProps: {
           generated: {
             stores: {
-              profile: {
-                selectedComplexityLevel: select(
-                  'complexityLevel',
-                  ComplexityLevels,
-                  ComplexityLevels.Advanced
-                ),
-              },
               wallets: {
                 selected: request.selected,
               },
@@ -196,7 +189,15 @@ export const mockTransferProps: {
             },
             DeregisterDialogContainerProps: {
               generated: {
-                stores: Object.freeze({}),
+                stores: {
+                  profile: {
+                    selectedComplexityLevel: select(
+                      'complexityLevel',
+                      ComplexityLevels,
+                      ComplexityLevels.Advanced
+                    ),
+                  },
+                },
                 actions: {
                   ada: {
                     delegationTransaction: {

--- a/app/containers/transfer/YoroiTransferPage.stories.js
+++ b/app/containers/transfer/YoroiTransferPage.stories.js
@@ -182,6 +182,11 @@ const genBaseProps: {|
               },
             },
             ada: {
+              trezorSend: {
+                sendUsingTrezor: {
+                  trigger: async (req) => action('sendUsingTrezor')(req),
+                },
+              },
               ledgerSend: {
                 sendUsingLedgerWallet: {
                   trigger: async (req) => action('sendUsingLedgerWallet')(req),

--- a/app/containers/transfer/YoroiTransferPage.stories.js
+++ b/app/containers/transfer/YoroiTransferPage.stories.js
@@ -457,6 +457,28 @@ export const TransferTxPage = (): Node => {
   })();
 };
 
+export const WithdrawalKeyInput = (): Node => {
+  const wallet = genShelleyCip1852DummyWithCache();
+  const lookup = walletLookup([wallet]);
+  return (() => {
+    const baseProps = genBaseProps({
+      wallet: wallet.publicDeriver,
+      yoroiTransfer: {
+        status: TransferStatus.GETTING_WITHDRAWAL_KEY,
+      },
+    });
+    return wrapTransfer(
+      mockTransferProps({
+        currentRoute: ROUTES.TRANSFER.YOROI,
+        selected: wallet.publicDeriver,
+        ...lookup,
+        YoroiTransferPageProps: baseProps,
+      }),
+    );
+  })();
+};
+
+
 export const WithdrawalTxPage = (): Node => {
   const wallet = genShelleyCip1852DummyWithCache();
   const lookup = walletLookup([wallet]);

--- a/app/containers/transfer/options/ShelleyEraOptionDialogContainer.js
+++ b/app/containers/transfer/options/ShelleyEraOptionDialogContainer.js
@@ -124,6 +124,16 @@ export default class ShelleyEraOptionDialogContainer extends Component<Props> {
       return (
         <DeregisterDialogContainer
           {...this.generated.DeregisterDialogContainerProps}
+          alwaysShowDeregister={
+            /* very easy for the user to not understand what is going on
+             * and enter their current wallet's recovery phrase in the claim / transfer page
+             * ex: using this thinking it will claim just ITN rewards in their current wallet
+             * not realizing this will undelegate their funds if they choose to deregister
+             * so by default, the claim / transfer page will hide the deregistration dialog
+             * unless the person considers themselves an "advanced" user
+             */
+             false
+          }
           onNext={() => {
             this.generated.actions.dialogs.updateDataForActiveDialog.trigger({
               disclaimer: DisclaimerStatus.Done,

--- a/app/containers/transfer/options/ShelleyEraOptionDialogContainer.js
+++ b/app/containers/transfer/options/ShelleyEraOptionDialogContainer.js
@@ -16,10 +16,9 @@ import { PublicDeriver } from '../../../api/ada/lib/storage/models/PublicDeriver
 import { WalletTypeOption, } from '../../../api/ada/lib/storage/models/ConceptualWallet/interfaces';
 import RewardClaimDisclaimer from '../../../components/transfer/RewardClaimDisclaimer';
 import { ChainDerivations } from '../../../config/numbersConfig';
-import type { ComplexityLevelType } from '../../../types/complexityLevelType';
 import DeregisterDialogContainer from '../DeregisterDialogContainer';
 import type { GeneratedData as DeregisterDialogContainerData } from '../DeregisterDialogContainer';
-import { ComplexityLevels } from '../../../types/complexityLevelType';
+
 import {
   Bip44DerivationLevels,
 } from '../../../api/ada/lib/storage/database/walletTypes/bip44/api/utils';
@@ -44,10 +43,6 @@ export default class ShelleyEraOptionDialogContainer extends Component<Props> {
   static contextTypes: {|intl: $npm$ReactIntl$IntlFormat|} = {
     intl: intlShape.isRequired
   };
-
-  componentDidMount() {
-    this.generated.actions.ada.delegationTransaction.setShouldDeregister.trigger(false);
-  }
 
   startTransferIcarusRewards: void => void = () => {
     this.generated.actions.yoroiTransfer.startTransferFunds.trigger({
@@ -114,11 +109,7 @@ export default class ShelleyEraOptionDialogContainer extends Component<Props> {
             continuation: undefined,
           })}
           onNext={() => {
-            const nextStatus = (
-              this.generated.stores.profile.selectedComplexityLevel === ComplexityLevels.Advanced
-            )
-              ? DisclaimerStatus.DeregisterDisclaimer
-              : DisclaimerStatus.Done;
+            const nextStatus = DisclaimerStatus.DeregisterDisclaimer;
             this.generated.actions.dialogs.updateDataForActiveDialog.trigger({
               disclaimer: nextStatus,
             });
@@ -167,9 +158,6 @@ export default class ShelleyEraOptionDialogContainer extends Component<Props> {
 
   @computed get generated(): {|
     stores: {|
-      profile: {|
-        selectedComplexityLevel: ?ComplexityLevelType,
-      |},
       wallets: {|
         selected: null | PublicDeriver<>,
       |},
@@ -212,9 +200,6 @@ export default class ShelleyEraOptionDialogContainer extends Component<Props> {
     const { yoroiTransfer } = actions;
     return Object.freeze({
       stores: {
-        profile: {
-          selectedComplexityLevel: stores.profile.selectedComplexityLevel,
-        },
         wallets: {
           selected: stores.wallets.selected,
         },

--- a/app/containers/wallet/WalletReceivePage.stories.js
+++ b/app/containers/wallet/WalletReceivePage.stories.js
@@ -225,6 +225,11 @@ const genBaseProps: {|
                     trigger: async (req) => action('sendUsingLedgerWallet')(req),
                   },
                 },
+                trezorSend: {
+                  sendUsingTrezor: {
+                    trigger: async (req) => action('sendUsingTrezor')(req),
+                  },
+                },
               },
             },
             stores: {

--- a/app/containers/wallet/WalletSummaryPage.stories.js
+++ b/app/containers/wallet/WalletSummaryPage.stories.js
@@ -348,6 +348,7 @@ export const Transaction = (): Node => {
         CertificateId: 0,
         TransactionId: 0,
         Kind: certificateSelect,
+        Ordinal: 0,
         Payload: ''
       },
     }];

--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -646,6 +646,7 @@ export default class StakingDashboardPage extends Component<Props> {
       return (
         <DeregisterDialogContainer
           {...this.generated.DeregisterDialogContainerProps}
+          alwaysShowDeregister
           onNext={() => {
             // note: purposely don't await since the next dialog will properly render the spinner
             this.generated.actions.ada.delegationTransaction.createWithdrawalTxForWallet.trigger({

--- a/app/containers/wallet/staking/StakingDashboardPage.stories.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.stories.js
@@ -35,9 +35,9 @@ import type {
   GetDelegatedBalanceFunc,
   CertificateForEpoch,
   GetCurrentDelegationFunc,
+  RewardHistoryFunc,
 } from '../../../api/common/lib/storage/bridge/delegationUtils';
 import type {
-  RewardHistoryForWallet,
   DelegationRequests,
   PoolMeta,
 } from '../../../stores/toplevel/DelegationStore';
@@ -568,7 +568,7 @@ function getStakingInfo(
       )),
     })
   );
-  const rewardHistory: CachedRequest<RewardHistoryForWallet> = new CachedRequest(
+  const rewardHistory: CachedRequest<RewardHistoryFunc> = new CachedRequest(
     _request => (
       stakingCase === stakingKeyCases.LongAgoDelegation ||
       stakingCase === stakingKeyCases.ManuallyUndelegate ||
@@ -607,7 +607,7 @@ export const Loading = (): Node => {
         allPoolIds: [],
       })
     );
-    const rewardHistory: CachedRequest<RewardHistoryForWallet> = new CachedRequest(
+    const rewardHistory: CachedRequest<RewardHistoryFunc> = new CachedRequest(
       _request => Promise.resolve([
       ])
     );
@@ -779,7 +779,7 @@ export const Errors = (): Node => {
       errorCases.Both
     );
     if (error === errorCases.PoolInfo || error === errorCases.Both) {
-      const rewardHistory: CachedRequest<RewardHistoryForWallet> = new CachedRequest(
+      const rewardHistory: CachedRequest<RewardHistoryFunc> = new CachedRequest(
         async _request => { throw new GetPoolInfoApiError(); }
       );
       rewardHistory.execute((null: any));

--- a/app/containers/wallet/staking/StakingDashboardPage.stories.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.stories.js
@@ -295,6 +295,11 @@ const genBaseProps: {|
                 },
               },
               ada: {
+                trezorSend: {
+                  sendUsingTrezor: {
+                    trigger: async (req) => action('sendUsingTrezor')(req),
+                  },
+                },
                 ledgerSend: {
                   sendUsingLedgerWallet: {
                     trigger: async (req) => action('sendUsingLedgerWallet')(req),

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -597,6 +597,10 @@ const globalMessages: * = defineMessages({
     id: 'wallet.transaction.withdrawalsLabel',
     defaultMessage: '!!!Withdrawals',
   },
+  withdrawnLabel: {
+    id: 'wallet.transaction.withdraw',
+    defaultMessage: '!!!Withdraw',
+  },
   byronLabel: {
     id: 'wallet.receive.navigation.byronLabel',
     defaultMessage: '!!!Byron'

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -597,7 +597,7 @@ const globalMessages: * = defineMessages({
     id: 'wallet.transaction.withdrawalsLabel',
     defaultMessage: '!!!Withdrawals',
   },
-  withdrawnLabel: {
+  withdrawLabel: {
     id: 'wallet.transaction.withdraw',
     defaultMessage: '!!!Withdraw',
   },

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -689,6 +689,7 @@
   "wallet.transaction.type.exchange": "Exchange",
   "wallet.transaction.type.intrawallet": "{currency} intrawallet transaction",
   "wallet.transaction.type.multiparty": "{currency} multiparty transaction",
+  "wallet.transaction.withdraw": "Withdraw",
   "wallet.transaction.withdrawalsLabel": "Withdrawals",
   "wallet.transfer.cards.byron": "Byron-era wallet",
   "wallet.transfer.cards.shelley": "Shelley-era wallet",

--- a/app/stores/ada/AdaDelegationStore.js
+++ b/app/stores/ada/AdaDelegationStore.js
@@ -27,13 +27,14 @@ import type {
   GetDelegatedBalanceFunc,
   GetCurrentDelegationFunc,
   GetCurrentDelegationResponse,
+  RewardHistoryFunc
 } from '../../api/common/lib/storage/bridge/delegationUtils';
 import {
   genToRelativeSlotNumber,
   genTimeToSlot,
 } from '../../api/ada/lib/storage/bridge/timeUtils';
 import { isCardanoHaskell, getCardanoHaskellBaseConfig } from '../../api/ada/lib/storage/database/prepackaged/networks';
-import type { DelegationRequests, RewardHistoryForWallet } from '../toplevel/DelegationStore';
+import type { DelegationRequests, } from '../toplevel/DelegationStore';
 import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
 import type { GetRegistrationHistoryResponse, GetRegistrationHistoryFunc } from '../../api/ada/lib/storage/bridge/delegationUtils';
 
@@ -55,7 +56,7 @@ export default class AdaDelegationStore extends Store {
       publicDeriver,
       getDelegatedBalance: new CachedRequest<GetDelegatedBalanceFunc>(getDelegatedBalance),
       getCurrentDelegation: new CachedRequest<GetCurrentDelegationFunc>(getCurrentDelegation),
-      rewardHistory: new CachedRequest<RewardHistoryForWallet>(async (address) => {
+      rewardHistory: new CachedRequest<RewardHistoryFunc>(async (address) => {
         // we need to defer this call because the store may not be initialized yet
         // by the time this constructor is called
         const stateFetcher = this.stores.substores.ada.stateFetchStore.fetcher;

--- a/app/stores/ada/AdaDelegationStore.js
+++ b/app/stores/ada/AdaDelegationStore.js
@@ -1,7 +1,8 @@
 // @flow
 
-import { action, reaction, runInAction } from 'mobx';
+import { action, observable, reaction, runInAction } from 'mobx';
 import BigNumber from 'bignumber.js';
+import { find } from 'lodash';
 import Store from '../base/Store';
 import {
   Logger,
@@ -20,6 +21,7 @@ import type {
 import {
   getDelegatedBalance,
   getCurrentDelegation,
+  getRegistrationHistory,
 } from '../../api/ada/lib/storage/bridge/delegationUtils';
 import type {
   GetDelegatedBalanceFunc,
@@ -33,15 +35,23 @@ import {
 import { isCardanoHaskell, getCardanoHaskellBaseConfig } from '../../api/ada/lib/storage/database/prepackaged/networks';
 import type { DelegationRequests, RewardHistoryForWallet } from '../toplevel/DelegationStore';
 import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
+import type { GetRegistrationHistoryResponse, GetRegistrationHistoryFunc } from '../../api/ada/lib/storage/bridge/delegationUtils';
+
+export type AdaDelegationRequests = {|
+  publicDeriver: PublicDeriver<>,
+  getRegistrationHistory: CachedRequest<GetRegistrationHistoryFunc>,
+|};
 
 export default class AdaDelegationStore extends Store {
+
+  @observable delegationRequests: Array<AdaDelegationRequests> = [];
 
   _recalculateDelegationInfoDisposer: void => void = () => {};
 
   @action addObservedWallet: PublicDeriver<> => void = (
     publicDeriver
   ) => {
-    const newObserved = {
+    this.stores.delegation.delegationRequests.push({
       publicDeriver,
       getDelegatedBalance: new CachedRequest<GetDelegatedBalanceFunc>(getDelegatedBalance),
       getCurrentDelegation: new CachedRequest<GetCurrentDelegationFunc>(getCurrentDelegation),
@@ -53,8 +63,11 @@ export default class AdaDelegationStore extends Store {
         return result[address] ?? [];
       }),
       error: undefined,
-    };
-    this.stores.delegation.delegationRequests.push(newObserved);
+    });
+    this.delegationRequests.push({
+      publicDeriver,
+      getRegistrationHistory: new CachedRequest<GetRegistrationHistoryFunc>(getRegistrationHistory),
+    });
   }
 
   setup(): void {
@@ -118,6 +131,19 @@ export default class AdaDelegationStore extends Store {
         allPoolIds: currentDelegation.allPoolIds,
       }));
 
+      const adaSpecific = (async () => {
+        const adaDelegationRequest = this.getDelegationRequests(publicDeriver);
+        if (adaDelegationRequest == null) {
+          return Promise.resolve();
+        }
+        const registrationHistory = await this._getRegistrationHistory({
+          publicDeriver: withStakingKey,
+          stakingKeyAddressId: stakingKeyResp.addr.AddressId,
+          delegationRequest: adaDelegationRequest,
+        });
+        return registrationHistory;
+      })();
+
       const rewardHistory = delegationRequest.rewardHistory.execute(
         stakingKeyResp.addr.Hash
       ).promise;
@@ -126,10 +152,38 @@ export default class AdaDelegationStore extends Store {
         accountStateCalcs,
         delegationHistory,
         rewardHistory,
+        adaSpecific,
       ]);
     } catch (e) {
       Logger.error(`${nameof(AdaDelegationStore)}::${nameof(this.refreshDelegation)} error: ` + stringifyError(e));
     }
+  }
+
+  _getRegistrationHistory: {|
+    publicDeriver: PublicDeriver<> & IGetStakingKey,
+    stakingKeyAddressId: number,
+    delegationRequest: AdaDelegationRequests,
+  |} => Promise<GetRegistrationHistoryResponse> = async (request) => {
+    const adaConfig = getCardanoHaskellBaseConfig(
+      request.publicDeriver.getParent().getNetworkInfo()
+    );
+    // TODO: use time store instead?
+    const toRelativeSlotNumber = await genToRelativeSlotNumber(adaConfig);
+    const timeToSlot = await genTimeToSlot(adaConfig);
+    const currentEpoch = toRelativeSlotNumber(
+      timeToSlot({
+        time: new Date(),
+      }).slot
+    ).epoch;
+
+    const currentDelegation = await request.delegationRequest.getRegistrationHistory.execute({
+      publicDeriver: request.publicDeriver,
+      stakingKeyAddressId: request.stakingKeyAddressId,
+      toRelativeSlotNumber,
+      currentEpoch,
+    }).promise;
+    if (currentDelegation == null) throw new Error('Should never happen');
+    return currentDelegation;
   }
 
   _getDelegationHistory: {|
@@ -206,6 +260,16 @@ export default class AdaDelegationStore extends Store {
         });
       }
     });
+  }
+
+  // TODO: refine input type to staking key wallets only
+  getDelegationRequests: PublicDeriver<> => void | AdaDelegationRequests = (
+    publicDeriver
+  ) => {
+    const foundRequest = find(this.delegationRequests, { publicDeriver });
+    if (foundRequest) return foundRequest;
+
+    return undefined; // can happen if the wallet is not a Shelley wallet
   }
 
   @action.bound

--- a/app/stores/jormungandr/JormungandrDelegationStore.js
+++ b/app/stores/jormungandr/JormungandrDelegationStore.js
@@ -25,13 +25,14 @@ import type {
   GetDelegatedBalanceFunc,
   GetCurrentDelegationFunc,
   GetCurrentDelegationResponse,
+  RewardHistoryFunc,
 } from '../../api/common/lib/storage/bridge/delegationUtils';
 import {
   genToRelativeSlotNumber,
   genTimeToSlot,
 } from '../../api/jormungandr/lib/storage/bridge/timeUtils';
 import { isJormungandr, getJormungandrBaseConfig } from '../../api/ada/lib/storage/database/prepackaged/networks';
-import type { DelegationRequests, RewardHistoryForWallet } from '../toplevel/DelegationStore';
+import type { DelegationRequests } from '../toplevel/DelegationStore';
 import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
 
 export default class JormungandrDelegationStore extends Store {
@@ -45,7 +46,7 @@ export default class JormungandrDelegationStore extends Store {
       publicDeriver,
       getDelegatedBalance: new CachedRequest<GetDelegatedBalanceFunc>(getDelegatedBalance),
       getCurrentDelegation: new CachedRequest<GetCurrentDelegationFunc>(getCurrentDelegation),
-      rewardHistory: new CachedRequest<RewardHistoryForWallet>(async (address) => {
+      rewardHistory: new CachedRequest<RewardHistoryFunc>(async (address) => {
         // we need to defer this call because the store may not be initialized yet
         // by the time this constructor is called
         const stateFetcher = this.stores.substores.jormungandr.stateFetchStore.fetcher;

--- a/app/stores/toplevel/DelegationStore.js
+++ b/app/stores/toplevel/DelegationStore.js
@@ -10,19 +10,18 @@ import LocalizedRequest from '../lib/LocalizedRequest';
 import Store from '../base/Store';
 import type {
   GetDelegatedBalanceFunc,
+  RewardHistoryFunc,
   GetCurrentDelegationFunc,
 } from '../../api/common/lib/storage/bridge/delegationUtils';
 import CachedRequest from '../lib/LocalizedCachedRequest';
 import LocalizableError from '../../i18n/LocalizableError';
 import type {
-  RewardTuple, ReputationObject,
+  ReputationObject,
 } from '../../api/jormungandr/lib/state-fetch/types';
 import { getApiForNetwork } from '../../api/common/utils';
 import {
   PoolMissingApiError,
 } from '../../api/common/errors';
-
-export type RewardHistoryForWallet = string => Promise<Array<RewardTuple>>;
 
 export type DelegationRequests = {|
   publicDeriver: PublicDeriver<>,
@@ -32,7 +31,7 @@ export type DelegationRequests = {|
    */
   getDelegatedBalance: CachedRequest<GetDelegatedBalanceFunc>,
   getCurrentDelegation: CachedRequest<GetCurrentDelegationFunc>,
-  rewardHistory: CachedRequest<RewardHistoryForWallet>,
+  rewardHistory: CachedRequest<RewardHistoryFunc>,
   error: LocalizableError | any;
 |};
 

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -8,19 +8,59 @@ Feature: Yoroi delegation dashboard
     
   @it-155
   Scenario: User can withdraw rewards from the dashboard w/ deregister (IT-155)
-    Given There is a Shelley wallet stored named shelley-simple-15
+    Given There is a Shelley wallet stored named shelley-delegated
     And I have a wallet with funds
     And I go to the dashboard screen
-
+    When I click on the withdraw button
     Then I click on the checkbox
     And I click the next button
     Then I should see on the Yoroi withdrawal transfer summary screen:
     | fromAddress                                                | amount           |
-    | stake1ux2436tfe25727kul3qtnyr7k72rvw6ep7h59ll53suwhzq05v5j9 | 5000000    |
+    | stake1u9tdkhx53zwggygdfh5scr2s8dgms3xm8ehas7v3ywyetwcufngyf | 5000000    |
     And I see the deregistration for the transaction
     And I enter the wallet password:
       | password   |
       | asdfasdfasdf |
-    Given The expected transaction is "g6YAgYJYIDZ351x7ppm/3GzVfULyRvhvY679dgJQBqx4MT+tK7ohAQGBglg5Aceyi86pDUQLVFWmoConylm4aW8Gf8GWf0f5M+eVWOlpyqnletz8QLmQfreUNjtZD69C//SMOOuIGgC8FzcCGgACpOkDGhH+lM0EgYIBggBYHJVY6WnKqeV63PxAuZB+t5Q2O1kPr0L/9Iw464gFoVgd4ZVY6WnKqeV63PxAuZB+t5Q2O1kPr0L/9Iw464gaAExLQKEAgoJYIMyYCZRBUMAPORPNKxA+m0L+YkP8NqdvnrgAaS4r2j8uWEB+/T0K3fmSzX6Flv7+EqQHqgh9Qy+bd89jrnq8kroN9RKb1Q8UyaAXuaAjKobtTPEHP0GAzZG93zv1/YKk+9IOglggYWJ2UyDJOtPILMKLlXi+MaeR8Do33K4FY0PMJbvLOzFYQG97rxjHKgHC5jQI7STQogD1onSv3m4steJANSWOsgRskvt9J2q2fVpUXJ7AOBteJfKM679/ru7Kj0LtIhR8qwf2"
+    Given The expected transaction is "g6YAgYJYIDZ36Gx7ppmv3BzVfULyRvhvaa79dgJQBqx4MT+tK7ohAAGBglg5AfiMMmOcqBWRIjRN6CEig4T8YKJcOWtIDaUVnSFW21zUiJyEEQ1N6QwNUDtRuETbPm/YeZEjiZW7GgCV8ZcCGgACpOkDGhH+lM0EgYIBggBYHFbbXNSInIQRDU3pDA1QO1G4RNs+b9h5kSOJlbsFoVgd4VbbXNSInIQRDU3pDA1QO1G4RNs+b9h5kSOJlbsaAExLQKEAgoJYIDHFsozgC4AMMNymh4uSd8Xls6VSRnf9Dxv6kiJPzsubWEDeymxh6IEQKI51A9krNH9zkI8E6r+yQhyKpgVMn318UvFlJ7PWkEA/UN5ttCRe+/8lHy6Vl9Dhu4RBHZ47Mu0Hglgg6cWNnhkPKitPspqy3T6+Lqi2VU1F/s8JE36FUprlBHBYQCyphTpHmP5U443IIuVOntgb8KaXTjazElk9hm6GFMebbuNWYuv907Ci+JvN7kk9wbO0R6ZKcA9pEgbbmlBYrA32"
     When I confirm Yoroi transfer funds
+    Then I should see the dashboard screen
+
+  @it-156
+  Scenario: User can withdraw Trezor rewards from the dashboard w/ deregister (IT-156)
+    Given I connected Trezor device 6495958994A4025BB5EE1DB1
+    When I select a Shelley-era Trezor device
+    And I restore the Trezor device
     Then I should see the summary screen
+    Then I should see a plate PALP-0076
+    And I have a wallet with funds
+    And I go to the dashboard screen
+    When I click on the withdraw button
+    Then I click on the checkbox
+    And I click the next button
+    Then I should see on the Yoroi withdrawal transfer summary screen:
+    | fromAddress                                                | amount           |
+    | stake1u9tdkhx53zwggygdfh5scr2s8dgms3xm8ehas7v3ywyetwcufngyf | 5000000    |
+    And I see the deregistration for the transaction
+    Given The expected transaction is "g6YAgYJYIDZ36Gx7ppmv3BzVfULyRvhvaa79dgJQBqx4MT+tK7ohAAGBglg5AfiMMmOcqBWRIjRN6CEig4T8YKJcOWtIDaUVnSFW21zUiJyEEQ1N6QwNUDtRuETbPm/YeZEjiZW7GgCV8ZcCGgACpOkDGhH+lM0EgYIBggBYHFbbXNSInIQRDU3pDA1QO1G4RNs+b9h5kSOJlbsFoVgd4VbbXNSInIQRDU3pDA1QO1G4RNs+b9h5kSOJlbsaAExLQKEAgoJYIDHFsozgC4AMMNymh4uSd8Xls6VSRnf9Dxv6kiJPzsubWEDeymxh6IEQKI51A9krNH9zkI8E6r+yQhyKpgVMn318UvFlJ7PWkEA/UN5ttCRe+/8lHy6Vl9Dhu4RBHZ47Mu0Hglgg6cWNnhkPKitPspqy3T6+Lqi2VU1F/s8JE36FUprlBHBYQCyphTpHmP5U443IIuVOntgb8KaXTjazElk9hm6GFMebbuNWYuv907Ci+JvN7kk9wbO0R6ZKcA9pEgbbmlBYrA32"
+    When I confirm Yoroi transfer funds
+    Then I should see the dashboard screen
+
+  @it-157
+  Scenario: User can withdraw Ledger rewards from the dashboard w/ deregister (IT-157)
+    Given I connected Ledger device 707fa118bf6b84
+    When I select a Shelley-era Ledger device
+    And I restore the Ledger device
+    Then I should see the summary screen
+    Then I should see a plate DDBZ-0107
+    And I have a wallet with funds
+    And I go to the dashboard screen
+    When I click on the withdraw button
+    Then I click on the checkbox
+    And I click the next button
+    Then I should see on the Yoroi withdrawal transfer summary screen:
+    | fromAddress                                                | amount           |
+    | stake1u80tp0xvht8gv38vhwet36ulc7ntpeecp68sr86yxexaqcqnl9kg3 | 5000000    |
+    And I see the deregistration for the transaction
+    Given The expected transaction is "g6YAgYJYIDZ36Gx7ppmv3BzVfULyRvhvaa79dgJQBqx4MT+tK7ohAAGBglg5AfiMMmOcqBWRIjRN6CEig4T8YKJcOWtIDaUVnSFW21zUiJyEEQ1N6QwNUDtRuETbPm/YeZEjiZW7GgCV8ZcCGgACpOkDGhH+lM0EgYIBggBYHFbbXNSInIQRDU3pDA1QO1G4RNs+b9h5kSOJlbsFoVgd4VbbXNSInIQRDU3pDA1QO1G4RNs+b9h5kSOJlbsaAExLQKEAgoJYIDHFsozgC4AMMNymh4uSd8Xls6VSRnf9Dxv6kiJPzsubWEDeymxh6IEQKI51A9krNH9zkI8E6r+yQhyKpgVMn318UvFlJ7PWkEA/UN5ttCRe+/8lHy6Vl9Dhu4RBHZ47Mu0Hglgg6cWNnhkPKitPspqy3T6+Lqi2VU1F/s8JE36FUprlBHBYQCyphTpHmP5U443IIuVOntgb8KaXTjazElk9hm6GFMebbuNWYuv907Ci+JvN7kk9wbO0R6ZKcA9pEgbbmlBYrA32"
+    When I confirm Yoroi transfer funds
+    Then I should see the dashboard screen

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -1,0 +1,26 @@
+
+Feature: Yoroi delegation dashboard
+
+  Background:
+    Given I have opened the extension
+    And I have completed the basic setup
+    Then I should see the Create wallet screen
+    
+  @it-155
+  Scenario: User can withdraw rewards from the dashboard w/ deregister (IT-155)
+    Given There is a Shelley wallet stored named shelley-simple-15
+    And I have a wallet with funds
+    And I go to the dashboard screen
+
+    Then I click on the checkbox
+    And I click the next button
+    Then I should see on the Yoroi withdrawal transfer summary screen:
+    | fromAddress                                                | amount           |
+    | stake1ux2436tfe25727kul3qtnyr7k72rvw6ep7h59ll53suwhzq05v5j9 | 5000000    |
+    And I see the deregistration for the transaction
+    And I enter the wallet password:
+      | password   |
+      | asdfasdfasdf |
+    Given The expected transaction is "g6YAgYJYIDZ351x7ppm/3GzVfULyRvhvY679dgJQBqx4MT+tK7ohAQGBglg5Aceyi86pDUQLVFWmoConylm4aW8Gf8GWf0f5M+eVWOlpyqnletz8QLmQfreUNjtZD69C//SMOOuIGgC8FzcCGgACpOkDGhH+lM0EgYIBggBYHJVY6WnKqeV63PxAuZB+t5Q2O1kPr0L/9Iw464gFoVgd4ZVY6WnKqeV63PxAuZB+t5Q2O1kPr0L/9Iw464gaAExLQKEAgoJYIMyYCZRBUMAPORPNKxA+m0L+YkP8NqdvnrgAaS4r2j8uWEB+/T0K3fmSzX6Flv7+EqQHqgh9Qy+bd89jrnq8kroN9RKb1Q8UyaAXuaAjKobtTPEHP0GAzZG93zv1/YKk+9IOglggYWJ2UyDJOtPILMKLlXi+MaeR8Do33K4FY0PMJbvLOzFYQG97rxjHKgHC5jQI7STQogD1onSv3m4steJANSWOsgRskvt9J2q2fVpUXJ7AOBteJfKM679/ru7Kj0LtIhR8qwf2"
+    When I confirm Yoroi transfer funds
+    Then I should see the summary screen

--- a/features/mock-chain/TestWallets.js
+++ b/features/mock-chain/TestWallets.js
@@ -30,6 +30,8 @@ function createWallet(payload: {|
 type WalletNames =
   'shelley-simple-24' |
   'shelley-simple-15' |
+  'shelley-delegated' |
+  'shelley-ledger-delegated' |
   'small-single-tx' |
   'failed-single-tx' |
   'many-tx-wallet' |
@@ -107,5 +109,17 @@ export const testWallets: { [key: WalletNames]: RestorationInput, ... } = Object
     name: ('shelley-simple-15': WalletNames),
     mnemonic: 'eight country switch draw meat scout mystery blade tip drift useless good keep usage title',
     plate: 'ZDDC-9858',
+  }),
+  createWallet({
+    name: ('shelley-delegated': WalletNames),
+    mnemonic: 'parrot offer switch thank film high drop salute task train squirrel coral consider coyote evolve',
+    plate: 'PALP-0076',
+    deviceId: '6495958994A4025BB5EE1DB1',
+  }),
+  createWallet({
+    name: ('shelley-ledger-delegated': WalletNames),
+    mnemonic: 'parrot offer switch thank film high drop salute task train squirrel coral consider coyote evolve',
+    plate: 'PALP-0076',
+    deviceId: '707fa118bf6b84',
   }),
 );

--- a/features/mock-chain/mockCardanoImporter.js
+++ b/features/mock-chain/mockCardanoImporter.js
@@ -8,8 +8,12 @@ import type {
   AddressUtxoFunc,
   RewardHistoryFunc,
   AccountStateFunc,
+  RemoteAccountState,
   HistoryFunc,
   BestBlockFunc,
+} from '../../app/api/ada/lib/state-fetch/types';
+import {
+  ShelleyCertificateTypes
 } from '../../app/api/ada/lib/state-fetch/types';
 import type {
   FilterFunc,
@@ -79,6 +83,10 @@ export const generateTransaction = (): {|
   bip44TrezorTx3: RemoteTransaction,
   cip1852TrezorTx1: RemoteTransaction,
   shelleySimple15: RemoteTransaction,
+  shelleyDelegatedTx1: RemoteTransaction,
+  shelleyDelegatedTx2: RemoteTransaction,
+  shelleyLedgerDelegatedTx1: RemoteTransaction,
+  shelleyLedgerDelegatedTx2: RemoteTransaction,
 |} => {
   const genesisTx = {
     hash: 'b713cc0d63106c3806b5a7077cc37a294fcca5e479f26aac64e51e09ae808d75',
@@ -368,6 +376,36 @@ export const generateTransaction = (): {|
         ),
         amount: '10000000'
       },
+      {
+        // index: 19
+        // Ae2tdPwUPEZ2y4rAdJG2coM4MXeNNAAKDztXXztz8LrcYRZ8waYoa7pWXgj
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ],
+        ),
+        amount: '10000000'
+      },
+      {
+        // index: 20
+        // Ae2tdPwUPEZ2y4rAdJG2coM4MXeNNAAKDztXXztz8LrcYRZ8waYoa7pWXgj
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ],
+        ),
+        amount: '10000000'
+      },
     ],
     height: 1,
     epoch: 0,
@@ -593,7 +631,7 @@ export const generateTransaction = (): {|
     ],
     height: 100,
     block_hash: '100',
-    tx_ordinal: 0,
+    tx_ordinal: 1,
     time: '2019-04-20T15:15:33.000Z',
     epoch: 0,
     slot: 100,
@@ -653,7 +691,7 @@ export const generateTransaction = (): {|
     ],
     height: 100,
     block_hash: '100',
-    tx_ordinal: 1,
+    tx_ordinal: 2,
     time: '2019-04-20T15:15:33.000Z',
     epoch: 0,
     slot: 100,
@@ -713,7 +751,7 @@ export const generateTransaction = (): {|
     ],
     height: 100,
     block_hash: '100',
-    tx_ordinal: 2,
+    tx_ordinal: 3,
     time: '2019-04-20T15:15:33.000Z',
     epoch: 0,
     slot: 100,
@@ -1327,6 +1365,222 @@ export const generateTransaction = (): {|
     tx_state: 'Successful'
   };
 
+  // =====================
+  //   shelley-delegated
+  // =====================
+
+  const shelleyDelegatedTx1 = {
+    hash: '3677e76c7ba699afdc6cd57d42f246f86f69aefd76025006ac78313fad2bba21',
+    inputs: [
+      {
+        // Ae2tdPwUPEZ2y4rAdJG2coM4MXeNNAAKDztXXztz8LrcYRZ8waYoa7pWXgj
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '19',
+        index: 19,
+        amount: '8500000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEZ2y4rAdJG2coM4MXeNNAAKDztXXztz8LrcYRZ8waYoa7pWXgj
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ]
+        ),
+        amount: '1'
+      },
+      {
+        // shelley-delegated base address index 0'/0/0
+        // eslint-disable-next-line max-len
+        // addr1qymwxh8y7pkdea6dyvrldnh6rtt5u9qxp0nd43dzn6c5y06kmdwdfzyussgs6n0fpsx4qw63hpzdk0n0mpuezgufjkas3clf5j
+        address: '0136e35ce4f06cdcf74d2307f6cefa1ad74e14060be6dac5a29eb1423f56db5cd4889c84110d4de90c0d503b51b844db3e6fd87991238995bb',
+        amount: '5500000'
+      },
+    ],
+    height: 100,
+    block_hash: '100',
+    tx_ordinal: 4,
+    time: '2019-04-20T15:15:33.000Z',
+    epoch: 0,
+    slot: 100,
+    last_update: '2019-05-20T23:16:51.899Z',
+    tx_state: 'Successful'
+  };
+  const shelleyDelegatedTx2 = {
+    hash: '3677e86c7ba699afdc1cd57d42f246f86f69aefd76025006ac78313fad2bba21',
+    type: 'shelley',
+    inputs: [
+      {
+        // shelley-delegated base address index 0'/0/0
+        // eslint-disable-next-line max-len
+        // addr1qymwxh8y7pkdea6dyvrldnh6rtt5u9qxp0nd43dzn6c5y06kmdwdfzyussgs6n0fpsx4qw63hpzdk0n0mpuezgufjkas3clf5j
+        address: '0136e35ce4f06cdcf74d2307f6cefa1ad74e14060be6dac5a29eb1423f56db5cd4889c84110d4de90c0d503b51b844db3e6fd87991238995bb',
+        txHash: shelleyDelegatedTx1.hash,
+        id: shelleyDelegatedTx1.hash + '1',
+        index: 1,
+        amount: '5500000'
+      }
+    ],
+    outputs: [
+      {
+        // shelley-delegated base address index 0'/1/0
+        // eslint-disable-next-line max-len
+        // addr1qxnhwn2yw8utcxprcqxl0hx0v2wq2g304tc5wyzmhx6cvgzkmdwdfzyussgs6n0fpsx4qw63hpzdk0n0mpuezgufjkaswuh3qd
+        address: '01a7774d4471f8bc1823c00df7dccf629c05222faaf147105bb9b5862056db5cd4889c84110d4de90c0d503b51b844db3e6fd87991238995bb',
+        amount: '3000000'
+      },
+    ],
+    ttl: '500',
+    fee: '500000',
+    certificates: [
+      {
+        certIndex: 0,
+        kind: (ShelleyCertificateTypes.StakeRegistration: 'StakeRegistration'),
+        rewardAddress: 'e156db5cd4889c84110d4de90c0d503b51b844db3e6fd87991238995bb',
+      },
+      {
+        certIndex: 1,
+        kind: ShelleyCertificateTypes.StakeDelegation,
+        rewardAddress: 'e156db5cd4889c84110d4de90c0d503b51b844db3e6fd87991238995bb',
+        poolKeyHash: 'df1750df9b2df285fcfb50f4740657a18ee3af42727d410c37b86207', // YOROI
+      },
+    ],
+    withdrawals: [],
+    metadata: null,
+    height: 200,
+    block_hash: '200',
+    tx_ordinal: 1,
+    time: '2019-04-21T15:13:33.000Z',
+    epoch: 0,
+    slot: 200,
+    last_update: '2019-05-21T23:14:51.899Z',
+    tx_state: 'Successful'
+  };
+
+  // ============================
+  //   shelley-ledger-delegated
+  // ============================
+
+  const shelleyLedgerDelegatedTx1 = {
+    hash: '3699e76c7ba699afdc6cd57d42f246f86f69aefd76025006ac78313fad2bba21',
+    inputs: [
+      {
+        // Ae2tdPwUPEZ2y4rAdJG2coM4MXeNNAAKDztXXztz8LrcYRZ8waYoa7pWXgj
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ]
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '20',
+        index: 20,
+        amount: '8500000'
+      }
+    ],
+    outputs: [
+      {
+        // Ae2tdPwUPEZ2y4rAdJG2coM4MXeNNAAKDztXXztz8LrcYRZ8waYoa7pWXgj
+        address: getSingleAddressString(
+          testWallets['dump-wallet'].mnemonic,
+          [
+            WalletTypePurpose.BIP44,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            1
+          ]
+        ),
+        amount: '1'
+      },
+      {
+        // shelley-ledger-delegated base address index 0'/0/0
+        // eslint-disable-next-line max-len
+        // addr1q82e70f6t2v5va99t2mvc894235wz5kfc32vhs5khf0c9xw7kz7vewkwsezwewajhr4el3axkrnnsr50qx05gdjd6psq4wu69r
+        address: '01d59f3d3a5a994674a55ab6cc1cb55468e152c9c454cbc296ba5f8299deb0bcccbace8644ecbbb2b8eb9fc7a6b0e7380e8f019f44364dd060',
+        amount: '5500000'
+      },
+    ],
+    height: 100,
+    block_hash: '100',
+    tx_ordinal: 5,
+    time: '2019-04-20T15:15:33.000Z',
+    epoch: 0,
+    slot: 100,
+    last_update: '2019-05-20T23:16:51.899Z',
+    tx_state: 'Successful'
+  };
+  const shelleyLedgerDelegatedTx2 = {
+    hash: '3688e86c7ba699afdc1cd57d42f246f86f69aefd76025006ac78313fad2bba21',
+    type: 'shelley',
+    inputs: [
+      {
+        // shelley-ledger-delegated base address index 0'/0/0
+        // eslint-disable-next-line max-len
+        // addr1q82e70f6t2v5va99t2mvc894235wz5kfc32vhs5khf0c9xw7kz7vewkwsezwewajhr4el3axkrnnsr50qx05gdjd6psq4wu69r
+        address: '01d59f3d3a5a994674a55ab6cc1cb55468e152c9c454cbc296ba5f8299deb0bcccbace8644ecbbb2b8eb9fc7a6b0e7380e8f019f44364dd060',
+        txHash: shelleyLedgerDelegatedTx1.hash,
+        id: shelleyLedgerDelegatedTx1.hash + '1',
+        index: 1,
+        amount: '5500000'
+      }
+    ],
+    outputs: [
+      {
+        // shelley-ledger-delegated base address index 0'/1/0
+        // eslint-disable-next-line max-len
+        // addr1q9mhtwlxextzp4kqe04ycj7gus5j8gd5jaz42xsklslcdzx7kz7vewkwsezwewajhr4el3axkrnnsr50qx05gdjd6psq62plmk
+        address: '017775bbe6c99620d6c0cbea4c4bc8e42923a1b49745551a16fc3f8688deb0bcccbace8644ecbbb2b8eb9fc7a6b0e7380e8f019f44364dd060',
+        amount: '3000000'
+      },
+    ],
+    ttl: '500',
+    fee: '500000',
+    certificates: [
+      {
+        certIndex: 0,
+        kind: (ShelleyCertificateTypes.StakeRegistration: 'StakeRegistration'),
+        rewardAddress: 'e1deb0bcccbace8644ecbbb2b8eb9fc7a6b0e7380e8f019f44364dd060',
+      },
+      {
+        certIndex: 1,
+        kind: ShelleyCertificateTypes.StakeDelegation,
+        rewardAddress: 'e1deb0bcccbace8644ecbbb2b8eb9fc7a6b0e7380e8f019f44364dd060',
+        poolKeyHash: 'df1750df9b2df285fcfb50f4740657a18ee3af42727d410c37b86207', // YOROI
+      },
+    ],
+    withdrawals: [],
+    metadata: null,
+    height: 200,
+    block_hash: '200',
+    tx_ordinal: 2,
+    time: '2019-04-21T15:13:33.000Z',
+    epoch: 0,
+    slot: 200,
+    last_update: '2019-05-21T23:14:51.899Z',
+    tx_state: 'Successful'
+  };
+
   return {
     genesisTx,
     distributorTx,
@@ -1347,6 +1601,10 @@ export const generateTransaction = (): {|
     bip44TrezorTx3,
     cip1852TrezorTx1,
     shelleySimple15,
+    shelleyDelegatedTx1,
+    shelleyDelegatedTx2,
+    shelleyLedgerDelegatedTx1,
+    shelleyLedgerDelegatedTx2,
   };
 };
 
@@ -1357,7 +1615,34 @@ export const generateTransaction = (): {|
 const transactions: Array<MockTx> = [];
 
 export function addTransaction(tx: MockTx): void {
-  transactions.push(tx);
+  // need to insert txs in order they appear in the blockchain
+  // note: pending transactions always go at the end
+  if (tx.epoch == null || tx.slot == null || tx.tx_ordinal == null) {
+    transactions.push(tx);
+    return;
+  }
+  const newTxEpoch = tx.epoch;
+  const newTxSlot = tx.slot;
+  const newTxOrdinal = tx.tx_ordinal;
+
+  const insertionIndex = transactions.findIndex(mockChainTx => {
+    const epoch = mockChainTx.epoch;
+    const slot = mockChainTx.slot;
+    const txOrdinal = mockChainTx.tx_ordinal;
+
+    if (epoch == null) return true;
+    if (epoch > newTxEpoch) return true;
+    if (slot == null) return true;
+    if (slot > newTxSlot) return true;
+    if (txOrdinal == null) return true;
+    if (txOrdinal > newTxOrdinal) return true;
+    return false;
+  });
+  if (insertionIndex === -1) {
+    transactions.push(tx);
+    return;
+  }
+  transactions.splice(insertionIndex, 0, tx);
 }
 
 export const MockChain = Object.freeze({
@@ -1399,6 +1684,12 @@ export function resetChain(
     addTransaction(txs.cip1852TrezorTx1);
     // shelley-simple-15
     addTransaction(txs.shelleySimple15);
+    // shelley-delegated
+    addTransaction(txs.shelleyDelegatedTx1);
+    addTransaction(txs.shelleyDelegatedTx2);
+    // shelley-ledger-delegated
+    addTransaction(txs.shelleyLedgerDelegatedTx1);
+    addTransaction(txs.shelleyLedgerDelegatedTx2);
   } else if (chainToUse === MockChain.TestAssurance) {
     // test setup
     addTransaction(txs.genesisTx);
@@ -1481,18 +1772,51 @@ const sendTx = (request: SignedRequestInternal): SignedResponse => {
 const getPoolInfo: PoolInfoFunc = genGetPoolInfo();
 const getRewardHistory: RewardHistoryFunc = genGetRewardHistory();
 
-const getAccountState: AccountStateFunc = async (_request) => {
+const getAccountState: AccountStateFunc = async (request) => {
   const totalRewards = new BigNumber(5000000);
   const totalWithdrawals = new BigNumber(0);
-  return {
-    // shelley-simple-15
-    e19558e969caa9e57adcfc40b9907eb794363b590faf42fff48c38eb88: {
-      poolOperator: null,
-      remainingAmount: totalRewards.minus(totalWithdrawals).toString(),
-      rewards: totalRewards.toString(),
-      withdrawals: totalWithdrawals.toString(),
-    }
-  };
+
+  // no good way to mock this since it's not implicitly stored in the chain
+  // with the exception of MIR certificates
+  const accountStateMap = new Map<string, RemoteAccountState>([
+    [
+      // shelley-simple-15
+      'e19558e969caa9e57adcfc40b9907eb794363b590faf42fff48c38eb88',
+      {
+        poolOperator: null,
+        remainingAmount: totalRewards.minus(totalWithdrawals).toString(),
+        rewards: totalRewards.toString(),
+        withdrawals: totalWithdrawals.toString(),
+      },
+    ],
+    [
+      // shelley-delegated
+      'e156db5cd4889c84110d4de90c0d503b51b844db3e6fd87991238995bb',
+      {
+        poolOperator: null,
+        remainingAmount: totalRewards.minus(totalWithdrawals).toString(),
+        rewards: totalRewards.toString(),
+        withdrawals: totalWithdrawals.toString(),
+      },
+    ],
+    [
+      // shelley-ledger-delegated
+      'e1deb0bcccbace8644ecbbb2b8eb9fc7a6b0e7380e8f019f44364dd060',
+      {
+        poolOperator: null,
+        remainingAmount: totalRewards.minus(totalWithdrawals).toString(),
+        rewards: totalRewards.toString(),
+        withdrawals: totalWithdrawals.toString(),
+      },
+    ],
+  ]);
+
+  const result: {| [key: string]: (null | RemoteAccountState) |} = {};
+  for (const addr of request.addresses) {
+    result[addr] = accountStateMap.get(addr) ?? null;
+  }
+
+  return result;
 };
 
 export default {

--- a/features/mock-trezor-connect/index.js
+++ b/features/mock-trezor-connect/index.js
@@ -162,7 +162,7 @@ class MockTrezorConnect {
     if (deviceId == null) return;
 
     if (MockTrezorConnect.selectedWallet == null) {
-      throw new Error(`No mock Ledger wallet selected`);
+      throw new Error(`No mock Trezor wallet selected`);
     }
     const selectedWallet = MockTrezorConnect.selectedWallet;
 
@@ -184,7 +184,7 @@ class MockTrezorConnect {
     const genPayload = (request: CardanoGetAddress): CardanoAddress => {
       // this.checkSerial;
       if (MockTrezorConnect.selectedWallet == null) {
-        throw new Error(`No mock Ledger wallet selected`);
+        throw new Error(`No mock Trezor wallet selected`);
       }
       const selectedWallet = MockTrezorConnect.selectedWallet;
       const address = deriveAddress(selectedWallet.rootKey, request);
@@ -233,7 +233,7 @@ class MockTrezorConnect {
     const genPayload = (key: CardanoGetPublicKey): CardanoPublicKey => {
       // this.checkSerial;
       if (MockTrezorConnect.selectedWallet == null) {
-        throw new Error(`No mock Ledger wallet selected`);
+        throw new Error(`No mock Trezor wallet selected`);
       }
       const selectedWallet = MockTrezorConnect.selectedWallet;
 
@@ -272,7 +272,7 @@ class MockTrezorConnect {
     MockTrezorConnect.mockConnectDevice();
 
     if (MockTrezorConnect.selectedWallet == null) {
-      throw new Error(`No mock Ledger wallet selected`);
+      throw new Error(`No mock Trezor wallet selected`);
     }
     const selectedWallet = MockTrezorConnect.selectedWallet;
 
@@ -488,7 +488,7 @@ class MockTrezorConnect {
 
   static mockConnectDevice: void => void = () => {
     if (MockTrezorConnect.selectedWallet == null) {
-      throw new Error(`No mock Ledger wallet selected`);
+      throw new Error(`No mock Trezor wallet selected`);
     }
     const selectedWallet = MockTrezorConnect.selectedWallet;
 

--- a/features/step_definitions/dashboard-steps.js
+++ b/features/step_definitions/dashboard-steps.js
@@ -1,0 +1,13 @@
+// @flow
+
+import { Given, When, Then } from 'cucumber';
+import { By } from 'selenium-webdriver';
+import { expect } from 'chai';
+import i18n from '../support/helpers/i18n-helpers';
+import { addTransaction, generateTransaction, } from '../mock-chain/mockCardanoImporter';
+import { setExpectedTx, } from '../mock-chain/mockCardanoServer';
+import { truncateAddress, } from '../../app/utils/formatters';
+
+When(/^I go to the dashboard screen$/, async function () {
+  await this.click('.stakeDashboard ');
+});

--- a/features/step_definitions/dashboard-steps.js
+++ b/features/step_definitions/dashboard-steps.js
@@ -1,13 +1,11 @@
 // @flow
 
-import { Given, When, Then } from 'cucumber';
-import { By } from 'selenium-webdriver';
-import { expect } from 'chai';
-import i18n from '../support/helpers/i18n-helpers';
-import { addTransaction, generateTransaction, } from '../mock-chain/mockCardanoImporter';
-import { setExpectedTx, } from '../mock-chain/mockCardanoServer';
-import { truncateAddress, } from '../../app/utils/formatters';
+import { When, } from 'cucumber';
 
 When(/^I go to the dashboard screen$/, async function () {
   await this.click('.stakeDashboard ');
+});
+
+When(/^I click on the withdraw button$/, async function () {
+  await this.click('.withdrawButton ');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15265,9 +15265,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.132.0.tgz",
-      "integrity": "sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.133.0.tgz",
+      "integrity": "sha512-01T5g8GdhtJEn+lhAwuv5zkrMStrmkuHrY3Nn9/aS9y6waNmNgimMKlzRpFH66S0F6Ez9EqU9psz5QaRveSJIA==",
       "dev": true
     },
     "flow-typed": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.20.6",
     "file-loader": "6.1.0",
-    "flow-bin": "0.132.0",
+    "flow-bin": "0.133.0",
     "flow-typed": "3.2.1",
     "geckodriver": "1.20.0",
     "html-loader": "1.3.0",

--- a/scripts/startWithMockServer.js
+++ b/scripts/startWithMockServer.js
@@ -30,11 +30,12 @@ console.log('and load unpacked extensions with `./dev` folder. (see https://deve
 const { RustModule } = require('../app/api/ada/lib/cardanoCrypto/rustLoader');
 const wasmv2 = require('cardano-wallet');
 const wasmv3 = require('@emurgo/js-chain-libs-node/js_chain_libs');
-const wasmv4 = require('@emurgo/cardano-serialization-lib-browser/cardano_serialization_lib');
+const wasmv4 = require('@emurgo/cardano-serialization-lib-nodejs/cardano_serialization_lib');
 
 RustModule._wasmv2 = wasmv2;
 // $FlowExpectedError[incompatible-type] nodejs & browser API have same interface so it's okay
 RustModule._wasmv3 = wasmv3;
+// $FlowExpectedError[incompatible-type] nodejs & browser API have same interface so it's okay
 RustModule._wasmv4 = wasmv4;
 
 const { getMockServer } = require('../features/mock-chain/mockCardanoServer');

--- a/stories/helpers/WalletCache.js
+++ b/stories/helpers/WalletCache.js
@@ -4,6 +4,7 @@ import type { ConceptualWalletSettingsCache } from '../../app/stores/toplevel/Wa
 import WalletSettingsStore from '../../app/stores/toplevel/WalletSettingsStore';
 import TransactionsStore from '../../app/stores/toplevel/TransactionsStore';
 import DelegationStore from '../../app/stores/toplevel/DelegationStore';
+import AdaDelegationStore from '../../app/stores/ada/AdaDelegationStore';
 import WalletStore from '../../app/stores/toplevel/WalletStore';
 import BaseCardanoTimeStore from '../../app/stores/base/BaseCardanoTimeStore';
 import { PublicDeriver } from '../../app/api/ada/lib/storage/models/PublicDeriver';
@@ -20,6 +21,8 @@ export type CardanoCacheValue = {|
     typeof TransactionsStore.prototype.getTxRequests,
   getDelegation:
     typeof DelegationStore.prototype.getDelegationRequests,
+  getAdaDelegation:
+    typeof AdaDelegationStore.prototype.getDelegationRequests,
   getSigningKeyCache:
     typeof WalletStore.prototype.getSigningKeyCache,
   getPublicDeriverSettingsCache:
@@ -45,6 +48,8 @@ export function walletLookup(wallets: $ReadOnlyArray<PossibleCacheTypes>): {|
     typeof TransactionsStore.prototype.getTxRequests,
   getDelegation:
     typeof DelegationStore.prototype.getDelegationRequests,
+  getAdaDelegation:
+    typeof AdaDelegationStore.prototype.getDelegationRequests,
   getSigningKeyCache:
     typeof WalletStore.prototype.getSigningKeyCache,
   getPublicDeriverSettingsCache:
@@ -60,6 +65,7 @@ export function walletLookup(wallets: $ReadOnlyArray<PossibleCacheTypes>): {|
       getConceptualWalletSettingsCache: (_conceptualWallet) => (null: any),
       getTransactions: (_publicDeriver) => (null: any),
       getDelegation: (_publicDeriver) => (null: any),
+      getAdaDelegation: (_publicDeriver) => (null: any),
       getPublicKeyCache: (_publicDeriver) => (null: any),
       getSigningKeyCache: (_publicDeriver) => (null: any),
       getPublicDeriverSettingsCache: (_publicDeriver) => (null: any),
@@ -95,6 +101,14 @@ export function walletLookup(wallets: $ReadOnlyArray<PossibleCacheTypes>): {|
       for (const wallet of wallets) {
         if (wallet.publicDeriver === publicDeriver && wallet.getDelegation) {
           return wallet.getDelegation(publicDeriver);
+        }
+      }
+      throw new Error(`Missing cache entry for delegation`);
+    },
+    getAdaDelegation: (publicDeriver) => {
+      for (const wallet of wallets) {
+        if (wallet.publicDeriver === publicDeriver && wallet.getAdaDelegation) {
+          return wallet.getAdaDelegation(publicDeriver);
         }
       }
       throw new Error(`Missing cache entry for delegation`);

--- a/stories/helpers/cardano/ByronMocks.js
+++ b/stories/helpers/cardano/ByronMocks.js
@@ -44,6 +44,7 @@ import { HaskellShelleyTxSignRequest } from '../../../app/api/ada/transactions/s
 import { RustModule } from '../../../app/api/ada/lib/cardanoCrypto/rustLoader';
 import type { ISignRequest } from '../../../app/api/common/lib/transactions/ISignRequest';
 import DelegationStore from '../../../app/stores/toplevel/DelegationStore';
+import AdaDelegationStore from '../../../app/stores/ada/AdaDelegationStore';
 
 function genByronSigningWallet(
   genHardwareInfo?: number => HwWalletMetaRow,
@@ -117,6 +118,7 @@ function genMockByronBip44Cache(dummyWallet: PublicDeriver<>) {
       },
     }),
     getDelegation: (_wallet) => (undefined),
+    getAdaDelegation: (_wallet) => (undefined),
     getTransactions: (wallet) => ({
       publicDeriver: wallet,
       lastSyncInfo: {
@@ -210,6 +212,8 @@ export type ByronCacheValue = {|
     typeof TransactionsStore.prototype.getTxRequests,
   getDelegation:
     typeof DelegationStore.prototype.getDelegationRequests,
+  getAdaDelegation:
+    typeof AdaDelegationStore.prototype.getDelegationRequests,
   getSigningKeyCache:
     typeof WalletStore.prototype.getSigningKeyCache,
   getPublicDeriverSettingsCache:

--- a/stories/helpers/cardano/ShelleyCip1852Mocks.js
+++ b/stories/helpers/cardano/ShelleyCip1852Mocks.js
@@ -46,6 +46,7 @@ import type { HwWalletMetaRow, } from '../../../app/api/ada/lib/storage/database
 import type { ISignRequest } from '../../../app/api/common/lib/transactions/ISignRequest';
 import { RustModule } from '../../../app/api/ada/lib/cardanoCrypto/rustLoader';
 import { HaskellShelleyTxSignRequest } from '../../../app/api/ada/transactions/shelley/HaskellShelleyTxSignRequest';
+import AdaDelegationStore from '../../../app/stores/ada/AdaDelegationStore';
 
 function genMockShelleyCip1852Cache(dummyWallet: PublicDeriver<>) {
   const pendingRequest = new CachedRequest(_publicDeriver => Promise.resolve([]));
@@ -73,6 +74,7 @@ function genMockShelleyCip1852Cache(dummyWallet: PublicDeriver<>) {
       },
     }),
     getDelegation: (_wallet) => (undefined),
+    getAdaDelegation: (_wallet) => (undefined),
     getTransactions: (wallet) => ({
       publicDeriver: wallet,
       lastSyncInfo: {
@@ -252,6 +254,8 @@ export type ShelleyCip1852CacheValue = {|
     typeof TransactionsStore.prototype.getTxRequests,
   getDelegation:
     typeof DelegationStore.prototype.getDelegationRequests,
+  getAdaDelegation:
+    typeof AdaDelegationStore.prototype.getDelegationRequests,
   getSigningKeyCache:
     typeof WalletStore.prototype.getSigningKeyCache,
   getPublicDeriverSettingsCache:


### PR DESCRIPTION
Right now we only support withdrawing from an inputted recovery phrase. This is not ideal UX for claiming your rewards from delegation and it's not supported by hardware wallets.
We need to also support withdrawing from the currently selected wallet on the dashboard.

TODO:
- [x] E2E tests
- [x] Storybook
- [x] Show deregistration prompt for all users
- [ ] Undelegate button that reroutes users to the withdrawal?