### PR TITLE
Fix mangled filter

### DIFF
--- a/app/components/wallet/staking/dashboard/UserSummary.js
+++ b/app/components/wallet/staking/dashboard/UserSummary.js
@@ -32,7 +32,7 @@ const messages = defineMessages({
   },
   mangledPopupDialogLine1: {
     id: 'wallet.dashboard.summary.mangled.line1',
-    defaultMessage: '!!!Your wallet has {adaAmount} {ticker} with a different delegation preferences.',
+    defaultMessage: '!!!Your wallet has {adaAmount} {ticker} with a different delegation preference.',
   },
   canUnmangleLine: {
     id: 'wallet.dashboard.summary.mangled.can',

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -468,7 +468,7 @@
   "wallet.dashboard.summary.delegatedTitle": "Total Delegated",
   "wallet.dashboard.summary.mangled.can": "{adaAmount} {ticker} can be corrected",
   "wallet.dashboard.summary.mangled.cannot": "{adaAmount} {ticker} cannot be corrected",
-  "wallet.dashboard.summary.mangled.line1": "Your wallet has {adaAmount} {ticker} with a different delegation preferences.",
+  "wallet.dashboard.summary.mangled.line1": "Your wallet has {adaAmount} {ticker} with a different delegation preference.",
   "wallet.dashboard.summary.mangled.line2": "We recommend to {transactionMessage} to delegate the {ticker}",
   "wallet.dashboard.summary.mangled.makeTx": "make a transaction",
   "wallet.dashboard.summary.note": "Less than you expected?",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
When refactoring code, I accidentally broke the filter for mangled so that it would always consider UTXOs entries as mangled. This PR fixes it