### PR TITLE
Show error message when wrong Ledger device is plugged in

### DIFF
--- a/app/actions/ada/ledger-send-actions.js
+++ b/app/actions/ada/ledger-send-actions.js
@@ -30,5 +30,6 @@ export default class LedgerSendActions {
     |},
     network: $ReadOnly<NetworkRow>,
     addressingMap: string => (void | $PropertyType<Addressing, 'addressing'>),
+    expectedSerial: string | void,
   |}> = new AsyncAction();
 }

--- a/app/containers/transfer/UpgradeTxDialogContainer.js
+++ b/app/containers/transfer/UpgradeTxDialogContainer.js
@@ -62,6 +62,7 @@ export default class UpgradeTxDialogContainer extends Component<Props> {
     |},
     network: $ReadOnly<NetworkRow>,
     addressingMap: string => (void | $PropertyType<Addressing, 'addressing'>),
+    expectedSerial: string | void,
   |} => Promise<void> = async (request) => {
     await this.generated.actions.ada.ledgerSend.sendUsingLedgerKey.trigger({
       ...request,
@@ -168,6 +169,8 @@ export default class UpgradeTxDialogContainer extends Component<Props> {
       </div>
     );
 
+    const expectedSerial = selected.getParent().hardwareInfo?.DeviceId || '';
+
     return (
       <TransferSummaryPage
         header={header}
@@ -187,7 +190,8 @@ export default class UpgradeTxDialogContainer extends Component<Props> {
               selected,
               this.generated.stores.addresses.addressSubgroupMap
             ),
-            ...tentativeTx
+            ...tentativeTx,
+            expectedSerial,
           }),
           label: intl.formatMessage(globalMessages.upgradeLabel),
         }}
@@ -227,6 +231,7 @@ export default class UpgradeTxDialogContainer extends Component<Props> {
               |},
               addressingMap: string => (void | $PropertyType<Addressing, 'addressing'>),
               network: $ReadOnly<NetworkRow>,
+              expectedSerial: string | void,
             |} => Promise<void>,
           |},
         |},

--- a/app/containers/uri/URILandingDialogContainer.js
+++ b/app/containers/uri/URILandingDialogContainer.js
@@ -53,7 +53,11 @@ export default class URILandingDialogContainer extends Component<Props> {
         <URIInvalidDialog
           onClose={this.onCancel}
           onSubmit={this.onCancel}
-          address={this.generated.stores.loading.uriParams ? this.generated.stores.loading.uriParams.address : null}
+          address={
+            this.generated.stores.loading.uriParams
+              ? this.generated.stores.loading.uriParams.address
+              : null
+          }
         />
       );
     }

--- a/app/domain/LedgerLocalizedError.js
+++ b/app/domain/LedgerLocalizedError.js
@@ -64,8 +64,6 @@ export function convertToLocalizableError(error: Error): LocalizableError {
     }
     // Ledger device related error happened, convert then to LocalizableError
     switch (error.message) {
-      // TODO: add serial error
-      // TODO: add version mismatch error
       case 'TransportError: Failed to sign with Ledger device: U2F TIMEOUT':
         // Showing - Failed to connect. Please check your ledger device and retry.
         localizableError = new LocalizableError(globalMessages.ledgerError101);

--- a/app/stores/ada/HWVerifyAddressStore.js
+++ b/app/stores/ada/HWVerifyAddressStore.js
@@ -142,13 +142,15 @@ export default class HWVerifyAddressStore extends Store {
         networkId: Number.parseInt(config.ChainNetworkId, 10),
         addressingMap: genAddressingLookup(publicDeriver, this.stores.addresses.addressSubgroupMap),
       });
+
+      const expectedSerial = publicDeriver.getParent().hardwareInfo?.DeviceId || '';
       if (this.ledgerConnect) {
         await this.ledgerConnect.showAddress({
           params: {
             address,
             ...addressParams,
           },
-          serial: undefined, // TODO
+          serial: expectedSerial,
         });
       }
     } catch (error) {

--- a/app/stores/ada/LedgerConnectStore.js
+++ b/app/stores/ada/LedgerConnectStore.js
@@ -181,6 +181,8 @@ export default class LedgerConnectStore
         params: {
           path: request.path,
         },
+        // don't pass serial
+        // since we use the request to fetch the public key to get the serial # in the first place
         serial: undefined,
       });
 

--- a/app/stores/toplevel/LoadingStore.js
+++ b/app/stores/toplevel/LoadingStore.js
@@ -17,11 +17,8 @@ import { migrate } from '../../api';
 import { Logger, stringifyError } from '../../utils/logging';
 import { closeOtherInstances } from '../../utils/tabManager';
 import { loadLovefieldDB, importOldDb, } from '../../api/ada/lib/storage/database/index';
-import { tryAddressToKind } from '../../api/ada/lib/storage/bridge/utils';
-import { CoreAddressTypes } from '../../api/ada/lib/storage/database/primitives/enums';
 import { ApiOptions, getApiMeta } from '../../api/common/utils';
 import { isWithinSupply } from '../../utils/validations';
-import { networks } from '../../api/ada/lib/storage/database/prepackaged/networks';
 import { RustModule } from '../../api/ada/lib/cardanoCrypto/rustLoader';
 
 /** Load dependencies before launching the app */

--- a/app/stores/toplevel/ProfileStore.js
+++ b/app/stores/toplevel/ProfileStore.js
@@ -648,8 +648,8 @@ export const getVarsForTheme: ({|
   const { getThemeVars } = require(`../../themes/prebuilt/${theme}.js`);
   // we used this theme for the Shelley version of the Yoroi extension
   // however, going forward, Yoroi will be a mono-project containing all sub-networks
+  // eslint-disable-next-line no-constant-condition
   if (false) {
-    // eslint-disable-line no-constant-condition
     return getThemeVars('shelley');
   }
   return getThemeVars(undefined);

--- a/app/stores/toplevel/WalletStore.js
+++ b/app/stores/toplevel/WalletStore.js
@@ -466,8 +466,8 @@ export default class WalletStore extends Store {
       const { plate } = this.getPublicKeyCache(withPubKey);
       const existingWarnings = this.stores.walletSettings.getWalletWarnings(publicDeriver);
       // bring this back if we ever need it. Removing this code deletes the i18n strings.
+      // eslint-disable-next-line no-constant-condition
       if (false) {
-        // eslint-disable-line no-constant-condition
         existingWarnings.dialogs.push(
           createProblematicWalletDialog(
             plate.TextPart,


### PR DESCRIPTION
Previously, we added code to be able to detect the wallet you currently have plugged in is different from the one that was used to create the wallet originally.

However, we never actually exposed this error message to the user.

This ticket is to properly show this error message

Unrelated: while testing this, I also realized we accidentally were not showing error messages on the Shelley wallet upgrade dialog. This PR fixes this issue also.