### PR TITLE
Fix main card styling

### DIFF
--- a/app/components/mixins/card-mixin.scss
+++ b/app/components/mixins/card-mixin.scss
@@ -10,7 +10,6 @@
   text-align: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: flex-end;
   margin: 0 8px;
   box-shadow: 0 5px 20px 0px rgba(24,26,30, .08);


### PR DESCRIPTION
This line breaks the styling of the main cards

![image](https://user-images.githubusercontent.com/2608559/101274535-30745900-37e2-11eb-9cac-0714730059ca.png)

and it seems to have no effect on the styling on the new transfer page cards, so I'm removing it.