### PR TITLE
Enable mangle address support for Haskell Shelley

### DIFF
--- a/app/containers/wallet/WalletReceivePage.stories.js
+++ b/app/containers/wallet/WalletReceivePage.stories.js
@@ -51,6 +51,7 @@ import {
   BASE_INTERNAL,
   BASE_MANGLED,
   REWARD_ADDRESS,
+  mangledStores,
 } from '../../stores/stateless/addressStores';
 import type { IAddressTypeStore, IAddressTypeUiSubset } from '../../stores/stateless/addressStores';
 import {
@@ -116,7 +117,22 @@ const genBaseProps: {|
     sendErrorCases,
     sendErrorCases.None
   );
+
+  const canUnmangle = (() => {
+    for (const store of mangledStores) {
+      const subgroup = request.addressSubgroupMap.get(store.class);
+      if (subgroup == null) continue;
+      for (const address of subgroup.all) {
+        // for the purposes of testing, consider any > 0 as unmangle-able
+        if (address.value != null && address.value.gt(0)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  })();
   return {
+    canUnmangle,
     stores: {
       app: {
         currentRoute: request.location,

--- a/app/containers/wallet/staking/StakingDashboardPage.stories.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.stories.js
@@ -1041,7 +1041,9 @@ export const Errors = (): Node => {
 };
 
 // wallet we can reuse for multiple tests
-const genBaseJormungandrWallet = () => {
+const genBaseJormungandrWallet = (
+  canUnmangleAmount: BigNumber,
+) => {
   const wallet = genJormungandrSigningWalletWithCache();
   {
     const requests = wallet.getTimeCalcRequests(wallet.publicDeriver).requests;
@@ -1054,7 +1056,7 @@ const genBaseJormungandrWallet = () => {
   const computedDelegation = getStakingInfo(
     wallet.publicDeriver,
     stakingKeyCases.LongAgoDelegation,
-    new BigNumber(0),
+    canUnmangleAmount,
   );
   wallet.getDelegation = (_publicDeriver) => computedDelegation;
   const balance: CachedRequest<GetBalanceFunc> = new CachedRequest(_request => Promise.resolve(
@@ -1108,7 +1110,7 @@ const genBaseAdaWallet = () => {
 };
 
 export const LessThanExpected = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(0));
   const lookup = walletLookup([wallet]);
   return wrapWallet(
     mockWalletProps({
@@ -1128,7 +1130,7 @@ export const LessThanExpected = (): Node => {
 };
 
 export const UnknownPool = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(0));
 
   // setup a map that doesn't have the metadata for a pool (a private pool)
   const newMockPoolInfo = (network, poolId) => {
@@ -1157,7 +1159,7 @@ export const UnknownPool = (): Node => {
 };
 
 export const UndelegateExecuting = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(0));
   const lookup = walletLookup([wallet]);
   return wrapWallet(
     mockWalletProps({
@@ -1192,7 +1194,7 @@ export const UndelegateExecuting = (): Node => {
 };
 
 export const UndelegateError = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(0));
   const lookup = walletLookup([wallet]);
   return wrapWallet(
     mockWalletProps({
@@ -1227,7 +1229,7 @@ export const UndelegateError = (): Node => {
 };
 
 export const UndelegateDialogShown = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(0));
   const lookup = walletLookup([wallet]);
   const errorCases = {
     NoError: 0,
@@ -1273,7 +1275,7 @@ export const UndelegateDialogShown = (): Node => {
 };
 
 export const Reputation = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(0));
   const lookup = walletLookup([wallet]);
   const flagCases = {
     Forks: 1,
@@ -1342,35 +1344,43 @@ export const MangledDashboardWarning = (): Node => {
     mangledCases.CanUnmangleAll
   );
 
+  const mangleValues = {
+    canUnmangle: new BigNumber(1000000),
+    cannotUnmangle: new BigNumber(1),
+  };
   const addresses = (() => {
     if (mangledValue === mangledCases.CannotUnmangle) {
       return [{
         address: 'addr1sj045dheysyptfekdyqa508nuzdzmh82vkda9hcwqwysrja6d8d66f0cfsfk50hhuqjymr08drnm2kdf0r2337l6kl7mtm0z44vv4jexkqhz5w',
-        value: new BigNumber(1),
+        value: mangleValues.cannotUnmangle,
         type: CoreAddressTypes.JORMUNGANDR_GROUP,
       }];
     }
     if (mangledValue === mangledCases.CanUnmangleSome) {
       return [{
         address: 'addr1sj045dheysyptfekdyqa508nuzdzmh82vkda9hcwqwysrja6d8d66f0cfsfk50hhuqjymr08drnm2kdf0r2337l6kl7mtm0z44vv4jexkqhz5w',
-        value: new BigNumber(1),
+        value: mangleValues.cannotUnmangle,
         type: CoreAddressTypes.JORMUNGANDR_GROUP,
       }, {
         address: 'addr1sj045dheysyptfekdyqa508nuzdzmh82vkda9hcwqwysrja6d8d66f0cfsfk50hhuqjymr08drnm2kdf0r2337l6kl7mtm0z44vv4jexkqhz5w',
-        value: new BigNumber(1000000),
+        value: mangleValues.canUnmangle,
         type: CoreAddressTypes.JORMUNGANDR_GROUP,
       }];
     }
     if (mangledValue === mangledCases.CanUnmangleAll) {
       return [{
         address: 'addr1sj045dheysyptfekdyqa508nuzdzmh82vkda9hcwqwysrja6d8d66f0cfsfk50hhuqjymr08drnm2kdf0r2337l6kl7mtm0z44vv4jexkqhz5w',
-        value: new BigNumber(1000000),
+        value: mangleValues.canUnmangle,
         type: CoreAddressTypes.JORMUNGANDR_GROUP,
       }];
     }
     throw new Error(`Unhandled mangled case ${mangledValue}`);
   })();
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(
+    mangledValue === mangledCases.CanUnmangleSome || mangledValue === mangledCases.CanUnmangleAll
+      ? mangleValues.canUnmangle
+      : new BigNumber(0)
+  );
   const lookup = walletLookup([wallet]);
   return wrapWallet(
     mockWalletProps({
@@ -1392,7 +1402,7 @@ export const MangledDashboardWarning = (): Node => {
 };
 
 export const UnmangleDialogLoading = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(1000000));
   const lookup = walletLookup([wallet]);
   return wrapWallet(
     mockWalletProps({
@@ -1421,7 +1431,7 @@ export const UnmangleDialogLoading = (): Node => {
 };
 
 export const UnmangleDialogError = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(1000000));
   const lookup = walletLookup([wallet]);
   return wrapWallet(
     mockWalletProps({
@@ -1450,7 +1460,7 @@ export const UnmangleDialogError = (): Node => {
 };
 
 export const UnmangleDialogConfirm = (): Node => {
-  const wallet = genBaseJormungandrWallet();
+  const wallet = genBaseJormungandrWallet(new BigNumber(1000000));
   const lookup = walletLookup([wallet]);
   const { tentativeTx } = genTentativeJormungandrTx();
   return wrapWallet(

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -293,7 +293,7 @@
   "sidebar.settings": "Settings",
   "sidebar.transfer": "Claim / Transfer",
   "sidebar.wallets": "My wallets",
-  "testnet.shelley.label.message": "YOU ARE ON TESTNET NETWORK ({network}).",
+  "testnet.shelley.label.message": "YOU ARE ON TESTNET NETWORK.",
   "transfer.form.instructions.step1.text": "It will take about 1 minute to restore your balance. In the next step, you will be presented with a transaction that will move all of your funds. Please review the details of the transaction carefully. You will need to pay a standard transaction fee on the Cardano network to make the transaction.",
   "transfer.form.masterkey.input.label": "Master key",
   "transfer.instructions.attention.title.label": "Attention",

--- a/app/stores/ada/AdaAddressesStore.js
+++ b/app/stores/ada/AdaAddressesStore.js
@@ -7,7 +7,50 @@ import {
 
 import type { StandardAddress, AddressTypeName, } from '../../types/AddressFilterTypes';
 import { AddressGroupTypes, AddressSubgroup } from '../../types/AddressFilterTypes';
-import { filterMangledAddresses } from '../stateless/mangledAddresses';
+import {
+  asGetStakingKey,
+} from '../../api/ada/lib/storage/models/PublicDeriver/traits';
+import {
+  unwrapStakingKey,
+} from '../../api/ada/lib/storage/bridge/utils';
+import {
+  filterAddressesByStakingKey,
+} from '../../api/ada/lib/storage/bridge/delegationUtils';
+
+export async function filterMangledAddresses(request: {|
+  publicDeriver: PublicDeriver<>,
+  baseAddresses: $ReadOnlyArray<$ReadOnly<StandardAddress>>,
+  invertFilter: boolean,
+|}): Promise<$ReadOnlyArray<$ReadOnly<StandardAddress>>> {
+  const withStakingKey = asGetStakingKey(request.publicDeriver);
+  if (withStakingKey == null) {
+    if (request.invertFilter) return [];
+    return request.baseAddresses.map(info => ({
+      ...info,
+      address: info.address
+    }));
+  }
+
+  const stakingKeyResp = await withStakingKey.getStakingKey();
+
+  const stakingKey = unwrapStakingKey(stakingKeyResp.addr.Hash);
+
+  const filterResult = filterAddressesByStakingKey(
+    stakingKey,
+    request.baseAddresses,
+    false,
+  );
+
+  const nonMangledSet = new Set(filterResult);
+  const result = request.baseAddresses.filter(
+    info => (request.invertFilter ? !nonMangledSet.has(info) : nonMangledSet.has(info))
+  );
+
+  return result.map(info => ({
+    ...info,
+    address: info.address,
+  }));
+}
 
 export default class AdaAddressesStore extends Store {
 
@@ -19,7 +62,7 @@ export default class AdaAddressesStore extends Store {
     if (request.storeName.group === AddressGroupTypes.addressBook) {
       return request.addresses;
     }
-    if (request.storeName.subgroup === AddressSubgroup.all) {
+    if (request.storeName.subgroup === AddressGroupTypes.base) {
       return filterMangledAddresses({
         publicDeriver: request.publicDeriver,
         baseAddresses: request.addresses,
@@ -33,10 +76,6 @@ export default class AdaAddressesStore extends Store {
         invertFilter: true,
       });
     }
-    return filterMangledAddresses({
-      publicDeriver: request.publicDeriver,
-      baseAddresses: request.addresses,
-      invertFilter: false,
-    });
+    return request.addresses;
   }
 }

--- a/app/stores/stateless/addressStores.js
+++ b/app/stores/stateless/addressStores.js
@@ -512,3 +512,5 @@ export function genAddressLookup(
     };
   };
 }
+
+export const mangledStores = [GROUP_MANGLED, BASE_MANGLED];

--- a/app/stores/stateless/mangledAddresses.js
+++ b/app/stores/stateless/mangledAddresses.js
@@ -1,100 +1,174 @@
 // @flow
 
 import BigNumber from 'bignumber.js';
+import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
 import {
-  asGetStakingKey
+  isCardanoHaskell,
+  getCardanoHaskellBaseConfig,
+  isJormungandr,
+  getJormungandrBaseConfig,
+} from '../../api/ada/lib/storage/database/prepackaged/networks';
+import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
+import { genFilterSmallUtxo } from '../../api/ada/transactions/shelley/transactions';
+import type { IGetAllUtxosResponse } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
+import {
+  asGetAllUtxos,
 } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
-import {
-  filterAddressesByStakingKey,
-  unwrapStakingKey,
-} from '../../api/jormungandr/lib/storage/bridge/utils';
 import {
   PublicDeriver,
 } from '../../api/ada/lib/storage/models/PublicDeriver/index';
-import type { StandardAddress, } from '../../types/AddressFilterTypes';
+import { BASE_MANGLED, GROUP_MANGLED } from './addressStores';
 
-export async function filterMangledAddresses(request: {|
+export type MangledAmountsRequest = {|
   publicDeriver: PublicDeriver<>,
-  baseAddresses: $ReadOnlyArray<$ReadOnly<StandardAddress>>,
-  invertFilter: boolean,
-|}): Promise<$ReadOnlyArray<$ReadOnly<StandardAddress>>> {
-  const withStakingKey = asGetStakingKey(request.publicDeriver);
-  if (withStakingKey == null) {
-    if (request.invertFilter) return [];
-    return request.baseAddresses.map(info => ({
-      ...info,
-      address: info.address
-    }));
+|};
+export type MangledAmountsResponse = {|
+  canUnmangle: BigNumber,
+  cannotUnmangle: BigNumber,
+|};
+export type MangledAmountFunc = MangledAmountsRequest => Promise<MangledAmountsResponse>;
+
+export async function getUnmangleAmounts(
+  request: MangledAmountsRequest
+): Promise<MangledAmountsResponse> {
+  const canUnmangle: Array<BigNumber> = [];
+  const cannotUnmangle: Array<BigNumber> = [];
+
+  const withUtxos = asGetAllUtxos(request.publicDeriver);
+  if (withUtxos == null) {
+    return {
+      canUnmangle: new BigNumber(0),
+      cannotUnmangle: new BigNumber(0),
+    };
   }
+  const utxos = await withUtxos.getAllUtxos();
 
-  const stakingKeyResp = await withStakingKey.getStakingKey();
+  const network = request.publicDeriver.getParent().getNetworkInfo();
+  if (isJormungandr(network)) {
+    const config = getJormungandrBaseConfig(
+      network
+    ).reduce((acc, next) => Object.assign(acc, next), {});
+    for (const utxo of utxos) {
+      const value = new BigNumber(utxo.output.UtxoTransactionOutput.Amount);
+      if (value.gt(config.LinearFee.coefficient)) {
+        canUnmangle.push(value);
+      } else {
+        cannotUnmangle.push(value);
+      }
+    }
+    const canUnmangleSum = canUnmangle.reduce(
+      (sum, val) => sum.plus(val),
+      new BigNumber(0)
+    );
+    const expectedFee = new BigNumber(canUnmangle.length + 1)
+      .times(config.LinearFee.coefficient)
+      .plus(config.LinearFee.constant);
 
-  // // TODO: this is Jormungandr-specific logic
-  // const stakingKey = unwrapStakingKey(stakingKeyResp.addr.Hash);
-
-  // const filterResult = filterAddressesByStakingKey(
-  //   stakingKey,
-  //   request.baseAddresses,
-  //   !request.invertFilter,
-  // );
-  const filterResult = request.baseAddresses;
-
-  let result = filterResult;
-  if (request.invertFilter) {
-    const nonMangledSet = new Set(filterResult);
-    result = request.baseAddresses.filter(info => !nonMangledSet.has(info));
-  }
-
-  return result.map(info => ({
-    ...info,
-    address: info.address,
-  }));
-}
-
-export function getUnmangleAmounts(
-  // TODO: this is the wrong input. It should pass in UTXOs instead
-  addresses: $ReadOnlyArray<$ReadOnly<StandardAddress>>,
-): {|
-  canUnmangle: Array<BigNumber>,
-  cannotUnmangle: Array<BigNumber>,
-|} {
-  // since this function is wrong for now, just return everything as can be unmangled
-  const canUnmangle = [];
-  const cannotUnmangle = [];
-  for (const addrInfo of addresses) {
-    if (addrInfo.value != null) {
-      canUnmangle.push(addrInfo.value);
+    // if user would strictly lose ADA by making the transaction, don't prompt them to make it
+    if (canUnmangleSum.lt(expectedFee)) {
+      while (canUnmangle.length > 0) {
+        cannotUnmangle.push(canUnmangle.pop());
+      }
     }
   }
-  // const canUnmangle = [];
-  // const cannotUnmangle = [];
-  // for (const addrInfo of addresses) {
-  //   if (addrInfo.value != null) {
-  //     const value = addrInfo.value;
-  //     if (addrInfo.value.gt(CONFIG.genesis.linearFee.coefficient)) {
-  //       canUnmangle.push(value);
-  //     } else {
-  //       cannotUnmangle.push(value);
-  //     }
-  //   }
-  // }
-  // const canUnmangleSum = canUnmangle.reduce(
-  //   (sum, val) => sum.plus(val),
-  //   new BigNumber(0)
-  // );
-  // const expectedFee = new BigNumber(canUnmangle.length + 1)
-  //   .times(CONFIG.genesis.linearFee.coefficient)
-  //   .plus(CONFIG.genesis.linearFee.constant);
+  if (isCardanoHaskell(network)) {
+    const config = getCardanoHaskellBaseConfig(
+      network
+    ).reduce((acc, next) => Object.assign(acc, next), {});
 
-  // // if user would strictly lose ADA by making the transaction, don't prompt them to make it
-  // if (canUnmangleSum.lt(expectedFee)) {
-  //   while (canUnmangle.length > 0) {
-  //     cannotUnmangle.push(canUnmangle.pop());
-  //   }
-  // }
+    const filter = genFilterSmallUtxo({
+      protocolParams: {
+        linearFee: RustModule.WalletV4.LinearFee.new(
+          RustModule.WalletV4.BigNum.from_str(config.LinearFee.coefficient),
+          RustModule.WalletV4.BigNum.from_str(config.LinearFee.constant),
+        ),
+      },
+    });
+
+    for (const utxo of utxos) {
+      const txIndex = utxo.output.Transaction.Ordinal;
+      // only null for pending transactions, which shouldn't happen
+      if (txIndex == null) throw new Error(`${nameof(getUnmangleAmounts)} unexpected pending tx`);
+
+      const value = new BigNumber(utxo.output.UtxoTransactionOutput.Amount);
+      if (filter({
+        utxo_id: utxo.output.Transaction.Hash + txIndex,
+        tx_hash: utxo.output.Transaction.Hash,
+        tx_index: txIndex,
+        receiver: utxo.address,
+        amount: utxo.output.UtxoTransactionOutput.Amount,
+      })) {
+        canUnmangle.push(value);
+      } else {
+        cannotUnmangle.push(value);
+      }
+    }
+  }
+
+  const flattenAmount = (list: Array<BigNumber>): BigNumber => list.reduce(
+    (total, next) => total.plus(next),
+    new BigNumber(0)
+  );
 
   return {
-    canUnmangle,
-    cannotUnmangle
+    canUnmangle: flattenAmount(canUnmangle),
+    cannotUnmangle: flattenAmount(cannotUnmangle),
   };
+}
+
+export function getMangledFilter(
+  getAddresses: Class<any> => Set<string>,
+  publicDeriver: PublicDeriver<>,
+): (ElementOf<IGetAllUtxosResponse> => boolean) {
+  if (isCardanoHaskell(publicDeriver.getParent().getNetworkInfo())) {
+    const relevantAddresses = getAddresses(BASE_MANGLED.class);
+
+    const config = getCardanoHaskellBaseConfig(
+      publicDeriver.getParent().getNetworkInfo()
+    ).reduce((acc, next) => Object.assign(acc, next), {});
+
+    const filter = genFilterSmallUtxo({
+      protocolParams: {
+        linearFee: RustModule.WalletV4.LinearFee.new(
+          RustModule.WalletV4.BigNum.from_str(config.LinearFee.coefficient),
+          RustModule.WalletV4.BigNum.from_str(config.LinearFee.constant),
+        ),
+      },
+    });
+
+    return (utxo) => {
+      if (!relevantAddresses.has(utxo.address)) {
+        return false;
+      }
+
+      const txIndex = utxo.output.Transaction.Ordinal;
+      // only null for pending transactions, which shouldn't happen
+      if (txIndex == null) throw new Error(`${nameof(getMangledFilter)} unexpected pending tx`);
+
+      return filter({
+        utxo_id: utxo.output.Transaction.Hash + txIndex,
+        tx_hash: utxo.output.Transaction.Hash,
+        tx_index: txIndex,
+        receiver: utxo.address,
+        amount: utxo.output.UtxoTransactionOutput.Amount,
+      });
+    };
+  }
+
+  if (isJormungandr(publicDeriver.getParent().getNetworkInfo())) {
+    const relevantAddresses = getAddresses(GROUP_MANGLED.class);
+
+    const config = getJormungandrBaseConfig(
+      publicDeriver.getParent().getNetworkInfo()
+    ).reduce((acc, next) => Object.assign(acc, next), {});
+
+    return (utxo) => {
+      if (!relevantAddresses.has(utxo.address)) {
+        return false;
+      }
+      const amount = new BigNumber(utxo.output.UtxoTransactionOutput.Amount);
+      return amount.gt(config.LinearFee.coefficient);
+    };
+  }
+  throw new Error(`${nameof(getMangledFilter)} no unmangle support for network ${publicDeriver.getParent().getNetworkInfo().NetworkId}`);
 }

--- a/app/stores/stateless/mangledAddresses.js
+++ b/app/stores/stateless/mangledAddresses.js
@@ -1,7 +1,6 @@
 // @flow
 
 import BigNumber from 'bignumber.js';
-import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
 import {
   isCardanoHaskell,
   getCardanoHaskellBaseConfig,

--- a/app/stores/toplevel/DelegationStore.js
+++ b/app/stores/toplevel/DelegationStore.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { observable, action, } from 'mobx';
-import BigNumber from 'bignumber.js';
 import { find } from 'lodash';
 import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
 import {

--- a/app/stores/toplevel/DelegationStore.js
+++ b/app/stores/toplevel/DelegationStore.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { observable, action, } from 'mobx';
+import BigNumber from 'bignumber.js';
 import { find } from 'lodash';
 import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
 import {
@@ -22,6 +23,7 @@ import { getApiForNetwork } from '../../api/common/utils';
 import {
   PoolMissingApiError,
 } from '../../api/common/errors';
+import type { MangledAmountFunc } from '../stateless/mangledAddresses';
 
 export type DelegationRequests = {|
   publicDeriver: PublicDeriver<>,
@@ -32,6 +34,7 @@ export type DelegationRequests = {|
   getDelegatedBalance: CachedRequest<GetDelegatedBalanceFunc>,
   getCurrentDelegation: CachedRequest<GetCurrentDelegationFunc>,
   rewardHistory: CachedRequest<RewardHistoryFunc>,
+  mangledAmounts: CachedRequest<MangledAmountFunc>,
   error: LocalizableError | any;
 |};
 

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -65,3 +65,20 @@ Feature: Yoroi delegation dashboard
     Given The expected transaction is "g6YAgYJYIDZ36Gx7ppmv3BzVfULyRvhvaa79dgJQBqx4MT+tK7ohAAGBglg5AfiMMmOcqBWRIjRN6CEig4T8YKJcOWtIDaUVnSFW21zUiJyEEQ1N6QwNUDtRuETbPm/YeZEjiZW7GgCV8ZcCGgACpOkDGhH+lM0EgYIBggBYHFbbXNSInIQRDU3pDA1QO1G4RNs+b9h5kSOJlbsFoVgd4VbbXNSInIQRDU3pDA1QO1G4RNs+b9h5kSOJlbsaAExLQKEAgoJYIDHFsozgC4AMMNymh4uSd8Xls6VSRnf9Dxv6kiJPzsubWEDeymxh6IEQKI51A9krNH9zkI8E6r+yQhyKpgVMn318UvFlJ7PWkEA/UN5ttCRe+/8lHy6Vl9Dhu4RBHZ47Mu0Hglgg6cWNnhkPKitPspqy3T6+Lqi2VU1F/s8JE36FUprlBHBYQCyphTpHmP5U443IIuVOntgb8KaXTjazElk9hm6GFMebbuNWYuv907Ci+JvN7kk9wbO0R6ZKcA9pEgbbmlBYrA32"
     When I confirm Yoroi transfer funds
     Then I should see the dashboard screen
+
+  @it-166
+  Scenario: Can unmangled from the dashboard (IT-166)
+    Given There is a Shelley wallet stored named shelley-mangled
+    And I have a wallet with funds
+    And I go to the dashboard screen
+    When I click on the unmangle warning
+    Then I should see on the Yoroi transfer summary screen:
+    | fromAddress                                                 | amount           |   
+    | addr1q8sm64ehfue7m7xrlh2zfu4uj9tn3z3yrzfdaly52gs667qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhzdk70 | 10000000    |
+    And I enter the wallet password:
+      | password   |
+      | asdfasdfasdf |
+    Given The expected transaction is "g6QAgYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgSugI11FwGBglg5ATFf/lO+USTb83qMl8g53oV7XmMSuklF3gfHb8kex9YZS/n0WTCduT05oFTkplWcw+TU0UvasV/VGgCWD6sCGgAChtUDGhH+lM2hAIGCWCCxG2517QHEmTBkk1BC3zBriToLyq4PxNikr8LCc0V+jFhAUiMjVxyfTJcGdgg9q914adTdNaD7+DW+eMviv5if69KbiPhAxWcIGldT8kDaG2uiyjtePEnGLd9fXRa3unVuBPY="
+    When I confirm Yoroi transfer funds
+    Then I should see the summary screen
+    And I should see 1 pending transactions

--- a/features/mock-chain/TestWallets.js
+++ b/features/mock-chain/TestWallets.js
@@ -44,7 +44,8 @@ type WalletNames =
   'ledger-wallet' |
   'trezor-wallet' |
   'ergo-simple-wallet' |
-  'shelley-enterprise';
+  'shelley-enterprise' |
+  'shelley-mangled';
 
 // eslint-disable-next-line prefer-object-spread
 export const testWallets: { [key: WalletNames]: RestorationInput, ... } = Object.assign(
@@ -134,6 +135,11 @@ export const testWallets: { [key: WalletNames]: RestorationInput, ... } = Object
     name: ('shelley-enterprise': WalletNames),
     mnemonic: 'much million increase spot visa domain grow brother chief mechanic innocent envelope vacant bundle coyote',
     plate: 'HBDZ-9545',
+  }),
+  createWallet({
+    name: ('shelley-mangled': WalletNames),
+    mnemonic: 'weekend december choose maid rack helmet canoe bridge strike section lift autumn route practice seat',
+    plate: 'JCEH-5025',
   }),
   createWallet({
     name: ('ergo-simple-wallet': WalletNames),

--- a/features/mock-chain/mockCardanoImporter.js
+++ b/features/mock-chain/mockCardanoImporter.js
@@ -30,6 +30,8 @@ import {
   genUtxoForAddresses,
   genUtxoSumForAddresses,
   getSingleAddressString,
+  getAddressForType,
+  getMangledAddressString,
   toRemoteByronTx,
 } from '../../app/api/ada/lib/state-fetch/mockNetwork';
 import {
@@ -42,6 +44,7 @@ import {
   ChainDerivations,
 } from '../../app/config/numbersConfig';
 import { testWallets } from './TestWallets';
+import { CoreAddressTypes } from '../../app/api/ada/lib/storage/database/primitives/enums';
 
 // based on abandon x 14 + share
 const genesisTransaction = '52929ce6f1ab83b439e65f6613bad9590bd264c0d6c4f910e36e2369bb987b35';
@@ -79,6 +82,7 @@ export const generateTransaction = (): {|
   shelleyLedgerDelegatedTx2: RemoteTransaction,
   shelleyOnlyRegisteredTx1: RemoteTransaction,
   shelleyOnlyRegisteredTx2: RemoteTransaction,
+  delegateMangledWallet: RemoteTransaction,
 |} => {
   /**
   * To simplify, our genesis is a single address which gives all its ada to a "distributor"
@@ -430,9 +434,66 @@ export const generateTransaction = (): {|
             0 + HARD_DERIVATION_START,
             ChainDerivations.EXTERNAL,
             0
-          ],
+          ]
         ),
         amount: '10000000'
+      },
+      {
+        // index: 23
+        // eslint-disable-next-line max-len
+        // addr1q8sm64ehfue7m7xrlh2zfu4uj9tn3z3yrzfdaly52gs667qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhzdk70
+        address: getMangledAddressString(
+          testWallets['shelley-mangled'].mnemonic,
+          [
+            WalletTypePurpose.CIP1852,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ],
+          Buffer.from(
+            '00000000000000000000000000000000000000000000000000000000',
+            'hex'
+          )
+        ),
+        amount: '10000000' // enough that it can be unmangled
+      },
+      {
+        // index: 24
+        // eslint-disable-next-line max-len
+        // addr1q8sm64ehfue7m7xrlh2zfu4uj9tn3z3yrzfdaly52gs667qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhzdk70
+        address: getMangledAddressString(
+          testWallets['shelley-mangled'].mnemonic,
+          [
+            WalletTypePurpose.CIP1852,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ],
+          Buffer.from(
+            '00000000000000000000000000000000000000000000000000000000',
+            'hex'
+          )
+        ),
+        amount: '1' // too little to unmangle
+      },
+      {
+        // index: 25
+        // eslint-disable-next-line max-len
+        // TODO
+        address: getAddressForType(
+          testWallets['shelley-mangled'].mnemonic,
+          [
+            WalletTypePurpose.CIP1852,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ],
+          CoreAddressTypes.CARDANO_BASE
+        ),
+        amount: '3500000'
       },
     ],
     height: 1,
@@ -1711,6 +1772,102 @@ export const generateTransaction = (): {|
     tx_state: 'Successful'
   };
 
+  // ===================
+  //   shelley-mangled
+  // ===================
+
+  const delegateMangledWallet = {
+    hash: '3456e86c7ba799afda1cd57d425946f86f69aefd76025006ac78313fad2bba21',
+    type: 'shelley',
+    inputs: [
+      {
+        // eslint-disable-next-line max-len
+        // TODO
+        address: getAddressForType(
+          testWallets['shelley-mangled'].mnemonic,
+          [
+            WalletTypePurpose.CIP1852,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.EXTERNAL,
+            0
+          ],
+          CoreAddressTypes.CARDANO_BASE
+        ),
+        txHash: distributorTx.hash,
+        id: distributorTx.hash + '25',
+        index: 25,
+        amount: '3500000'
+      }
+    ],
+    outputs: [
+      {
+        // eslint-disable-next-line max-len
+        // TODO
+        address: getAddressForType(
+          testWallets['shelley-mangled'].mnemonic,
+          [
+            WalletTypePurpose.CIP1852,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.INTERNAL,
+            1
+          ],
+          CoreAddressTypes.CARDANO_BASE
+        ),
+        amount: '1000000'
+      },
+    ],
+    ttl: '500',
+    fee: '500000',
+    certificates: [
+      {
+        certIndex: 0,
+        kind: (ShelleyCertificateTypes.StakeRegistration: 'StakeRegistration'),
+        // TODO: bech32 address
+        rewardAddress: getAddressForType(
+          testWallets['shelley-mangled'].mnemonic,
+          [
+            WalletTypePurpose.CIP1852,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.CHIMERIC_ACCOUNT,
+            0
+          ],
+          CoreAddressTypes.CARDANO_REWARD
+        ),
+      },
+      {
+        certIndex: 1,
+        kind: ShelleyCertificateTypes.StakeDelegation,
+        // TODO: bech32 address
+        rewardAddress: getAddressForType(
+          testWallets['shelley-mangled'].mnemonic,
+          [
+            WalletTypePurpose.CIP1852,
+            CoinTypes.CARDANO,
+            0 + HARD_DERIVATION_START,
+            ChainDerivations.CHIMERIC_ACCOUNT,
+            0
+          ],
+          CoreAddressTypes.CARDANO_REWARD
+        ),
+        poolKeyHash: 'df1750df9b2df285fcfb50f4740657a18ee3af42727d410c37b86207', // YOROI
+      },
+    ],
+    withdrawals: [],
+    metadata: null,
+    height: 200,
+    block_hash: '200',
+    tx_ordinal: 4,
+    time: '2019-04-21T15:13:33.000Z',
+    epoch: 0,
+    slot: 200,
+    last_update: '2019-05-21T23:14:51.899Z',
+    tx_state: 'Successful'
+  };
+
+
   return {
     genesisTx,
     distributorTx,
@@ -1737,6 +1894,7 @@ export const generateTransaction = (): {|
     shelleyLedgerDelegatedTx2,
     shelleyOnlyRegisteredTx1,
     shelleyOnlyRegisteredTx2,
+    delegateMangledWallet,
   };
 };
 
@@ -1828,6 +1986,8 @@ export function resetChain(
     // shelley-only-registered
     addTransaction(txs.shelleyOnlyRegisteredTx1);
     addTransaction(txs.shelleyOnlyRegisteredTx2);
+    // shelley-mangled
+    addTransaction(txs.delegateMangledWallet);
   } else if (chainToUse === MockChain.TestAssurance) {
     // test setup
     addTransaction(txs.genesisTx);

--- a/features/step_definitions/dashboard-steps.js
+++ b/features/step_definitions/dashboard-steps.js
@@ -13,3 +13,8 @@ When(/^I click on the withdraw button$/, async function () {
 Then(/^I should rewards in the history$/, async function () {
   await this.waitForElement('.recharts-bar');
 });
+
+When(/^I click on the unmangle warning$/, async function () {
+  await this.click('.UserSummary_mangledWarningIcon');
+  await this.click('.UserSummary_link');
+});

--- a/features/step_definitions/transactions-steps.js
+++ b/features/step_definitions/transactions-steps.js
@@ -7,6 +7,7 @@ import i18n from '../support/helpers/i18n-helpers';
 import { addTransaction, generateTransaction, } from '../mock-chain/mockCardanoImporter';
 import { setExpectedTx, } from '../mock-chain/mockCardanoServer';
 import { truncateAddress, } from '../../app/utils/formatters';
+import { getAdaCurrencyMeta } from '../../app/api/ada/currencyInfo';
 
 Given(/^I have a wallet with funds$/, async function () {
   const amountWithCurrency = await this.driver.findElements(By.xpath("//div[@class='WalletTopbarTitle_walletAmount']"));
@@ -38,10 +39,11 @@ Given(/^The expected transaction is "([^"]*)"$/, (base64Tx) => {
 When(/^I see CONFIRM TRANSACTION Pop up:$/, async function (table) {
   const fields = table.hashes()[0];
   const total = parseFloat(fields.amount) + parseFloat(fields.fee);
+  const { decimalPlaces } = getAdaCurrencyMeta();
   await this.waitUntilText('.WalletSendConfirmationDialog_addressTo', truncateAddress(fields.address));
   await this.waitUntilContainsText('.WalletSendConfirmationDialog_fees', fields.fee);
   await this.waitUntilContainsText('.WalletSendConfirmationDialog_amount', fields.amount);
-  await this.waitUntilContainsText('.WalletSendConfirmationDialog_totalAmount', total);
+  await this.waitUntilContainsText('.WalletSendConfirmationDialog_totalAmount', total.toFixed(decimalPlaces.toNumber()));
 });
 
 When(/^I clear the receiver$/, async function () {
@@ -146,4 +148,8 @@ Then(/^I should see a warning block$/, async function () {
 
 Then(/^I should see no warning block$/, async function () {
   await this.waitForElementNotPresent('.WarningBox_warning');
+});
+
+When(/^I click on the unmangle button$/, async function () {
+  await this.click('.MangledHeader_submitButton ');
 });

--- a/features/transactions.feature
+++ b/features/transactions.feature
@@ -25,8 +25,8 @@ Feature: Send transaction
 
     Examples:
       | amount              | fee       | expectedTx |
-      | 1.000000            | 0.640003  | "g6QAhYJYILcTzA1jEGw4BrGnB3zDeilPzKDkefJqrGTlHgmugI11AIJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAIJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAIJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAQGBglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAD0JAAhoACcQDAxoR/pTNoQKDhFggXnGsSYUyhwTHwB1G9f7mkd9iHoKwNvA477DkhDTXmX5YQGysuAsWMrUoYD6f5n5k2vmnVr2jWdoeFuanaxW8pk/F2kBfv7IPOpOwIvTVWuUknxJtJ11amUkNnHpX5GSRMQRYIO23hdKX7dxt3V0Cchr8MLvy1UwjID2hIegQ0F2VF6vHQaCEWCCPBkfbIHjkWa3BQgOfZnSx2uNRXSeHf/3Dr6sioCh8qlhANGxtDeRnQfiiCPFaWuvN/hiItSZxBk0NSGaQ5k4GPG3nFQdYatQrUqBCgqTcLz+3OG935IbMoHAIAnNlbcNeBlggRYcsb5A2HZ+Idr1h/VYzDe7f0Gt4E0SVRIi2VqWKcA5BoIRYIOx7+AYOSniTUHVqDkzhtFF7b1HM/9BBkw6++m8Q+/SzWEDqP1LXZUyJhvy/JouWNtcm8m9Ot0yejTfqvC7Wcjl4LXB7j+KJEl5DrLIXHij4ZBPHxOJc1n/bC7PJb7nRJ4APWCBWM2zqwExuk/gcTouvBpcmhtN2NEKb5aluF5K/hwZh2EGg9g==" |
-      | 2.000000            | 0.460004  | "g6QAh4JYILcTzA1jEGw4BrGnB3zDeilPzKDkefJqrGTlHgmugI11AIJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAIJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAIJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI11AIJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI11AQGBglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAHoSAAhoABwTkAxoR/pTNoQKEhFggXnGsSYUyhwTHwB1G9f7mkd9iHoKwNvA477DkhDTXmX5YQPWw5EUQVR9Y0dpzBWAYt0qh24YUZDGLVyjx7xro2LUHyrY0OY6cIxzaxMfYKa0mtABRJnaMvfxZWoP8NBVKxghYIO23hdKX7dxt3V0Cchr8MLvy1UwjID2hIegQ0F2VF6vHQaCEWCCPBkfbIHjkWa3BQgOfZnSx2uNRXSeHf/3Dr6sioCh8qlhAE6jTe/dfPba0aRJ8UdimHG6quEaw3FfCSInH8RAz1SZqRN16ZbbHHKXmxwKxDxEqc4zUZGEnOjXFjnmFt9ynA1ggRYcsb5A2HZ+Idr1h/VYzDe7f0Gt4E0SVRIi2VqWKcA5BoIRYIOx7+AYOSniTUHVqDkzhtFF7b1HM/9BBkw6++m8Q+/SzWEDepjjJbs6tU03PMrQMi+pFuq/trlwj0XK5m/pAncaCWEe7zRl0fEz1y4I/PgUzVZD0IuasCqKtcO/wEWZh0MwLWCBWM2zqwExuk/gcTouvBpcmhtN2NEKb5aluF5K/hwZh2EGghFggzHvtZR+ntErMZIIgbq2uQ2B/jHt0TTIZ2j1JzMH2HTtYQOzHvkEeFMuENCAvK2BcEeduNcIteaV+ptOBphyadkg2102rQPi1VZF2wzyTWjWk6hC4FDb7wbk5J2jsi43xOA1YIFiANkZLmGZ3Oe+LI3Q8iACb9dHcrlZN4L/sajTg+7+/QaD2" |
+      | 1.000000            | 0.640000  | "g6QAgoJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAQGBglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAD0JAAhoACcQAAxoR/pTNoQKChFggjwZH2yB45FmtwUIDn2Z0sdrjUV0nh3/9w6+rIqAofKpYQJnz4URZfjl5AOpaEjMTWdF1lsFXPE+IKC0puBMdBjkWaqk6BIzW8VZ7pu7f8J/Mv8E3lRFiBVX7BnDQNYlT7g1YIEWHLG+QNh2fiHa9Yf1WMw3u39BreBNElUSItlalinAOQaCEWCDse/gGDkp4k1B1ag5M4bRRe29RzP/QQZMOvvpvEPv0s1hASaHptgaRcfgiyLBN80gqUIAueQBKkwSLu9iAd+UIN7PELThmN5ItmVzMeZIevE/7eS7wFX15sax9ap5ihK/1ClggVjNs6sBMbpP4HE6LrwaXJobTdjRCm+WpbheSv4cGYdhBoPY=" |
+      | 2.000000            | 0.460000  | "g6QAg4JYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI11AQGBglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAHoSAAhoABwTgAxoR/pTNoQKDhFggjwZH2yB45FmtwUIDn2Z0sdrjUV0nh3/9w6+rIqAofKpYQLM12LTh1NoxSUm0bbVTQfygHhTVh6bLYXlVC4cnlUPGu45AojcnGEqZTE/+vItV7EvsBBlKTapopZofryrXrA5YIEWHLG+QNh2fiHa9Yf1WMw3u39BreBNElUSItlalinAOQaCEWCDse/gGDkp4k1B1ag5M4bRRe29RzP/QQZMOvvpvEPv0s1hAwPcLKhKTeclUAgVMRh7EHv2F+jv6zQ7fpsQwbSucHpESYz+8QamNsB45zU8ocp5K4WDesTR7nxE7I9lvBc0jAlggVjNs6sBMbpP4HE6LrwaXJobTdjRCm+WpbheSv4cGYdhBoIRYIMx77WUfp7RKzGSCIG6trkNgf4x7dE0yGdo9SczB9h07WEBwOJ1TbOoaNh9Uf+erO5luL5/5sIvddiala/3VB2vFJXbohZnvvrJvQoi5Cc0AthRftjupDgna8dmSt25s7WYFWCBYgDZGS5hmdznviyN0PIgAm/XR3K5WTeC/7Go04Pu/v0Gg9g==" |
 
   @it-90
   Scenario Outline: Spending Password should be case-sensitive [Transaction confirmation] (IT-90)
@@ -58,7 +58,7 @@ Feature: Send transaction
     And I fill the form:
       | address                        | amount   |
       | <address>                      | <amount> |
-    And The transaction fees are "<fee>"
+    And The transaction fees are "0.640000"
     And I click on the next button in the wallet send form
     And I see CONFIRM TRANSACTION Pop up:
       | address   | amount    |fee      |
@@ -66,7 +66,7 @@ Feature: Send transaction
 
   Examples:
       | address                                                     | amount    |fee      |
-      | Ae2tdPwUPEZ3HUU7bmfexrUzoZpAZxuyt4b4bn7fus7RHfXoXRightdgMCv | 1.000000  |0.640003 | 
+      | Ae2tdPwUPEZ3HUU7bmfexrUzoZpAZxuyt4b4bn7fus7RHfXoXRightdgMCv | 1.000000  |0.640000 | 
 
   @it-46
   Scenario: User can't send funds to the invalid address (IT-46)
@@ -138,7 +138,7 @@ Feature: Send transaction
     And I fill the form:
       | address                                                     | amount   |
       | Ae2tdPwUPEZ3HUU7bmfexrUzoZpAZxuyt4b4bn7fus7RHfXoXRightdgMCv | 1.000000 |
-    And The transaction fees are "0.640003"
+    And The transaction fees are "0.640000"
     And I click on the next button in the wallet send form
     And I see send money confirmation dialog
     And I enter the wallet password:
@@ -181,7 +181,7 @@ Feature: Send transaction
     And I fill the form:
       | address                                                     | amount   |
       | Ae2tdPwUPEZ3HUU7bmfexrUzoZpAZxuyt4b4bn7fus7RHfXoXRightdgMCv | 2.000000 |
-    And The transaction fees are "0.460004"
+    And The transaction fees are "0.460000"
     And I click on the next button in the wallet send form
     And I see send money confirmation dialog
     Then A successful tx gets sent from my wallet from another client
@@ -194,7 +194,7 @@ Feature: Send transaction
     And I enter the wallet password:
       | password   |
       | asdfasdfasdf |
-    Given The expected transaction is "g6QAiIJYILcTzA1jEGw4BrGnB3zDeilPzKDkefJqrGTlHgmugI11AIJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAIJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAIJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI11AIJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI11AYJYIAoHNmmEX+pK6DzUQYoLT9VmEAl6iWAagWtYkfZn40lsAIJYIAoHNmmEX+pK6DzUQYoLT9VmEAl6iWAagWtYkfZn40lsAQGBglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAHoSAAhoABGzVAxoR/pTNoQKFhFggXnGsSYUyhwTHwB1G9f7mkd9iHoKwNvA477DkhDTXmX5YQEeb8ZgfkuchaWdmsZDIgu9Ne7EJVqJXuuI42ZKVxMRj91gmestk6pmBB32kKNj0GcLrynJ/McozqJJ4Vqp10AtYIO23hdKX7dxt3V0Cchr8MLvy1UwjID2hIegQ0F2VF6vHQaCEWCDse/gGDkp4k1B1ag5M4bRRe29RzP/QQZMOvvpvEPv0s1hAuN3MeNWhhiHRPMfQtVjdDUjLodew3LHPulO8TSjqxlfjLGl39sfmQ55tRDjZg79jDfLaAkxzWbXJ6WMaPmrWDVggVjNs6sBMbpP4HE6LrwaXJobTdjRCm+WpbheSv4cGYdhBoIRYIMx77WUfp7RKzGSCIG6trkNgf4x7dE0yGdo9SczB9h07WEAJTFdcHXI7gUmQmE1L/iO5MUNHHGjX3IqWk90nIKtuEzZWzcnsZC4/c8XLFclp++Zt++VffPyDWUkibAstP34EWCBYgDZGS5hmdznviyN0PIgAm/XR3K5WTeC/7Go04Pu/v0GghFggq89sIniqpRC9CbEInMd52i6wG9KoB+AjifwBNwGbwndYQBfx8lWIAaMnuv8fYEnZ7V5knrDaCPLfMzxkqhIPbQNRAfK5SIrlCh4PYdsFTpZOTrjKvoAz+ZDYESdn5I4cvgVYIF7CeZr1rkg9Mv//7NfE+OX8w46WodL6lwd3q57SNCDRQaCEWCC5TTZuZiJW+mD46uJ/IIwwoYvtsvdGnWfNR4HzHKY/BlhAo8VaQ1EYi/XnNGyr7sHCYADHCLv8sl7Vqge3qoS2bZ3oLMfDVXt1zVyOwvywfVVRTNYRosp35AhV/YClViAdCFggrsddVEovzNzpsw4Y3PHrjzmP9bkBd+LCRWEJPOQv66VBoPY="
+    Given The expected transaction is "g6QAg4JYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI11AYJYIAoHNmmEX+pK6DzUQYoLT9VmEAl6iWAagWtYkfZn40lsAQGBglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAHoSAAhoABGzQAxoR/pTNoQKDhFgg7Hv4Bg5KeJNQdWoOTOG0UXtvUcz/0EGTDr76bxD79LNYQJgmViCF11mg1pQBlxk5WmjKSs335DeKn3nsuX34oYLm25fA7GEios1jIGV+DVc5TCvhR9taKi5BImTCR56izgNYIFYzbOrATG6T+BxOi68GlyaG03Y0QpvlqW4Xkr+HBmHYQaCEWCDMe+1lH6e0SsxkgiBura5DYH+Me3RNMhnaPUnMwfYdO1hA2eLKUK3aour0AVVuH9n8iplfXanW6IR4KpRrPT03y0a5wCR9LBoyZKIvAI0VhZChXHZUqm7wxy6O5eD6mLpICFggWIA2RkuYZnc574sjdDyIAJv10dyuVk3gv+xqNOD7v79BoIRYILlNNm5mIlb6YPjq4n8gjDChi+2y90adZ81HgfMcpj8GWEAdrzsYU4XXFWKVSukTrZoSKmwL9O5BFooOSPuLB3XUpVQz9jW4TIa1jRIPBnfiVzvASIzc+7YdJ4EPfEhkjPgKWCCux11USi/M3OmzDhjc8euPOY/1uQF34sJFYQk85C/rpUGg9g=="
     And I submit the wallet send form
     Then I should see the summary screen
 
@@ -206,7 +206,7 @@ Feature: Send transaction
     And I fill the form:
       | address                                                     | amount   |
       | Ae2tdPwUPEZ3HUU7bmfexrUzoZpAZxuyt4b4bn7fus7RHfXoXRightdgMCv | 1.000000 |
-    And The transaction fees are "0.640003"
+    And The transaction fees are "0.640000"
     And I click on the next button in the wallet send form
     And I see send money confirmation dialog
     And I enter the wallet password:
@@ -218,7 +218,7 @@ Feature: Send transaction
     And I enter the wallet password:
       | password      |
       | asdfasdfasdf |
-    Given The expected transaction is "g6QAhYJYILcTzA1jEGw4BrGnB3zDeilPzKDkefJqrGTlHgmugI11AIJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAIJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAIJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAQGBglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAD0JAAhoACcQDAxoR/pTNoQKDhFggXnGsSYUyhwTHwB1G9f7mkd9iHoKwNvA477DkhDTXmX5YQGysuAsWMrUoYD6f5n5k2vmnVr2jWdoeFuanaxW8pk/F2kBfv7IPOpOwIvTVWuUknxJtJ11amUkNnHpX5GSRMQRYIO23hdKX7dxt3V0Cchr8MLvy1UwjID2hIegQ0F2VF6vHQaCEWCCPBkfbIHjkWa3BQgOfZnSx2uNRXSeHf/3Dr6sioCh8qlhANGxtDeRnQfiiCPFaWuvN/hiItSZxBk0NSGaQ5k4GPG3nFQdYatQrUqBCgqTcLz+3OG935IbMoHAIAnNlbcNeBlggRYcsb5A2HZ+Idr1h/VYzDe7f0Gt4E0SVRIi2VqWKcA5BoIRYIOx7+AYOSniTUHVqDkzhtFF7b1HM/9BBkw6++m8Q+/SzWEDqP1LXZUyJhvy/JouWNtcm8m9Ot0yejTfqvC7Wcjl4LXB7j+KJEl5DrLIXHij4ZBPHxOJc1n/bC7PJb7nRJ4APWCBWM2zqwExuk/gcTouvBpcmhtN2NEKb5aluF5K/hwZh2EGg9g=="
+    Given The expected transaction is "g6QAgoJYIGBJO/JuYLC5jxQ2R2E74uwcb1C9X8FaFKL/UY9fo2vgAYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgmugI1xAQGBglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAD0JAAhoACcQAAxoR/pTNoQKChFggjwZH2yB45FmtwUIDn2Z0sdrjUV0nh3/9w6+rIqAofKpYQJnz4URZfjl5AOpaEjMTWdF1lsFXPE+IKC0puBMdBjkWaqk6BIzW8VZ7pu7f8J/Mv8E3lRFiBVX7BnDQNYlT7g1YIEWHLG+QNh2fiHa9Yf1WMw3u39BreBNElUSItlalinAOQaCEWCDse/gGDkp4k1B1ag5M4bRRe29RzP/QQZMOvvpvEPv0s1hASaHptgaRcfgiyLBN80gqUIAueQBKkwSLu9iAd+UIN7PELThmN5ItmVzMeZIevE/7eS7wFX15sax9ap5ihK/1ClggVjNs6sBMbpP4HE6LrwaXJobTdjRCm+WpbheSv4cGYdhBoPY="
     And I submit the wallet send form
     Then I should see the summary screen
 
@@ -230,7 +230,7 @@ Feature: Send transaction
     And I fill the form:
       | address                                                     | amount   |
       | Ae2tdPwUPEZ3HUU7bmfexrUzoZpAZxuyt4b4bn7fus7RHfXoXRightdgMCv | 2.000000 |
-    And The transaction fees are "0.460004"
+    And The transaction fees are "0.460000"
     Then A pending tx gets sent from my wallet from another client
     Then I should see a warning block
 
@@ -360,3 +360,24 @@ Feature: Send transaction
     Examples:
       | amount              | fee       | expectedTx |
       | 1.000000            | 0.167833  | "g6QAgYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgSugI11FgGCglgrgtgYWCGDWBxA66wjgpZH9bPPW9JExWBcIUqKGMmxBlNBcCzWoAAa8oZfOxoAD0JAglg5Af0wLcvG6+RrU5YfLU0x/8kfm6HbRxOuVhSWZr6F4UOa5bEdhsrcaqLcJ6I+wLsaSX6JnAGqOfdrGgCGxKcCGgACj5kDGhH+lM2hAIGCWCAosn+8mv+rxG+osiOOtkzZqx67+DrT7IF+s0fWbhA6bFhARoefmMDg363oeCLxKyJbZI115/Lref2ZleBk7xpQgv3F4JEvqP+7D0p+6Oi8m0+UOaEREqwotQeDWSe/olRFC/Y=" |
+
+  @it-165
+  Scenario: Can receive & unmangle utxo entries (IT-165)
+    Given There is a Shelley wallet stored named shelley-mangled
+    And I have a wallet with funds
+    And I go to the receive screen
+    When I click on the base mangled tab
+    And I should see the addresses exactly list them
+    | address                                                    |
+    | addr1q8sm64ehfue7m7xrlh2zfu4uj9tn3z3yrzfdaly52gs667qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhzdk70 |
+    When I click on the unmangle button
+    Then I should see on the Yoroi transfer summary screen:
+    | fromAddress                                                 | amount           |   
+    | addr1q8sm64ehfue7m7xrlh2zfu4uj9tn3z3yrzfdaly52gs667qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhzdk70 | 10000000    |
+    And I enter the wallet password:
+      | password   |
+      | asdfasdfasdf |
+    Given The expected transaction is "g6QAgYJYILcTzA1jEGw4BrWnB3zDeilPzKDkefJqrGTlHgSugI11FwGBglg5ATFf/lO+USTb83qMl8g53oV7XmMSuklF3gfHb8kex9YZS/n0WTCduT05oFTkplWcw+TU0UvasV/VGgCWD6sCGgAChtUDGhH+lM2hAIGCWCCxG2517QHEmTBkk1BC3zBriToLyq4PxNikr8LCc0V+jFhAUiMjVxyfTJcGdgg9q914adTdNaD7+DW+eMviv5if69KbiPhAxWcIGldT8kDaG2uiyjtePEnGLd9fXRa3unVuBPY="
+    When I confirm Yoroi transfer funds
+    Then I should see the summary screen
+    And I should see 1 pending transactions

--- a/features/transactions.feature
+++ b/features/transactions.feature
@@ -121,7 +121,7 @@ Feature: Send transaction
     And I fill the form:
       | address                                                     | amount   |
       | Ae2tdPwUPEZ3HUU7bmfexrUzoZpAZxuyt4b4bn7fus7RHfXoXRightdgMCv | 1.000000 |
-    And The transaction fees are "0.640003"
+    And The transaction fees are "0.640000"
     And I click on the next button in the wallet send form
     And I see send money confirmation dialog
     And I enter the wallet password:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
We supported this for Jormungandr. This PR adds the equivalent functionality for Haskell Shelley

![image](https://user-images.githubusercontent.com/2608559/97203221-e0c06c00-17f7-11eb-84ea-e2ebe54babe8.png)

![image](https://user-images.githubusercontent.com/2608559/97203285-f2097880-17f7-11eb-8cb8-dca7bcc8c6e0.png)
