### PR TITLE
fix(explorers): correct url for cardano.org explorers

### DIFF
--- a/app/api/ada/lib/storage/database/prepackaged/explorers.js
+++ b/app/api/ada/lib/storage/database/prepackaged/explorers.js
@@ -47,8 +47,8 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
-      address: 'https://cardanoexplorer.com/address/',
-      transaction: 'https://explorer.cardano.org/en/transaction/',
+      address: 'https://explorer.cardano.org/en/address?address=',
+      transaction: 'https://explorer.cardano.org/en/transaction?id=',
     },
     Name: 'CardanoExplorer',
   },
@@ -138,8 +138,8 @@ const CardanoTestnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     NetworkId: networks.CardanoTestnet.NetworkId,
     IsBackup: true,
     Endpoints: {
-      address: 'https://explorer.cardano-testnet.iohkdev.io/address/',
-      transaction: 'https://explorer.cardano-testnet.iohkdev.io/en/transaction/',
+      address: 'https://explorer.cardano-testnet.iohkdev.io/en/address?address=',
+      transaction: 'https://explorer.cardano-testnet.iohkdev.io/en/transaction?id=',
     },
     Name: 'CardanoExplorer',
   },

--- a/app/api/ada/lib/storage/tests/__snapshots__/index.test.js.snap
+++ b/app/api/ada/lib/storage/tests/__snapshots__/index.test.js.snap
@@ -718,8 +718,8 @@ Object {
     },
     Object {
       "Endpoints": Object {
-        "address": "https://cardanoexplorer.com/address/",
-        "transaction": "https://explorer.cardano.org/en/transaction/",
+        "address": "https://explorer.cardano.org/en/address?address=",
+        "transaction": "https://explorer.cardano.org/en/transaction?id=",
       },
       "ExplorerId": 104,
       "IsBackup": false,
@@ -769,8 +769,8 @@ Object {
     },
     Object {
       "Endpoints": Object {
-        "address": "https://explorer.cardano-testnet.iohkdev.io/address/",
-        "transaction": "https://explorer.cardano-testnet.iohkdev.io/en/transaction/",
+        "address": "https://explorer.cardano-testnet.iohkdev.io/en/address?address=",
+        "transaction": "https://explorer.cardano-testnet.iohkdev.io/en/transaction?id=",
       },
       "ExplorerId": 400,
       "IsBackup": true,


### PR DESCRIPTION
I noticed the links for cardano.org explorers are no longer working.