### PR TITLE
Fix issue with hidden amounts' text

### DIFF
--- a/app/components/wallet/staking/dashboard/UserSummary.js
+++ b/app/components/wallet/staking/dashboard/UserSummary.js
@@ -332,7 +332,7 @@ export default class UserSummary extends Component<Props, State> {
       .split('.');
 
     const amountNode = this.props.shouldHideBalance
-      ? <>hiddenAmount</>
+      ? <>{hiddenAmount}</>
       : (
         <>
           {splitAmount[0]}


### PR DESCRIPTION
Fix issue with hidden amounts' text

<img width="1281" alt="Screen Shot 2021-01-19 at 6 47 53 PM" src="https://user-images.githubusercontent.com/1622112/105111647-ef30c380-5a86-11eb-9dc8-b8932fea367b.png">
