### PR TITLE
Add root-level error page

### DIFF
--- a/app/components/loading/Crashed.js
+++ b/app/components/loading/Crashed.js
@@ -1,0 +1,87 @@
+// @flow
+import React, { Component } from 'react';
+import type { Node } from 'react';
+import { observer } from 'mobx-react';
+import ExternalLinkSVG from '../../assets/images/link-external.inline.svg';
+import styles from './Crashed.scss';
+import globalMessages from '../../i18n/global-messages';
+import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
+import UnavailableDialog from '../widgets/UnavailableDialog';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
+
+const messages = defineMessages({
+  title: {
+    id: 'crash.screen.title',
+    defaultMessage: '!!!Yoroi crashed',
+  },
+});
+
+type Props = {|
+  +onExternalLinkClick: MouseEvent => void,
+  +onDownloadLogs: void => void,
+|};
+
+@observer
+export default class Crashed extends Component<Props> {
+
+  static contextTypes: {|intl: $npm$ReactIntl$IntlFormat|} = {
+    intl: intlShape.isRequired,
+  };
+
+  render(): Node {
+    const { intl } = this.context;
+
+    return (
+      <UnavailableDialog
+        title={intl.formatMessage(messages.title)}
+      >
+        <div className={styles.body}>
+          <div className={styles.attention}>
+            {intl.formatMessage(globalMessages.attentionHeaderText)}
+          </div>
+          <br />
+          <div className={styles.explanation}>
+            {this._getErrorMessageComponent()}
+          </div>
+        </div>
+      </UnavailableDialog>
+    );
+  }
+
+  _getErrorMessageComponent: (void => Node) = () => {
+    const { intl } = this.context;
+    const {
+      onExternalLinkClick,
+      onDownloadLogs
+    } = this.props;
+
+    const downloadLogsLink = (
+      // eslint-disable-next-line jsx-a11y/anchor-is-valid
+      <a
+        className={styles.link}
+        href="#"
+        onClick={_event => onDownloadLogs()}
+      >
+        {intl.formatMessage(globalMessages.downloadLogsLink)}
+      </a>
+    );
+
+    const supportRequestLink = (
+      <a
+        className={styles.link}
+        href={intl.formatMessage(globalMessages.supportRequestLinkUrl)}
+        onClick={event => onExternalLinkClick(event)}
+      >
+        {intl.formatMessage(globalMessages.contactSupport)}
+      </a>
+    );
+
+    return (
+      <p>
+        <FormattedMessage {...globalMessages.logsContent} values={{ downloadLogsLink }} />
+        <br /><br />
+        <FormattedMessage {...globalMessages.forMoreHelp} values={{ supportRequestLink }} />
+      </p>
+    );
+  };
+}

--- a/app/components/loading/Crashed.scss
+++ b/app/components/loading/Crashed.scss
@@ -1,0 +1,22 @@
+@import '../../themes/mixins/underline';
+
+.body {
+  padding-left: 40px;
+  padding-right: 40px;
+
+  .attention {
+    color: var(--theme-dialog-title-color);
+    font-family: var(--font-medium);
+    font-size: 16px;
+    line-height: 19px;
+    text-align: center;
+  }
+
+  .explanation {
+    color: var(--theme-dialog-title-color);
+    font-family: var(--font-regular);
+    font-size: 14px;
+    line-height: 22px;
+    text-align: center;
+  }
+}

--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -17,10 +17,6 @@ const messages = defineMessages({
     id: 'loading.screen.loading',
     defaultMessage: '!!!loading components',
   },
-  error: {
-    id: 'loading.screen.error',
-    defaultMessage: '!!!For more help, you can {supportRequestLink}',
-  },
 });
 
 type Props = {|
@@ -122,7 +118,7 @@ export default class Loading extends Component<Props> {
     return (
       <p>
         <FormattedMessage {...globalMessages.logsContent} values={{ downloadLogsLink }} /><br />
-        <FormattedMessage {...messages.error} values={{ supportRequestLink }} />
+        <FormattedMessage {...globalMessages.forMoreHelp} values={{ supportRequestLink }} />
       </p>
     );
   };

--- a/app/components/loading/Maintenance.js
+++ b/app/components/loading/Maintenance.js
@@ -4,11 +4,10 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape, } from 'react-intl';
 import ExternalLinkSVG from '../../assets/images/link-external.inline.svg';
