### PR TITLE
Update backend version (Payment keys + reward history)

### DIFF
--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -1464,7 +1464,7 @@ export default class AdaApi {
     } catch (error) {
       Logger.error(`${nameof(AdaApi)}::${nameof(this.restoreWallet)} error: ` + stringifyError(error));
       // TODO: handle case where wallet already exists (this if case is never hit)
-      if (error.message.includes('Wallet with that mnemonics already exists')) {
+      if (error.message != null && error.message.includes('Wallet with that mnemonics already exists')) {
         throw new WalletAlreadyRestoredError();
       }
 
@@ -1589,7 +1589,7 @@ export default class AdaApi {
       // where not imported/restored if some where. if no wallets are imported
       // we will error out completely with throw block below
       // TODO: use error ID instead of error message
-      if (error.message.includes('Wallet with that mnemonics already exists')) {
+      if (error.message != null && error.message.includes('Wallet with that mnemonics already exists')) {
         throw new WalletAlreadyRestoredError();
       }
       if (error instanceof LocalizableError) throw error;

--- a/app/api/ada/lib/state-fetch/types.js
+++ b/app/api/ada/lib/state-fetch/types.js
@@ -262,10 +262,10 @@ export type RewardHistoryRequest = {|
   ...BackendNetworkInfo,
   addresses: Array<string>,
 |};
-export type RewardTuple = [
-  number, /* epoch */
-  number /* amount in lovelaces */
-];
+export type RewardTuple = {|
+  epoch: number,
+  reward: string,
+|};
 export type RewardHistoryResponse = { [address: string]: Array<RewardTuple>, ... };
 export type RewardHistoryFunc = (body: RewardHistoryRequest) => Promise<RewardHistoryResponse>;
 

--- a/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -130,7 +130,7 @@ import {
 import type {
   FilterFunc,
 } from '../../../../common/lib/state-fetch/currencySpecificTypes';
-import { addressToKind, addressToDisplayString } from './utils';
+import { addressToKind, } from './utils';
 import { RustModule } from '../../cardanoCrypto/rustLoader';
 
 async function rawGetAllTxIds(

--- a/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1151,16 +1151,13 @@ async function rawUpdateTransactions(
       network,
       addresses: [
         ...addresses.utxoAddresses
-          // Note: don't send base/ptr keys
-          // Since the payment key is duplicated inside the enterprise addresses
-          // .filter(address => (
-          //   address.Type !== CoreAddressTypes.CARDANO_BASE &&
-          //   address.Type !== CoreAddressTypes.CARDANO_PTR
-          // ))
-          // TODO: get rid of this once backend supports querying by payment key
-          .map(address => address.Hash)
-          // TODO: remove this when we properly support passing payment keys
-          .map(addr => addressToDisplayString(addr, publicDeriver.getParent().getNetworkInfo())),
+          .filter(address => (
+            // enterprise address will get the history for any address that has the same payment key
+            address.Type === CoreAddressTypes.CARDANO_ENTERPRISE ||
+            // needs to send legacy addresses directly since they don't use the payment key method
+            address.Type === CoreAddressTypes.CARDANO_LEGACY
+          ))
+          .map(address => address.Hash),
         // note: sending account addresses is required
         // since for example, the staking key registration certificate doesn't need a witness
         // so a tx where no input/output belongs to you could register your staking key

--- a/app/api/ada/lib/storage/bridge/walletBuilder/shelley.js
+++ b/app/api/ada/lib/storage/bridge/walletBuilder/shelley.js
@@ -66,24 +66,22 @@ export async function getAccountDefaultDerivations(
       .derive(ChainDerivations.EXTERNAL)
       .derive(i)
       .to_raw_key();
-    const addr = RustModule.WalletV4.BaseAddress.new(
+    const addr = RustModule.WalletV4.EnterpriseAddress.new(
       chainNetworkId,
       RustModule.WalletV4.StakeCredential.from_keyhash(key.hash()),
-      RustModule.WalletV4.StakeCredential.from_keyhash(stakingKey.hash())
     );
-    return addr.to_address().to_bech32();
+    return Buffer.from(addr.to_address().to_bytes());
   });
   const internalAddrs = addressesIndex.map(i => {
     const key = accountPublicKey
       .derive(ChainDerivations.INTERNAL)
       .derive(i)
       .to_raw_key();
-    const addr = RustModule.WalletV4.BaseAddress.new(
+    const addr = RustModule.WalletV4.EnterpriseAddress.new(
       chainNetworkId,
       RustModule.WalletV4.StakeCredential.from_keyhash(key.hash()),
-      RustModule.WalletV4.StakeCredential.from_keyhash(stakingKey.hash())
     );
-    return addr.to_address().to_bech32();
+    return Buffer.from(addr.to_address().to_bytes());
   });
   /**
    * Even if the user has no internet connection and scanning fails,

--- a/app/api/common/lib/storage/bridge/delegationUtils.js
+++ b/app/api/common/lib/storage/bridge/delegationUtils.js
@@ -53,7 +53,7 @@ export type GetCurrentDelegationFunc = (
 export type RewardHistoryRequest = string;
 export type RewardHistoryResponse = Array<[
   number, // epoch
-  number, // amount
+  BigNumber, // amount
 ]>;
 export type RewardHistoryFunc = (
   request: RewardHistoryRequest

--- a/app/api/ergo/index.js
+++ b/app/api/ergo/index.js
@@ -417,7 +417,7 @@ export default class ErgoApi {
     } catch (error) {
       Logger.error(`${nameof(ErgoApi)}::${nameof(this.restoreWallet)} error: ` + stringifyError(error));
       // TODO: handle case where wallet already exists (this if case is never hit)
-      if (error.message.includes('Wallet with that mnemonics already exists')) {
+      if (error.message != null && error.message.includes('Wallet with that mnemonics already exists')) {
         throw new WalletAlreadyRestoredError();
       }
 

--- a/app/api/jormungandr/index.js
+++ b/app/api/jormungandr/index.js
@@ -755,7 +755,7 @@ export default class JormungandrApi {
     } catch (error) {
       Logger.error(`${nameof(JormungandrApi)}::${nameof(this.restoreWallet)} error: ` + stringifyError(error));
       // TODO: handle case where wallet already exists (this if case is never hit)
-      if (error.message.includes('Wallet with that mnemonics already exists')) {
+      if (error.message != null && error.message.includes('Wallet with that mnemonics already exists')) {
         throw new WalletAlreadyRestoredError();
       }
 
@@ -893,7 +893,7 @@ export default class JormungandrApi {
       // where not imported/restored if some where. if no wallets are imported
       // we will error out completely with throw block below
       // TODO: use error ID instead of error message
-      if (error.message.includes('Wallet with that mnemonics already exists')) {
+      if (error.message != null && error.message.includes('Wallet with that mnemonics already exists')) {
         throw new WalletAlreadyRestoredError();
       }
       if (error instanceof LocalizableError) throw error;

--- a/app/components/wallet/staking/dashboard/StakingDashboard.js
+++ b/app/components/wallet/staking/dashboard/StakingDashboard.js
@@ -106,13 +106,13 @@ export default class StakingDashboard extends Component<Props> {
       ? null
       : (
         <div className={styles.graphsWrapper}>
-          {/* {this._displayGraph(graphData.rewardsGraphData)} */}
+          {this._displayGraph(graphData.rewardsGraphData)}
           {/* <GraphWrapper
-            themeVars={themeVars}
+            themeVars={this.props.themeVars}
             tabs={[
-              intl.formatMessage(messages.positionsLabel),
-              intl.formatMessage(globalMessages.marginsLabel),
-              intl.formatMessage(messages.costsLabel),
+              this.context.intl.formatMessage(messages.positionsLabel),
+              this.context.intl.formatMessage(globalMessages.marginsLabel),
+              this.context.intl.formatMessage(messages.costsLabel),
             ]}
             graphName="positions"
             data={graphData.positionsGraphData}

--- a/app/containers/wallet/staking/StakingDashboardPage.stories.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.stories.js
@@ -563,7 +563,7 @@ function getStakingInfo(
       stakingCase === stakingKeyCases.LongAgoDelegation ||
       stakingCase === stakingKeyCases.ManuallyUndelegate ||
       stakingCase === stakingKeyCases.ChangePools
-        ? Promise.resolve([[99, 1000], [100, 500]])
+        ? Promise.resolve([[99, new BigNumber(1000)], [100, new BigNumber(500)]])
         : Promise.resolve([])
     )
   );

--- a/app/stores/ada/AdaDelegationStore.js
+++ b/app/stores/ada/AdaDelegationStore.js
@@ -60,11 +60,17 @@ export default class AdaDelegationStore extends Store {
         // we need to defer this call because the store may not be initialized yet
         // by the time this constructor is called
         const stateFetcher = this.stores.substores.ada.stateFetchStore.fetcher;
-        const result = await stateFetcher.getRewardHistory({
+        const historyResult = await stateFetcher.getRewardHistory({
           network: publicDeriver.getParent().getNetworkInfo(),
           addresses: [address],
         });
-        return result[address] ?? [];
+        // flowlint-next-line unnecessary-optional-chain:off
+        const addressRewards = historyResult[address]?.map(info => (
+          ([info.epoch, new BigNumber(info.reward)]: [number, BigNumber])
+        ));
+        return addressRewards != null
+          ? addressRewards
+          : [];
       }),
       error: undefined,
     });

--- a/app/stores/jormungandr/JormungandrDelegationStore.js
+++ b/app/stores/jormungandr/JormungandrDelegationStore.js
@@ -52,11 +52,17 @@ export default class JormungandrDelegationStore extends Store {
         const { BackendService } = publicDeriver.getParent().getNetworkInfo().Backend;
         if (BackendService == null) throw new Error(`rewardHistory missing backend url`);
         const stateFetcher = this.stores.substores.jormungandr.stateFetchStore.fetcher;
-        const result = await stateFetcher.getRewardHistory({
+        const historyResult = await stateFetcher.getRewardHistory({
           network: publicDeriver.getParent().getNetworkInfo(),
           addresses: [address]
         });
-        return result[address] ?? [];
+        // flowlint-next-line unnecessary-optional-chain:off
+        const addressRewards = historyResult[address]?.map(info => (
+          ([info[0], new BigNumber(info[1])]: [number, BigNumber])
+        ));
+        return addressRewards != null
+          ? addressRewards
+          : [];
       }),
       error: undefined,
     };

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -11,6 +11,7 @@ Feature: Yoroi delegation dashboard
     Given There is a Shelley wallet stored named shelley-delegated
     And I have a wallet with funds
     And I go to the dashboard screen
+    Then I should rewards in the history
     When I click on the withdraw button
     Then I click on the checkbox
     And I click the next button

--- a/features/mock-chain/mockCardanoImporter.js
+++ b/features/mock-chain/mockCardanoImporter.js
@@ -6,7 +6,7 @@ import type {
   UtxoSumFunc,
   PoolInfoFunc,
   AddressUtxoFunc,
-  RewardHistoryFunc,
+  RewardHistoryRequest, RewardHistoryResponse, RewardHistoryFunc,
   AccountStateFunc,
   RemoteAccountState,
   HistoryFunc,
@@ -24,7 +24,6 @@ import type {
 import BigNumber from 'bignumber.js';
 import {
   genGetTransactionsHistoryForAddresses,
-  genGetRewardHistory,
   genGetPoolInfo,
   genGetBestBlock,
   genCheckAddressesInUse,
@@ -1897,7 +1896,24 @@ const sendTx = (request: SignedRequestInternal): SignedResponse => {
 };
 
 const getPoolInfo: PoolInfoFunc = genGetPoolInfo();
-const getRewardHistory: RewardHistoryFunc = genGetRewardHistory();
+const getRewardHistory: RewardHistoryFunc = async (
+  _body: RewardHistoryRequest,
+): Promise<RewardHistoryResponse> => {
+  return {
+    e19558e969caa9e57adcfc40b9907eb794363b590faf42fff48c38eb88: [{
+      epoch: 210,
+      reward: '5000000',
+    }],
+    e156db5cd4889c84110d4de90c0d503b51b844db3e6fd87991238995bb: [{
+      epoch: 210,
+      reward: '5000000',
+    }],
+    e1deb0bcccbace8644ecbbb2b8eb9fc7a6b0e7380e8f019f44364dd060: [{
+      epoch: 210,
+      reward: '5000000',
+    }],
+  };
+};
 
 const getAccountState: AccountStateFunc = async (request) => {
   const totalRewards = new BigNumber(5000000);

--- a/features/mock-chain/mockCardanoServer.js
+++ b/features/mock-chain/mockCardanoServer.js
@@ -7,6 +7,7 @@ import type {
   HistoryRequest, HistoryResponse,
   AccountStateRequest, AccountStateResponse,
   PoolInfoRequest, PoolInfoResponse,
+  RewardHistoryRequest, RewardHistoryResponse,
   BestBlockRequest, BestBlockResponse,
   SignedResponse,
   SignedRequestInternal,
@@ -137,7 +138,7 @@ export function getMockServer(
       }
     });
 
-    server.post('/api/getPoolInfo', async (
+    server.post('/api/pool/info', async (
       req: { body: PoolInfoRequest, ... },
       res: { send(arg: PoolInfoResponse): any, ... }
     ): Promise<void> => {
@@ -145,7 +146,15 @@ export function getMockServer(
       res.send(poolsInfo);
     });
 
-    server.post('/api/getAccountState', async (
+    server.post('/api/account/rewardHistory', async (
+      req: { body: RewardHistoryRequest, ... },
+      res: { send(arg: RewardHistoryResponse): any, ... }
+    ): Promise<void> => {
+      const poolsInfo = await mockImporter.getRewardHistory(req.body);
+      res.send(poolsInfo);
+    });
+
+    server.post('/api/account/state', async (
       req: { body: AccountStateRequest, ... },
       res: { send(arg: AccountStateResponse): any, ... }
     ): Promise<void> => {

--- a/features/step_definitions/dashboard-steps.js
+++ b/features/step_definitions/dashboard-steps.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { When, } from 'cucumber';
+import { Then, When, } from 'cucumber';
 
 When(/^I go to the dashboard screen$/, async function () {
   await this.click('.stakeDashboard ');
@@ -8,4 +8,8 @@ When(/^I go to the dashboard screen$/, async function () {
 
 When(/^I click on the withdraw button$/, async function () {
   await this.click('.withdrawButton ');
+});
+
+Then(/^I should rewards in the history$/, async function () {
+  await this.waitForElement('.recharts-bar');
 });


### PR DESCRIPTION
This PR updates to use the new version of the Yoroi backend that supports

- Queries by payment keys instead of bech32 addresses
- Reward history endpoint

![image](https://user-images.githubusercontent.com/2608559/96467998-89098a00-1266-11eb-85b2-12184323bf1d.png)

TODO:
- [x] E2E test mock backend support for payment key queries
- [x] E2E test for reward history
