### PR TITLE
topbar/banners: removing the network

### DIFF
--- a/app/components/topbar/banners/TestnetWarningBanner.js
+++ b/app/components/topbar/banners/TestnetWarningBanner.js
@@ -15,7 +15,7 @@ const messages = defineMessages({
   },
   nightlyLabel: {
     id: 'nightly.banner.label.message',
-    defaultMessage: '!!!YOU ARE ON YOROI NIGHTLY ({network}).',
+    defaultMessage: '!!!YOU ARE ON YOROI NIGHTLY.',
   },
 });
 
@@ -38,7 +38,6 @@ export default class TestnetWarningBanner extends Component<Props> {
           <div className={styles.text}>
             <FormattedMessage
               {...messages.nightlyLabel}
-              values={{ network: environment.getNetworkName() }}
               key="1"
             />
           </div>
@@ -52,7 +51,6 @@ export default class TestnetWarningBanner extends Component<Props> {
           <div className={styles.text}>
             <FormattedMessage
               {...messages.testnetLabel}
-              values={{ network: environment.getNetworkName() }}
               key="1"
             />
           </div>

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -145,7 +145,7 @@
   "myWallets.wallets.neverSync": "Never synced",
   "myWallets.wallets.sumInfoText": "Total wallet balance",
   "networkError.label.message": "WARNING: Connection to the server failed.<br>Please check your internet connection or <a target='blank' href='https://twitter.com/YoroiWallet'>our Twitter account</a>.<br>The displayed balance and transaction history may appear incorrect until our servers are back to normal, but your actual balance is not affected.",
-  "nightly.banner.label.message": "YOU ARE ON YOROI NIGHTLY ({network}).",
+  "nightly.banner.label.message": "YOU ARE ON YOROI NIGHTLY.",
   "noticeBoard.noNoticeText.chooseAPool": "To view notifications here, first <strong>choose a stake pool</strong> and delegate your {ticker}.",
   "noticeBoard.noNoticeText.notDelegatedYet": "You have not delegated a stake yet.",
   "noticeBoard.notice.costChanged.subMessage": "Old cost was {oldCost} {currency} and new cost is {newCost} {currency}",


### PR DESCRIPTION
Removing the network from the banners, given we are multi network currently. The banner is shown before any network is chosen.

closes #1732