-import ErrorInfo from '../../assets/images/error-info.inline.svg';
 import styles from './Maintenance.scss';
 import globalMessages from '../../i18n/global-messages';
-import VerticallyCenteredLayout from '../layout/VerticallyCenteredLayout';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
+import UnavailableDialog from '../widgets/UnavailableDialog';
 
 const messages = defineMessages({
   title: {
@@ -36,36 +35,28 @@ export default class Maintenance extends Component<Props> {
     const { intl } = this.context;
 
     return (
-      <div className={styles.component}>
-        <div className={styles.dialog}>
-          <div className={styles.header}>
-            <VerticallyCenteredLayout>
-              <div className={styles.title}>{intl.formatMessage(messages.title)}</div>
-            </VerticallyCenteredLayout>
+      <UnavailableDialog
+        title={intl.formatMessage(messages.title)}
+      >
+        <div className={styles.body}>
+          <div className={styles.attention}>
+            {intl.formatMessage(globalMessages.attentionHeaderText)}
           </div>
-          <div className={styles.errorLogo}>
-            <ErrorInfo />
+          <br />
+          <div className={styles.explanation}>
+            {intl.formatMessage(messages.explanation)}
           </div>
-          <div className={styles.body}>
-            <div className={styles.attention}>
-              {intl.formatMessage(globalMessages.attentionHeaderText)}
-            </div>
-            <br />
-            <div className={styles.explanation}>
-              {intl.formatMessage(messages.explanation)}
-            </div>
-            <div className={styles.learnMore}>
-              <a
-                href="https://twitter.com/YoroiWallet"
-                onClick={event => this.props.onExternalLinkClick(event)}
-              >
-                {intl.formatMessage(globalMessages.learnMore) + ' '}
-                <ExternalLinkSVG />
-              </a>
-            </div>
+          <div className={styles.learnMore}>
+            <a
+              href="https://twitter.com/YoroiWallet"
+              onClick={event => this.props.onExternalLinkClick(event)}
+            >
+              {intl.formatMessage(globalMessages.learnMore) + ' '}
+              <ExternalLinkSVG />
+            </a>
           </div>
         </div>
-      </div>
+      </UnavailableDialog>
     );
   }
 }

--- a/app/components/loading/Maintenance.scss
+++ b/app/components/loading/Maintenance.scss
@@ -1,97 +1,48 @@
 @import '../../themes/mixins/underline';
 
-.component {
-  background-color: var(--theme-maintenance-background-color);
-  width: 100%;
-  height: 100%;
-}
+.body {
+  padding-left: 40px;
+  padding-right: 40px;
 
-.dialog {
-  position: absolute;
-  left: 0;
-  right: 0;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 90px;
-  width: 485px;
-  padding-bottom: 40px;
-  background-color: #ffffff;
-
-  box-sizing: border-box;
-  border: 1px solid var(--theme-maintenance-border-color);
-  border-radius: 8px;
-  background-color: #FFFFFF;
-  box-shadow: 0 13px 20px -1px rgba(0,0,0,0.15);
-
-  display: flex;
-  flex-direction: column;
-
-  .header {
-    background-color: var(--theme-default-color-red);
-    border-radius: 7.5px 7.5px 0 0;
-    width: 100%;
-    height: 65px;
-
-    .title {
-      font-family: var(--font-medium);
-      font-size: 16px;
-      line-height: 19px;
-      text-align: center;
-      color: white;
-    }
+  .attention {
+    color: var(--theme-dialog-title-color);
+    font-family: var(--font-medium);
+    font-size: 16px;
+    line-height: 19px;
+    text-align: center;
   }
 
-  .errorLogo {
+  .explanation {
+    color: var(--theme-dialog-title-color);
+    font-family: var(--font-regular);
+    font-size: 14px;
+    line-height: 22px;
+    text-align: center;
+  }
+
+  .learnMore {
+    margin-top: 6px;
     margin-left: auto;
     margin-right: auto;
-    margin-top: 38px;
-    margin-bottom: 30px;
-  }
+    width: fit-content;
 
-  .body {
-    padding-left: 40px;
-    padding-right: 40px;
-
-    .attention {
-      color: var(--theme-dialog-title-color);
-      font-family: var(--font-medium);
-      font-size: 16px;
-      line-height: 19px;
-      text-align: center;
-    }
-
-    .explanation {
-      color: var(--theme-dialog-title-color);
+    a {
+      color: var(--cmn-default-color-grey);
       font-family: var(--font-regular);
       font-size: 14px;
       line-height: 22px;
-      text-align: center;
+      text-decoration: none;
     }
 
-    .learnMore {
-      margin-top: 6px;
-      margin-left: auto;
-      margin-right: auto;
-      width: fit-content;
+    span {
+      margin-left: 4px;
+      margin-top: 2px;
+      width: 14px;
+      height: 14px;
+    }
 
-      a {
-        color: var(--cmn-default-color-grey);
-        font-family: var(--font-regular);
-        font-size: 14px;
-        line-height: 22px;
-        text-decoration: none;
-      }
-
-      span {
-        margin-left: 4px;
-        margin-top: 2px;
-        width: 14px;
-        height: 14px;
-      }
-
-      &:hover {
-        @include underline(var(--theme-underline-dark-color));
-      }
+    &:hover {
+      @include underline(var(--theme-underline-dark-color));
     }
   }
 }

--- a/app/components/widgets/UnavailableDialog.js
+++ b/app/components/widgets/UnavailableDialog.js
@@ -1,0 +1,33 @@
+// @flow
+import React, { Component } from 'react';
+import type { Node } from 'react';
+import { observer } from 'mobx-react';
+import ErrorInfo from '../../assets/images/error-info.inline.svg';
+import styles from './UnavailableDialog.scss';
+import VerticallyCenteredLayout from '../layout/VerticallyCenteredLayout';
+
+type Props = {|
+  +children: Node,
+  +title: string,
+|};
+
+@observer
+export default class UnavailableDialog extends Component<Props> {
+  render(): Node {
+    return (
+      <div className={styles.component}>
+        <div className={styles.dialog}>
+          <div className={styles.header}>
+            <VerticallyCenteredLayout>
+              <div className={styles.title}>{this.props.title}</div>
+            </VerticallyCenteredLayout>
+          </div>
+          <div className={styles.errorLogo}>
+            <ErrorInfo />
+          </div>
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/components/widgets/UnavailableDialog.scss
+++ b/app/components/widgets/UnavailableDialog.scss
@@ -1,0 +1,50 @@
+@import '../../themes/mixins/underline';
+
+.component {
+  background-color: var(--theme-maintenance-background-color);
+  width: 100%;
+  height: 100%;
+}
+
+.dialog {
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 90px;
+  width: 485px;
+  padding-bottom: 40px;
+  background-color: #ffffff;
+
+  box-sizing: border-box;
+  border: 1px solid var(--theme-maintenance-border-color);
+  border-radius: 8px;
+  background-color: #FFFFFF;
+  box-shadow: 0 13px 20px -1px rgba(0,0,0,0.15);
+
+  display: flex;
+  flex-direction: column;
+
+  .header {
+    background-color: var(--theme-default-color-red);
+    border-radius: 7.5px 7.5px 0 0;
+    width: 100%;
+    height: 65px;
+
+    .title {
+      font-family: var(--font-medium);
+      font-size: 16px;
+      line-height: 19px;
+      text-align: center;
+      color: white;
+    }
+  }
+
+  .errorLogo {
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 38px;
+    margin-bottom: 30px;
+  }
+}

--- a/app/containers/CrashPage.js
+++ b/app/containers/CrashPage.js
@@ -1,0 +1,36 @@
+// @flow
+import type { Node } from 'react';
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import { computed } from 'mobx';
+import Crashed from '../components/loading/Crashed';
+import type { InjectedOrGenerated } from '../types/injectedPropsType';
+import { handleExternalLinkClick } from '../utils/routing';
+import { downloadLogs } from '../utils/logging';
+
+type GeneratedData = typeof CrashPage.prototype.generated;
+
+@observer
+export default class CrashPage extends Component<InjectedOrGenerated<GeneratedData>> {
+
+  render(): Node {
+    return (
+      <Crashed
+        onExternalLinkClick={this.generated.handleExternalLinkClick}
+        onDownloadLogs={downloadLogs}
+      />
+    );
+  }
+
+  @computed get generated(): {|handleExternalLinkClick: (event: MouseEvent) => void|} {
+    if (this.props.generated !== undefined) {
+      return this.props.generated;
+    }
+    if (this.props.stores == null || this.props.actions == null) {
+      throw new Error(`${nameof(CrashPage)} no way to generated props`);
+    }
+    return Object.freeze({
+      handleExternalLinkClick,
+    });
+  }
+}

--- a/app/containers/CrashPage.stories.js
+++ b/app/containers/CrashPage.stories.js
@@ -1,0 +1,22 @@
+// @flow
+
+import type { Node } from 'react';
+import React from 'react';
+
+import { action } from '@storybook/addon-actions';
+import CrashPage from './CrashPage';
+import { withScreenshot } from 'storycap';
+
+export default {
+  title: `${__filename.split('.')[0]}`,
+  component: CrashPage,
+  decorators: [withScreenshot],
+};
+
+export const Generic = (): Node => (
+  <CrashPage
+    generated={{
+      handleExternalLinkClick: action('External link click'),
+    }}
+  />
+);

--- a/app/i18n/LocalizableError.js
+++ b/app/i18n/LocalizableError.js
@@ -7,7 +7,7 @@ import type { MessageDescriptor } from 'react-intl';
 const messages = defineMessages({
   unknownError: {
     id: 'app.errors.unknowError',
-    defaultMessage: '!!!Unknow error.',
+    defaultMessage: '!!!Unknown error.',
   },
   unexpectedError: {
     id: 'app.errors.unexpectedError',

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -333,6 +333,10 @@ const globalMessages: * = defineMessages({
     id: 'global.staleTxnWarningLine2',
     defaultMessage: '!!!You can still send this transaction but it may fail.',
   },
+  forMoreHelp: {
+    id: 'loading.screen.error',
+    defaultMessage: '!!!For more help, you can {supportRequestLink}',
+  },
   logsContent: {
     id: 'settings.support.logs.content',
     defaultMessage: '!!!If you want to inspect logs, you can {downloadLogsLink}. Logs do not contain sensitive information, and it would be helpful to attach them to problem reports to help the team investigate the issue you are experiencing. Logs can be attached automatically when using the bug reporting feature.',

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -45,6 +45,7 @@
   "app.errors.unableToLoad": "Unable to load!",
   "app.errors.unexpectedError": "Something unexpected happened. Please retry.",
   "app.errors.unknowError": "Unknown error.",
+  "crash.screen.title": "Yoroi crashed",
   "daedalusTransfer.error.noTransferTxError": "There is no transaction to be sent.",
   "daedalusTransfer.error.transferFundsError": "Unable to transfer funds.",
   "daedalusTransfer.error.webSocketRestoreError": "Error while restoring blockchain addresses.",


### PR DESCRIPTION
Yoroi has no root-level error page so if an edge case causes the entire app to crash, it just renders a blank page. It's hard to get logs from the user in this case (you have to explain what the chrome console is, etc.)

A root-level error page with a log download button would solve this.

![image](https://user-images.githubusercontent.com/2608559/92418809-836b4f80-f1a4-11ea-8018-4d80fa47d704.png)
