### PR TITLE
Make ergo use derived chains instead of accounts

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -182,7 +182,7 @@ export type CreateAdaPaperRequest = {|
 export type AdaPaper = {|
   addresses: Array<string>,
   scrambledWords: Array<string>,
-  accountPlate: WalletChecksum,
+  plate: WalletChecksum,
 |};
 export type CreateAdaPaperFunc = (
   request: CreateAdaPaperRequest
@@ -524,13 +524,13 @@ export default class AdaApi {
       request.network
     ).reduce((acc, next) => Object.assign(acc, next), {});
 
-    const { addresses, accountPlate } = generateByronPlate(
+    const { addresses, plate } = generateByronPlate(
       rootPk,
       0, // paper wallets always use account 0
       request.numAddresses != null ? request.numAddresses : DEFAULT_ADDRESSES_PER_PAPER,
       config.ByronNetworkId
     );
-    return { addresses, scrambledWords, accountPlate };
+    return { addresses, scrambledWords, plate };
   }
 
   async createAdaPaperPdf(
@@ -541,12 +541,12 @@ export default class AdaApi {
       updateStatus
     }: CreateAdaPaperPdfRequest
   ): Promise<CreateAdaPaperPdfResponse> {
-    const { addresses, scrambledWords, accountPlate } = paper;
+    const { addresses, scrambledWords, plate } = paper;
     // noinspection UnnecessaryLocalVariableJS
     const res : Promise<CreateAdaPaperPdfResponse> = generateAdaPaperPdf({
       words: scrambledWords,
       addresses,
-      accountPlate: printAccountPlate === true ? accountPlate : undefined,
+      plate: printAccountPlate === true ? plate : undefined,
       network,
     }, s => {
       Logger.info('[PaperWalletRender] ' + s);

--- a/app/api/ada/lib/cardanoCrypto/plate.js
+++ b/app/api/ada/lib/cardanoCrypto/plate.js
@@ -26,7 +26,7 @@ export const generateByronPlate = (
   const accountPublic = accountKey.to_public();
   const chainKey = accountPublic.derive(ChainDerivations.EXTERNAL);
 
-  const accountPlate = legacyWalletChecksum(
+  const plate = legacyWalletChecksum(
     Buffer.from(accountPublic.as_bytes()).toString('hex')
   );
   const generateAddressFunc = v2genAddressBatchFunc(
@@ -39,7 +39,7 @@ export const generateByronPlate = (
     byronNetworkMagic
   );
   const addresses = generateAddressFunc([...Array(count).keys()]);
-  return { addresses, accountPlate };
+  return { addresses, plate };
 };
 
 export const generateShelleyPlate = (
@@ -60,7 +60,7 @@ export const generateShelleyPlate = (
     .derive(STAKING_KEY_INDEX)
     .to_raw_key();
 
-  const accountPlate = walletChecksum(
+  const plate = walletChecksum(
     Buffer.from(accountPublic.as_bytes()).toString('hex')
   );
   const generateAddressFunc = genBaseAddressBatchFunc(
@@ -69,7 +69,7 @@ export const generateShelleyPlate = (
     chainNetworkId,
   );
   const addresses = generateAddressFunc([...Array(count).keys()]);
-  return { addresses, accountPlate };
+  return { addresses, plate };
 };
 
 export function genBaseAddressBatchFunc(

--- a/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -37,6 +37,7 @@ import {
   GetTransaction,
   GetTxAndBlock,
   GetCertificates,
+  GetKeyDerivation,
 } from '../database/primitives/api/read';
 import {
   ModifyAddress,
@@ -784,6 +785,7 @@ export async function updateTransactions(
       AssociateTxWithUtxoIOs,
       AssociateTxWithAccountingIOs,
       GetCertificates,
+      GetKeyDerivation,
     });
     const updateTables = Object
       .keys(updateDepTables)
@@ -1057,6 +1059,7 @@ async function rawUpdateTransactions(
     AssociateTxWithUtxoIOs: Class<AssociateTxWithUtxoIOs>,
     AssociateTxWithAccountingIOs: Class<AssociateTxWithAccountingIOs>,
     GetCertificates: Class<GetCertificates>,
+    GetKeyDerivation: Class<GetKeyDerivation>,
   |},
   publicDeriver: IPublicDeriver<>,
   lastSyncInfo: $ReadOnly<LastSyncInfoRow>,
@@ -1103,6 +1106,7 @@ async function rawUpdateTransactions(
           ModifyDisplayCutoff: deps.ModifyDisplayCutoff,
           GetDerivationsByPath: deps.GetDerivationsByPath,
           GetDerivationSpecific: deps.GetDerivationSpecific,
+          GetKeyDerivation: deps.GetKeyDerivation,
         },
         // TODO: race condition because we don't pass in best block here
         { checkAddressesInUse },

--- a/app/api/ada/lib/storage/bridge/walletBuilder/byron.js
+++ b/app/api/ada/lib/storage/bridge/walletBuilder/byron.js
@@ -218,7 +218,20 @@ export async function createStandardBip44Wallet(request: {|
               publicDeriverMeta: {
                 name: request.accountName,
               },
-              path: [WalletTypePurpose.BIP44, CoinTypes.CARDANO, request.accountIndex],
+              path: [
+                {
+                  index: WalletTypePurpose.BIP44,
+                  insert: {},
+                },
+                {
+                  index: CoinTypes.CARDANO,
+                  insert: {},
+                },
+                {
+                  index: request.accountIndex,
+                  insert: {},
+                },
+              ],
               initialDerivations,
             },
             privateDeriverKeyDerivationId: id,

--- a/app/api/ada/lib/storage/bridge/walletBuilder/shelley.js
+++ b/app/api/ada/lib/storage/bridge/walletBuilder/shelley.js
@@ -255,7 +255,20 @@ export async function createStandardCip1852Wallet(request: {|
               publicDeriverMeta: {
                 name: request.accountName,
               },
-              path: [WalletTypePurpose.CIP1852, CoinTypes.CARDANO, request.accountIndex],
+              path: [
+                {
+                  index: WalletTypePurpose.CIP1852,
+                  insert: {},
+                },
+                {
+                  index: CoinTypes.CARDANO,
+                  insert: {},
+                },
+                {
+                  index: request.accountIndex,
+                  insert: {},
+                },
+              ],
               initialDerivations,
             },
             privateDeriverKeyDerivationId: id,

--- a/app/api/ada/lib/storage/database/walletTypes/common/api/read.js
+++ b/app/api/ada/lib/storage/database/walletTypes/common/api/read.js
@@ -29,7 +29,7 @@ export class GetDerivationSpecific {
   ): Promise<$ReadOnlyArray<$ReadOnly<Row>>> {
     const tableName = derivationTables.get(level);
     if (tableName == null) {
-      throw new Error('GetDerivationSpecific::get Unknown table queried');
+      throw new Error(`${nameof(GetDerivationSpecific)}::get Unknown table queried`);
     }
     return await getRowIn<Row>(
       db, tx,

--- a/app/api/ada/lib/storage/database/walletTypes/common/api/write.js
+++ b/app/api/ada/lib/storage/database/walletTypes/common/api/write.js
@@ -53,7 +53,7 @@ export class AddDerivationTree {
     for (let i = 0; i < tree.children.length; i++) {
       const tableName = derivationTables.get(level + 1);
       if (tableName == null) {
-        throw new Error('AddDerivationTree::excludingParent Unknown table queried');
+        throw new Error(`${nameof(AddDerivationTree)}::${nameof(AddDerivationTree.excludingParent)} Unknown table queried`);
       }
       const child = await AddDerivationTree.depTables.GetOrAddDerivation.getOrAdd(
         db, tx,
@@ -107,7 +107,7 @@ export class AddDerivationTree {
   ): Promise<TreeResultStart<Row>> {
     const tableName = derivationTables.get(startingLevel);
     if (tableName == null) {
-      throw new Error('AddDerivationTree::includingParent Unknown table queried');
+      throw new Error(`${nameof(AddDerivationTree)}::${nameof(AddDerivationTree.includingParent)} Unknown table queried`);
     }
     const root = await AddDerivationTree.depTables.AddDerivation.add(
       db, tx,
@@ -143,7 +143,7 @@ export class AddDerivationTree {
     for (let i = 0; i < request.path.length; i++) {
       const tableName = derivationTables.get(request.pathStartLevel + i);
       if (tableName == null) {
-        throw new Error('AddDerivationTree::fromSinglePath Unknown table queried');
+        throw new Error(`${nameof(AddDerivationTree)}::${nameof(AddDerivationTree.fromSinglePath)} Unknown table queried`);
       }
       const levelResult = await AddDerivationTree.depTables.GetOrAddDerivation.getOrAdd(
         db, tx,
@@ -221,7 +221,7 @@ export class DerivePublicDeriverFromKey {
       true,
     );
     if (derivationAndKey.privateKey == null) {
-      throw new StaleStateError('DerivePublicDeriverFromKey::add privateKey');
+      throw new StaleStateError(`${nameof(DerivePublicDeriverFromKey)}::${nameof(DerivePublicDeriverFromKey.add)} privateKey`);
     }
     const derivedPath = body.pathToPublic(
       derivationAndKey.privateKey,
@@ -229,7 +229,7 @@ export class DerivePublicDeriverFromKey {
 
     // TODO: refactor to use fromSinglePathWithKey ?
     if (derivedPath.length === 0) {
-      throw new Error('DerivePublicDeriverFromKey::add derivedPath');
+      throw new Error(`${nameof(DerivePublicDeriverFromKey)}::${nameof(DerivePublicDeriverFromKey.add)} derivedPath`);
     }
     const pathResult = await DerivePublicDeriverFromKey.depTables.AddDerivationTree.fromSinglePath(
       db, tx,
@@ -252,7 +252,7 @@ export class DerivePublicDeriverFromKey {
         privateDeriverLevel + derivedPath.length
       );
       if (tableName == null) {
-        throw new Error('AddDerivation::add Unknown table queried');
+        throw new Error(`${nameof(DerivePublicDeriverFromKey)}::${nameof(DerivePublicDeriverFromKey.add)} Unknown table queried`);
       }
       pubDeriver = await DerivePublicDeriverFromKey.depTables.AddPublicDeriver.add(
         db, tx,
@@ -356,7 +356,7 @@ export class AddAdhocPublicDeriver {
       request.pathStartLevel + request.pathToPublic.length - 1
     );
     if (tableName == null) {
-      throw new Error('AddDerivation::add Unknown table queried');
+      throw new Error(`${nameof(AddAdhocPublicDeriver)}::${nameof(DerivePublicDeriverFromKey.add)} Unknown table queried`);
     }
 
     const existingWallets = await AddAdhocPublicDeriver.depTables.GetPublicDeriver.forWallet(

--- a/app/api/ada/lib/storage/models/ConceptualWallet/interfaces.js
+++ b/app/api/ada/lib/storage/models/ConceptualWallet/interfaces.js
@@ -81,7 +81,10 @@ export type IDerivePublicFromPrivateRequest = {|
    */
   encryptPublicDeriverPassword?: null | string,
   initialDerivations: TreeInsert<any>,
-  path: Array<number>,
+  path: Array<{|
+    index: number,
+    insert: any,
+  |}>,
 |};
 export type IDerivePublicFromPrivateResponse<Row> = AddPublicDeriverResponse<Row>;
 export type IDerivePublicFromPrivateFunc<Row> = (

--- a/app/api/ada/lib/storage/models/ConceptualWallet/traits.js
+++ b/app/api/ada/lib/storage/models/ConceptualWallet/traits.js
@@ -78,21 +78,23 @@ export async function derivePublicDeriver<Row>(
         const pubDeriverKey = normalizeToPubDeriverLevel({
           privateKeyRow,
           password: body.decryptPrivateDeriverPassword,
-          path: body.path,
+          path: body.path.map(entry => entry.index),
         });
         return [
-          ...body.path.slice(0, body.path.length - 1).map(index => ({
-            index,
+          ...body.path.slice(0, body.path.length - 1).map(pathEntry => ({
+            index: pathEntry.index,
             insert: insertRequest => Promise.resolve({
               KeyDerivationId: insertRequest.keyDerivationId,
+              ...pathEntry.insert,
             }),
             privateKey: null,
             publicKey: null,
           })),
           {
-            index: body.path[body.path.length - 1],
+            index: body.path[body.path.length - 1].index,
             insert: insertRequest => Promise.resolve({
               KeyDerivationId: insertRequest.keyDerivationId,
+              ...body.path[body.path.length - 1].insert,
             }),
             privateKey: body.encryptPublicDeriverPassword === undefined
               ? null

--- a/app/api/ada/lib/storage/models/ConceptualWallet/traits.js
+++ b/app/api/ada/lib/storage/models/ConceptualWallet/traits.js
@@ -75,7 +75,7 @@ export async function derivePublicDeriver<Row>(
     {
       publicDeriverMeta: body.publicDeriverMeta,
       pathToPublic: privateKeyRow => {
-        const accountKey = normalizeToPubDeriverLevel({
+        const pubDeriverKey = normalizeToPubDeriverLevel({
           privateKeyRow,
           password: body.decryptPrivateDeriverPassword,
           path: body.path,
@@ -98,17 +98,17 @@ export async function derivePublicDeriver<Row>(
               ? null
               : {
                 Hash: body.encryptPublicDeriverPassword === null
-                  ? accountKey.prvKeyHex
+                  ? pubDeriverKey.prvKeyHex
                   : encryptWithPassword(
                     body.encryptPublicDeriverPassword,
-                    Buffer.from(accountKey.prvKeyHex, 'hex')
+                    Buffer.from(pubDeriverKey.prvKeyHex, 'hex')
                   ),
                 IsEncrypted: true,
                 PasswordLastUpdate: null,
                 Type: privateKeyRow.Type, // type doesn't change with derivations
               },
             publicKey: {
-              Hash: accountKey.pubKeyHex,
+              Hash: pubDeriverKey.pubKeyHex,
               IsEncrypted: false,
               PasswordLastUpdate: null,
               Type: privateKeyRow.Type, // type doesn't change with derivations

--- a/app/api/ada/lib/storage/models/PublicDeriver/interfaces.js
+++ b/app/api/ada/lib/storage/models/PublicDeriver/interfaces.js
@@ -19,6 +19,7 @@ import type { UtxoTxOutput } from '../../database/transactionModels/utxo/api/rea
 import type {
   AddressRow,
   KeyRow,
+  CanonicalAddressInsert,
   CanonicalAddressRow,
   KeyDerivationRow,
 } from '../../database/primitives/tables';
@@ -416,7 +417,7 @@ export type IScanAccountFunc = (
   body: IScanAccountRequest
 ) => Promise<IScanAccountResponse>;
 
-export interface IScanUtxo {
+export interface IScanAccountUtxo {
   +rawScanAccount: RawTableVariation<
     IScanAccountFunc,
     {|
@@ -425,6 +426,28 @@ export interface IScanUtxo {
       GetDerivationSpecific: Class<GetDerivationSpecific>,
     |},
     IScanAccountRequest
+  >;
+}
+
+export type IScanChainRequest = {|
+  chainPublicKey: string,
+  lastUsedIndex: number,
+  addresses: Array<number>,
+  checkAddressesInUse: FilterFunc,
+|};
+export type IScanChainResponse = TreeInsert<CanonicalAddressInsert>;
+export type IScanChainFunc = (
+  body: IScanChainRequest
+) => Promise<IScanChainResponse>;
+export interface IScanChainUtxo {
+  +rawScanChain: RawTableVariation<
+    IScanChainFunc,
+    {|
+      GetPathWithSpecific: Class<GetPathWithSpecific>,
+      GetAddress: Class<GetAddress>,
+      GetDerivationSpecific: Class<GetDerivationSpecific>,
+    |},
+    IScanChainRequest
   >;
 }
 

--- a/app/api/ada/lib/storage/models/PublicDeriver/interfaces.js
+++ b/app/api/ada/lib/storage/models/PublicDeriver/interfaces.js
@@ -234,7 +234,8 @@ export interface IDisplayCutoff {
     IDisplayCutoffSetFunc,
     {|
       ModifyDisplayCutoff: Class<ModifyDisplayCutoff>,
-      GetDerivationsByPath: Class<GetDerivationsByPath>
+      GetDerivationsByPath: Class<GetDerivationsByPath>,
+      GetKeyDerivation: Class<GetKeyDerivation>,
     |},
     IDisplayCutoffSetRequest
   >;
@@ -386,6 +387,7 @@ export interface IScanAddresses {
       ModifyDisplayCutoff: Class<ModifyDisplayCutoff>,
       GetDerivationsByPath: Class<GetDerivationsByPath>,
       GetDerivationSpecific: Class<GetDerivationSpecific>,
+      GetKeyDerivation: Class<GetKeyDerivation>,
     |},
     IScanAddressesRequest
   >;
@@ -486,6 +488,7 @@ export interface IAddBip44FromPublic {
       GetDerivationsByPath: Class<GetDerivationsByPath>,
       GetPathWithSpecific: Class<GetPathWithSpecific>,
       GetDerivationSpecific: Class<GetDerivationSpecific>,
+      GetKeyDerivation: Class<GetKeyDerivation>,
     |},
     IAddBip44FromPublicRequest
   >;

--- a/app/api/ada/lib/storage/models/utils.js
+++ b/app/api/ada/lib/storage/models/utils.js
@@ -405,15 +405,21 @@ export async function updateCutoffFromInsert(
   derivationTables: Map<number, string>,
 ): Promise<void> {
   if (request.displayCutoffInstance != null) {
-    if (request.publicDeriverLevel !== Bip44DerivationLevels.ACCOUNT.level) {
+    const newEntries = (() => {
+      if (request.publicDeriverLevel === Bip44DerivationLevels.ACCOUNT.level) {
+        const external = request.tree.find(node => node.index === ChainDerivations.EXTERNAL);
+        if (external == null || external.children == null) {
+          throw new Error(`${nameof(updateCutoffFromInsert)} should never happen`);
+        }
+        return external.children;
+      }
+      if (request.publicDeriverLevel === Bip44DerivationLevels.CHAIN.level) {
+        return request.tree;
+      }
       throw new Error(`${nameof(updateCutoffFromInsert)} incorrect pubderiver level`);
-    }
-    const external = request.tree.find(node => node.index === ChainDerivations.EXTERNAL);
-    if (external == null || external.children == null) {
-      throw new Error(`${nameof(updateCutoffFromInsert)} should never happen`);
-    }
+    })();
     let bestNewCutoff = 0;
-    for (const child of external.children) {
+    for (const child of newEntries) {
       if (child.index > bestNewCutoff) {
         bestNewCutoff = child.index;
       }

--- a/app/api/ada/lib/storage/models/utils.js
+++ b/app/api/ada/lib/storage/models/utils.js
@@ -43,6 +43,7 @@ import {
   GetPathWithSpecific,
   GetDerivationsByPath,
   GetCertificates,
+  GetKeyDerivation,
 } from '../database/primitives/api/read';
 import {
   getAllSchemaTables,
@@ -394,6 +395,7 @@ export async function updateCutoffFromInsert(
     GetDerivationSpecific: Class<GetDerivationSpecific>,
     GetDerivationsByPath: Class<GetDerivationsByPath>,
     ModifyDisplayCutoff: Class<ModifyDisplayCutoff>,
+    GetKeyDerivation: Class<GetKeyDerivation>,
   |},
   request: {|
     publicDeriverLevel: number,
@@ -432,6 +434,7 @@ export async function updateCutoffFromInsert(
         {
           ModifyDisplayCutoff: deps.ModifyDisplayCutoff,
           GetDerivationsByPath: deps.GetDerivationsByPath,
+          GetKeyDerivation: deps.GetKeyDerivation,
         },
         { newIndex: bestNewCutoff - BIP44_SCAN_SIZE },
       );

--- a/app/api/ada/lib/storage/tests/index.test.js
+++ b/app/api/ada/lib/storage/tests/index.test.js
@@ -110,7 +110,20 @@ test('Can add and fetch address in wallet', async (done) => {
           publicDeriverMeta: {
             name: 'Checking account',
           },
-          path: [WalletTypePurpose.BIP44, CoinTypes.CARDANO, accountIndex],
+          path: [
+            {
+              index: WalletTypePurpose.BIP44,
+              insert: {},
+            },
+            {
+              index: CoinTypes.CARDANO,
+              insert: {},
+            },
+            {
+              index: accountIndex,
+              insert: {},
+            },
+          ],
           decryptPrivateDeriverPassword: privateDeriverPassword,
           initialDerivations: [
             {

--- a/app/api/ada/paperWallet/paperWalletPdf.js
+++ b/app/api/ada/paperWallet/paperWalletPdf.js
@@ -12,7 +12,7 @@ import { createIcon as blockiesIcon } from '@download/blockies';
 export type PaperRequest = {|
   words: Array<string>,
   addresses: Array<string>,
-  accountPlate: ?WalletChecksum,
+  plate: ?WalletChecksum,
   network: Network,
 |}
 
@@ -33,7 +33,7 @@ export const generateAdaPaperPdf = async (
 ): Promise<?Blob> => {
   // Prepare params
   // eslint-disable-next-line no-unused-vars
-  const { network, addresses, words, accountPlate } = request;
+  const { network, addresses, words, plate } = request;
 
   updateStatus(PdfGenSteps.initializing);
 
@@ -56,10 +56,10 @@ export const generateAdaPaperPdf = async (
       printTestnetLabel(doc, network, 172);
     }
 
-    if (accountPlate) {
+    if (plate) {
       // print account plate ID bottom-left corner of main front section
       doc.setFontSize(12);
-      doc.text(145, 180, accountPlate.TextPart);
+      doc.text(145, 180, plate.TextPart);
     }
 
     updateStatus(PdfGenSteps.frontpage);
@@ -83,11 +83,11 @@ export const generateAdaPaperPdf = async (
       printTestnetLabel(doc, network, 75, 180);
     }
 
-    if (accountPlate) {
+    if (plate) {
 
       // Generate account plate icon
       const icon = blockiesIcon({
-        seed: accountPlate.ImagePart,
+        seed: plate.ImagePart,
         size: 7,
         scale: 5,
         bgcolor: '#fff',
@@ -106,7 +106,7 @@ export const generateAdaPaperPdf = async (
 
       // Print account plate ID under the plate icon on backside
       doc.setFontSize(12);
-      textCenter(doc, 130, accountPlate.TextPart, null, 180, true);
+      textCenter(doc, 130, plate.TextPart, null, 180, true);
     }
 
     await addImage(doc, paperWalletPage2Path, pageSize);

--- a/app/api/common/lib/crypto/plate.js
+++ b/app/api/common/lib/crypto/plate.js
@@ -4,5 +4,5 @@ import type { WalletChecksum } from '@emurgo/cip4-js';
 
 export type PlateResponse = {|
   addresses: Array<string>,
-  accountPlate: WalletChecksum
+  plate: WalletChecksum
 |};

--- a/app/api/common/lib/restoration/bip44.js
+++ b/app/api/common/lib/restoration/bip44.js
@@ -47,7 +47,7 @@ export async function addAddrForType(
   };
 }
 
-async function scanChain(request: {|
+export async function scanBip44Chain(request: {|
   generateAddressFunc: GenerateAddressFunc,
   lastUsedIndex: number,
   checkAddressesInUse: FilterFunc,
@@ -90,7 +90,7 @@ export async function scanBip44Account(request: {|
   addByHash: AddByHashFunc,
   type: CoreAddressT,
 |}): Promise<TreeInsert<Bip44ChainInsert>> {
-  const externalAddresses = await scanChain({
+  const externalAddresses = await scanBip44Chain({
     generateAddressFunc: request.generateInternalAddresses,
     lastUsedIndex: request.lastUsedExternal,
     checkAddressesInUse: request.checkAddressesInUse,
@@ -98,7 +98,7 @@ export async function scanBip44Account(request: {|
     addByHash: request.addByHash,
     type: request.type,
   });
-  const internalAddresses = await scanChain({
+  const internalAddresses = await scanBip44Chain({
     generateAddressFunc: request.generateExternalAddresses,
     lastUsedIndex: request.lastUsedInternal,
     checkAddressesInUse: request.checkAddressesInUse,

--- a/app/api/ergo/lib/crypto/plate.js
+++ b/app/api/ergo/lib/crypto/plate.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { ergoGenAddressBatchFunc } from '../restoration/scan';
-import { BIP32PrivateKey, deriveKey, derivePath } from '../../../common/lib/crypto/keys/keyRepository';
+import { BIP32PrivateKey, derivePath } from '../../../common/lib/crypto/keys/keyRepository';
 import {
   HARD_DERIVATION_START,
   CoinTypes,
@@ -17,23 +17,22 @@ export const generateErgoPlate = (
   accountIndex: number,
   count: number,
 ): PlateResponse => {
-  const accountKey = derivePath(
+  const chainKey = derivePath(
     rootPk,
     [
       WalletTypePurpose.BIP44,
       CoinTypes.ERGO,
       accountIndex + HARD_DERIVATION_START,
+      ChainDerivations.EXTERNAL,
     ]
   );
-  const accountPublic = accountKey.toPublic();
-  const chainKey = deriveKey(accountPublic, ChainDerivations.EXTERNAL);
 
   const accountPlate = walletChecksum(
-    accountPublic.toBuffer().toString('hex')
+    chainKey.toBuffer().toString('hex')
   );
 
   const baseAddressGen = ergoGenAddressBatchFunc(
-    chainKey.key,
+    chainKey.toPublic().key,
   );
   const generateAddressFunc = (indices: Array<number>) => (
     baseAddressGen(indices)

--- a/app/api/ergo/lib/crypto/plate.js
+++ b/app/api/ergo/lib/crypto/plate.js
@@ -25,14 +25,14 @@ export const generateErgoPlate = (
       accountIndex + HARD_DERIVATION_START,
       ChainDerivations.EXTERNAL,
     ]
-  );
+  ).toPublic();
 
-  const accountPlate = walletChecksum(
+  const plate = walletChecksum(
     chainKey.toBuffer().toString('hex')
   );
 
   const baseAddressGen = ergoGenAddressBatchFunc(
-    chainKey.toPublic().key,
+    chainKey.key,
   );
   const generateAddressFunc = (indices: Array<number>) => (
     baseAddressGen(indices)
@@ -42,5 +42,5 @@ export const generateErgoPlate = (
       .map(addr => addr.address)
   );
   const addresses = generateAddressFunc([...Array(count).keys()]);
-  return { addresses, accountPlate };
+  return { addresses, plate };
 };

--- a/app/api/ergo/lib/restore.test.js
+++ b/app/api/ergo/lib/restore.test.js
@@ -76,6 +76,6 @@ test('Restore Ergo wallet', async () => {
   if (asGetPublicKeyInstance != null) {
     const pubKey = await asGetPublicKeyInstance.getPublicKey();
     const plate = legacyWalletChecksum(pubKey.Hash);
-    expect(plate.TextPart).toEqual('TNSS-9933');
+    expect(plate.TextPart).toEqual('NTOA-0222');
   }
 });

--- a/app/api/ergo/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ergo/lib/storage/bridge/updateTransactions.js
@@ -33,6 +33,7 @@ import {
   GetDerivationsByPath,
   GetTransaction,
   GetTxAndBlock,
+  GetKeyDerivation,
 } from '../../../../ada/lib/storage/database/primitives/api/read';
 import {
   ModifyAddress,
@@ -612,6 +613,7 @@ export async function updateTransactions(
       ModifyErgoTx,
       ErgoAssociateTxWithIOs,
       AssociateTxWithUtxoIOs,
+      GetKeyDerivation,
     });
     const updateTables = Object
       .keys(updateDepTables)
@@ -874,6 +876,7 @@ async function rawUpdateTransactions(
     ModifyErgoTx: Class<ModifyErgoTx>,
     ErgoAssociateTxWithIOs: Class<ErgoAssociateTxWithIOs>,
     AssociateTxWithUtxoIOs: Class<AssociateTxWithUtxoIOs>,
+    GetKeyDerivation: Class<GetKeyDerivation>,
   |},
   publicDeriver: IPublicDeriver<>,
   lastSyncInfo: $ReadOnly<LastSyncInfoRow>,
@@ -917,6 +920,7 @@ async function rawUpdateTransactions(
           ModifyDisplayCutoff: deps.ModifyDisplayCutoff,
           GetDerivationsByPath: deps.GetDerivationsByPath,
           GetDerivationSpecific: deps.GetDerivationSpecific,
+          GetKeyDerivation: deps.GetKeyDerivation,
         },
         // TODO: race condition because we don't pass in best block here
         { checkAddressesInUse },

--- a/app/api/ergo/lib/walletBuilder/builder.js
+++ b/app/api/ergo/lib/walletBuilder/builder.js
@@ -182,10 +182,24 @@ export async function createStandardBip44Wallet(request: {|
                 name: request.accountName,
               },
               path: [
-                WalletTypePurpose.BIP44,
-                CoinTypes.ERGO,
-                request.accountIndex,
-                ChainDerivations.EXTERNAL
+                {
+                  index: WalletTypePurpose.BIP44,
+                  insert: {},
+                },
+                {
+                  index: CoinTypes.ERGO,
+                  insert: {},
+                },
+                {
+                  index: request.accountIndex,
+                  insert: {},
+                },
+                {
+                  index: ChainDerivations.EXTERNAL,
+                  insert: {
+                    DisplayCutoff: 0,
+                  },
+                },
               ],
               initialDerivations,
             },

--- a/app/api/ergo/lib/walletBuilder/builder.js
+++ b/app/api/ergo/lib/walletBuilder/builder.js
@@ -35,7 +35,7 @@ import type { AddByHashFunc } from '../../../common/lib/storage/bridge/hashMappe
 import { rawGenAddByHash } from '../../../common/lib/storage/bridge/hashMapper';
 import { addErgoP2PK } from '../restoration/scan';
 import { KeyKind } from '../../../common/lib/crypto/keys/types';
-import { derivePath, BIP32PublicKey, BIP32PrivateKey } from '../../../common/lib/crypto/keys/keyRepository';
+import { derivePath, deriveKey, BIP32PublicKey, BIP32PrivateKey } from '../../../common/lib/crypto/keys/keyRepository';
 
 // TODO: maybe move this inside walletBuilder somehow so it's all done in the same transaction
 /**
@@ -43,7 +43,7 @@ import { derivePath, BIP32PublicKey, BIP32PrivateKey } from '../../../common/lib
  * This is because scanning depends on having an internet connection
  * But we need to ensure the address maintains the BIP44 gap regardless of internet connection
  */
-export async function getAccountDefaultDerivations(
+export async function getChainDefaultDerivations(
   bip32Account: BIP32PublicKey,
   addByHash: AddByHashFunc,
 ): Promise<TreeInsert<Bip44ChainInsert>> {
@@ -54,27 +54,7 @@ export async function getAccountDefaultDerivations(
 
   const externalAddrs = addressesIndex.map(i => (
     Address.fromPk(
-      derivePath(
-        bip32Account,
-        [
-          ChainDerivations.EXTERNAL,
-          i,
-        ]
-      )
-        .key
-        .publicKey
-        .toString('hex')
-    ).addrBytes.toString('hex')
-  ));
-  const internalAddrs = addressesIndex.map(i => (
-    Address.fromPk(
-      derivePath(
-        bip32Account,
-        [
-          ChainDerivations.INTERNAL,
-          i,
-        ]
-      )
+      deriveKey(bip32Account, i)
         .key
         .publicKey
         .toString('hex')
@@ -101,35 +81,8 @@ export async function getAccountDefaultDerivations(
       );
     },
   }));
-  const internalAddresses = addressesIndex.map(i => ({
-    index: i,
-    insert: async insertRequest => {
-      return await addErgoP2PK(
-        addByHash,
-        insertRequest,
-        internalAddrs[i]
-      );
-    },
-  }));
 
-  return [
-    {
-      index: 0,
-      insert: insertRequest => Promise.resolve({
-        KeyDerivationId: insertRequest.keyDerivationId,
-        DisplayCutoff: 0
-      }),
-      children: externalAddresses,
-    },
-    {
-      index: 1,
-      insert: insertRequest => Promise.resolve({
-        KeyDerivationId: insertRequest.keyDerivationId,
-        DisplayCutoff: null,
-      }),
-      children: internalAddresses,
-    }
-  ];
+  return externalAddresses;
 }
 
 export async function createStandardBip44Wallet(request: {|
@@ -150,17 +103,18 @@ export async function createStandardBip44Wallet(request: {|
     request.rootPk.toBuffer(),
   );
 
-  const accountKey = derivePath(
+  const chainKey = derivePath(
     request.rootPk,
     [
       WalletTypePurpose.BIP44,
       CoinTypes.ERGO,
       request.accountIndex,
+      ChainDerivations.EXTERNAL,
     ]
   ).toPublic();
 
-  const initialDerivations = await getAccountDefaultDerivations(
-    accountKey,
+  const initialDerivations = await getChainDefaultDerivations(
+    chainKey,
     rawGenAddByHash(new Set()),
   );
 
@@ -208,7 +162,7 @@ export async function createStandardBip44Wallet(request: {|
         finalState => ({
           ConceptualWalletId: finalState.conceptualWalletRow.ConceptualWalletId,
           SignerLevel: Bip44DerivationLevels.ROOT.level,
-          PublicDeriverLevel: Bip44DerivationLevels.ACCOUNT.level,
+          PublicDeriverLevel: Bip44DerivationLevels.CHAIN.level,
           PrivateDeriverKeyDerivationId: finalState.root.root.KeyDerivation.KeyDerivationId,
           PrivateDeriverLevel: pathToPrivate.length,
           RootKeyDerivationId: finalState.root.root.KeyDerivation.KeyDerivationId,
@@ -227,7 +181,12 @@ export async function createStandardBip44Wallet(request: {|
               publicDeriverMeta: {
                 name: request.accountName,
               },
-              path: [WalletTypePurpose.BIP44, CoinTypes.ERGO, request.accountIndex],
+              path: [
+                WalletTypePurpose.BIP44,
+                CoinTypes.ERGO,
+                request.accountIndex,
+                ChainDerivations.EXTERNAL
+              ],
               initialDerivations,
             },
             privateDeriverKeyDerivationId: id,

--- a/app/api/jormungandr/lib/crypto/plate.js
+++ b/app/api/jormungandr/lib/crypto/plate.js
@@ -32,7 +32,7 @@ export const generateJormungandrPlate = (
     .derive(STAKING_KEY_INDEX)
     .to_raw_key();
 
-  const accountPlate = legacyWalletChecksum(
+  const plate = legacyWalletChecksum(
     Buffer.from(accountPublic.as_bytes()).toString('hex')
   );
   const generateAddressFunc = genGroupAddressBatchFunc(
@@ -41,7 +41,7 @@ export const generateJormungandrPlate = (
     discrimination,
   );
   const addresses = generateAddressFunc([...Array(count).keys()]);
-  return { addresses, accountPlate };
+  return { addresses, plate };
 };
 
 export function genGroupAddressBatchFunc(

--- a/app/api/jormungandr/lib/storage/bridge/updateTransactions.js
+++ b/app/api/jormungandr/lib/storage/bridge/updateTransactions.js
@@ -31,6 +31,7 @@ import {
   GetDerivationsByPath,
   GetTransaction,
   GetTxAndBlock,
+  GetKeyDerivation,
 } from '../../../../ada/lib/storage/database/primitives/api/read';
 import {
   ModifyAddress,
@@ -664,6 +665,7 @@ export async function updateTransactions(
       JormungandrAssociateTxWithIOs,
       AssociateTxWithAccountingIOs,
       AssociateTxWithUtxoIOs,
+      GetKeyDerivation,
     });
     const updateTables = Object
       .keys(updateDepTables)
@@ -934,6 +936,7 @@ async function rawUpdateTransactions(
     JormungandrAssociateTxWithIOs: Class<JormungandrAssociateTxWithIOs>,
     AssociateTxWithAccountingIOs: Class<AssociateTxWithAccountingIOs>,
     AssociateTxWithUtxoIOs: Class<AssociateTxWithUtxoIOs>,
+    GetKeyDerivation: Class<GetKeyDerivation>,
   |},
   publicDeriver: IPublicDeriver<>,
   lastSyncInfo: $ReadOnly<LastSyncInfoRow>,
@@ -981,6 +984,7 @@ async function rawUpdateTransactions(
           ModifyDisplayCutoff: deps.ModifyDisplayCutoff,
           GetDerivationsByPath: deps.GetDerivationsByPath,
           GetDerivationSpecific: deps.GetDerivationSpecific,
+          GetKeyDerivation: deps.GetKeyDerivation,
         },
         // TODO: race condition because we don't pass in best block here
         { checkAddressesInUse },

--- a/app/api/jormungandr/lib/storage/bridge/walletBuilder/jormungandr.js
+++ b/app/api/jormungandr/lib/storage/bridge/walletBuilder/jormungandr.js
@@ -253,7 +253,20 @@ export async function createStandardCip1852Wallet(request: {|
               publicDeriverMeta: {
                 name: request.accountName,
               },
-              path: [WalletTypePurpose.CIP1852, CoinTypes.CARDANO, request.accountIndex],
+              path: [
+                {
+                  index: WalletTypePurpose.CIP1852,
+                  insert: {},
+                },
+                {
+                  index: CoinTypes.CARDANO,
+                  insert: {},
+                },
+                {
+                  index: request.accountIndex,
+                  insert: {},
+                },
+              ],
               initialDerivations,
             },
             privateDeriverKeyDerivationId: id,

--- a/app/components/wallet/WalletRestoreVerifyDialog.js
+++ b/app/components/wallet/WalletRestoreVerifyDialog.js
@@ -173,7 +173,7 @@ export default class WalletRestoreVerifyDialog extends Component<Props> {
 
     const plateElems = this.props.plates.map(plate => this.generatePlate(
       intl.formatMessage(plate.checksumTitle),
-      plate.accountPlate,
+      plate.plate,
     ));
 
     const addressElems = this.props.plates.map(plate => this.generateAddresses(

--- a/app/components/wallet/add/paper-wallets/FinalizeDialog.js
+++ b/app/components/wallet/add/paper-wallets/FinalizeDialog.js
@@ -110,16 +110,16 @@ export default class FinalizeDialog extends Component<Props> {
           </li>
         </ul>
 
-        {paper.accountPlate ? (
+        {paper.plate ? (
           <div>
             <h2 className={styles.addressLabel}>
               {intl.formatMessage(messages.paperAccountIdLabel)}
             </h2>
             <div className={styles.plateRowDiv}>
               <WalletAccountIcon
-                iconSeed={paper.accountPlate.ImagePart}
+                iconSeed={paper.plate.ImagePart}
               />
-              <span className={styles.plateIdSpan}>{paper.accountPlate.TextPart}</span>
+              <span className={styles.plateIdSpan}>{paper.plate.TextPart}</span>
             </div>
           </div>
         ) : ''}

--- a/app/containers/wallet/WalletAddPage.stories.js
+++ b/app/containers/wallet/WalletAddPage.stories.js
@@ -1494,7 +1494,7 @@ const constructedPaperWallet = {
     'Ae2tdPwUPEZAPUqpvUgoBB7QjrfAbu1RXbFRoLcdYYV8r4FaSJrq4oowAhv',
   ],
   scrambledWords: getValidationMnemonicCases(21).Correct.split(' '),
-  accountPlate: {
+  plate: {
     ImagePart: '7b9bf637f341bed7933c8673f9fb7e405097746115f24ec7d192f80fb6efb219da8bc1902dab99fc070f156b7877f29dd8e581da616ff7fdad28493d084a0db9',
     TextPart: 'XLBS-6706',
   },

--- a/app/stores/base/AddressSubgroupStore.js
+++ b/app/stores/base/AddressSubgroupStore.js
@@ -259,6 +259,20 @@ export class GroupMangledAddressesSubgroup extends AddressTypeStore implements I
     return this;
   }
 }
+export class P2PKAllAddressesSubgroup extends AddressTypeStore implements IAddressTypeStore {
+  constructor(data: SubgroupCtorData): IAddressTypeStore {
+    super({
+      stores: data.stores,
+      actions: data.actions,
+      request: (request) => data.stores.addresses._wrapForAllAddresses({
+        ...request,
+        storeName: data.name,
+        type: CoreAddressTypes.ERGO_P2PK,
+      }),
+    });
+    return this;
+  }
+}
 export class P2PKExternalAddressesSubgroup extends AddressTypeStore implements IAddressTypeStore {
   constructor(data: SubgroupCtorData): IAddressTypeStore {
     super({

--- a/app/stores/stateless/addressStores.js
+++ b/app/stores/stateless/addressStores.js
@@ -13,6 +13,7 @@ import {
   GroupExternalAddressesSubgroup,
   GroupInternalAddressesSubgroup,
   GroupMangledAddressesSubgroup,
+  P2PKAllAddressesSubgroup,
   P2PKExternalAddressesSubgroup,
   P2PKInternalAddressesSubgroup,
 } from '../base/AddressSubgroupStore';
@@ -115,7 +116,8 @@ export const BYRON_ALL: AddressSubgroupMeta<
 > = registerAddressSubgroup({
   isRelated: request => (
     matchParent(request.selected, parent => parent instanceof Bip44Wallet) &&
-    asHasUtxoChains(request.selected) == null
+    asHasUtxoChains(request.selected) == null &&
+    matchCoinType(request.selected, coinType => coinType === CoinTypes.CARDANO)
   ),
   class: ByronAllAddressesSubgroup,
   validFilters: standardFilter,
@@ -272,6 +274,22 @@ export const GROUP_MANGLED: AddressSubgroupMeta<
     group: AddressGroupTypes.group,
   },
   isHidden: request => request.result == null || request.result.length === 0,
+});
+export const P2PK_ALL: AddressSubgroupMeta<
+  P2PKAllAddressesSubgroup
+> = registerAddressSubgroup({
+  isRelated: request => (
+    matchParent(request.selected, parent => parent instanceof Bip44Wallet) &&
+    asHasUtxoChains(request.selected) == null &&
+    matchCoinType(request.selected, coinType => coinType === CoinTypes.ERGO)
+  ),
+  class: P2PKAllAddressesSubgroup,
+  validFilters: standardFilter,
+  name: {
+    subgroup: AddressSubgroup.all,
+    group: AddressGroupTypes.p2pk,
+  },
+  isHidden: _request => false,
 });
 export const P2PK_EXTERNAL: AddressSubgroupMeta<
   P2PKExternalAddressesSubgroup

--- a/features/mock-chain/TestWallets.js
+++ b/features/mock-chain/TestWallets.js
@@ -132,6 +132,6 @@ export const testWallets: { [key: WalletNames]: RestorationInput, ... } = Object
   createWallet({
     name: ('ergo-simple-wallet': WalletNames),
     mnemonic: 'eight country switch draw meat scout mystery blade tip drift useless good keep usage title',
-    plate: 'DXSD-7186',
+    plate: 'CXTP-1821',
   }),
 );

--- a/features/wallet-restoration.feature
+++ b/features/wallet-restoration.feature
@@ -358,7 +358,7 @@ Feature: Restore Wallet
     | password   | repeatedPassword |
     | asdfasdfasdf | asdfasdfasdf       |
     And I click the "Restore Wallet" button
-    Then I should see a plate DXSD-7186
+    Then I should see a plate CXTP-1821
     Then I click the next button
     Then I should see the opened wallet with name "Restored Wallet"
     And I go to the receive screen


### PR DESCRIPTION
This makes that Ergo wallets are now derived chain wallets instead of derived account wallets (and therefore no longer support internal addresses)

TODO
- [x] fix the new address scanning after the initial sync