### PR TITLE
fix crash when no explores support link type

### DIFF
--- a/app/components/wallet/staking/dashboard/UpcomingRewards.js
+++ b/app/components/wallet/staking/dashboard/UpcomingRewards.js
@@ -51,7 +51,7 @@ export type BoxInfo = {|
 type Props = {|
   +content: [?BoxInfo, ?BoxInfo, ?BoxInfo],
   +showWarning: boolean,
-  +baseUrl: string,
+  +baseUrl: void | string,
   +useEndOfEpoch: boolean, // Haskell uses end-of-epoch but Jormungandr doesn't
   +onExternalLinkClick: MouseEvent => void,
 |};
@@ -158,23 +158,32 @@ export default class UpcomingRewards extends Component<Props> {
     const tooltip = pool.ticker == null
       ? pool.id[0]
       : (<>{pool.ticker}<br />{pool.id[0]}</>);
+
+    const img = (
+      <img
+        alt="Pool avatar"
+        src={avatar}
+        className={styles.avatar}
+      />
+    );
     return (
       <CustomTooltip
         key={pool.id[0] + pool.id[1]}
         toolTip={<div className={styles.poolInfo}>{tooltip}</div>}
         isOpeningUpward={false}
       >
-        <a
-          className={styles.url}
-          href={this.props.baseUrl + pool.id[0]}
-          onClick={event => this.props.onExternalLinkClick(event)}
-        >
-          <img
-            alt="Pool avatar"
-            src={avatar}
-            className={styles.avatar}
-          />
-        </a>
+        {this.props.baseUrl != null
+          ? (
+            <a
+              className={styles.url}
+              href={this.props.baseUrl + pool.id[0]}
+              onClick={event => this.props.onExternalLinkClick(event)}
+            >
+              {img}
+            </a>
+          )
+          : img
+        }
       </CustomTooltip>
     );
   }

--- a/app/components/wallet/staking/dashboard/UpcomingRewards.scss
+++ b/app/components/wallet/staking/dashboard/UpcomingRewards.scss
@@ -91,7 +91,6 @@
     }
 
     .avatar {
-        cursor: pointer;
         margin-top: 10px;
         width: 24px;
         height: 24px;

--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -400,7 +400,7 @@ export default class StakingDashboardPage extends Component<Props> {
 
         const poolExplorerLink = this.generated.stores.explorers.selectedExplorer
           .get(publicDeriver.getParent().getNetworkInfo().NetworkId)
-          ?.getOrDefault('pool') ?? (() => { throw new Error('No explorer for wallet network'); })();
+          ?.getOrDefault('pool');
 
         const upcomingTuples = ((upcomingRewards.slice(0, 3): any): [?BoxInfo, ?BoxInfo, ?BoxInfo]);
         const rewardPopup = (
@@ -409,7 +409,7 @@ export default class StakingDashboardPage extends Component<Props> {
             content={upcomingTuples}
             showWarning={upcomingRewards.length === 3}
             onExternalLinkClick={handleExternalLinkClick}
-            baseUrl={poolExplorerLink.baseUrl}
+            baseUrl={poolExplorerLink?.baseUrl}
           />
         );
         rewardInfo = {

--- a/app/containers/widgets/ExplorableHashContainer.js
+++ b/app/containers/widgets/ExplorableHashContainer.js
@@ -36,6 +36,9 @@ export default class ExplorableHashContainer extends Component<Props> {
     const { intl } = this.context;
 
     const explorerInfo = this.props.selectedExplorer.getOrDefault(this.props.linkType);
+    if (explorerInfo == null) {
+      return this.props.children ?? null;
+    }
 
     const displayName = explorerInfo.name + ' ' + intl.formatMessage(globalMessages.blockchainExplorer);
 

--- a/app/domain/SelectedExplorer.js
+++ b/app/domain/SelectedExplorer.js
@@ -17,7 +17,7 @@ export class SelectedExplorer {
     this.backup = data.backup;
   }
 
-  getOrDefault: LinkType => {|
+  getOrDefault: LinkType => void | {|
     name: string,
     baseUrl: string,
   |} = (type) => {
@@ -35,7 +35,7 @@ export class SelectedExplorer {
         baseUrl: backupLink,
       };
     }
-    throw new Error(`Endpoint ${type} not in either selected or backup`);
+    return undefined;
   }
 }
 


### PR DESCRIPTION
(remade PR to fix github issue with detecting commits)

This never happens on mainnet, but on testnet there is no explorer that supports pool information which was causing a crash for testnet wallets if they delegated. This PR should fix it.