### PR TITLE
Ergo feedback

### DIFF
--- a/app/api/common/lib/MultiToken.js
+++ b/app/api/common/lib/MultiToken.js
@@ -63,7 +63,21 @@ export class MultiToken {
       return this;
     }
     existingEntry.amount = existingEntry.amount.plus(entry.amount);
+    this._removeIfZero(entry.identifier);
     return this;
+  }
+
+  _removeIfZero: string => void = (identifier) => {
+    // if after modifying a token value we end up with a value of 0,
+    // we should just remove the token from the list
+    // However, we must keep a value of 0 for the default entry
+    if (identifier === this.defaults.defaultIdentifier) {
+      return;
+    }
+    const existingValue = this.get(identifier);
+    if (existingValue != null && existingValue.eq(0)) {
+      this.values = this.values.filter(value => value.identifier !== identifier);
+    }
   }
 
   subtract: TokenEntry => MultiToken = (entry) => {

--- a/features/transactions.feature
+++ b/features/transactions.feature
@@ -397,7 +397,7 @@ Feature: Send transaction
 
     Examples:
       | address                                             | amount       |fee         |
-      | 9guxMsa2S1Z4xzr5JHUHZesznThjZ4BMM9Ra5Lfx2E9duAnxEmv | 123  |0.001100000 |
+      | 9guxMsa2S1Z4xzr5JHUHZesznThjZ4BMM9Ra5Lfx2E9duAnxEmv | 123  |0.010000000 |
 
   @it-171
   Scenario: Can send all of a custom token (IT-171)
@@ -412,7 +412,7 @@ Feature: Send transaction
     And I fill the address of the form:
       | address                                                     |
       | 9guxMsa2S1Z4xzr5JHUHZesznThjZ4BMM9Ra5Lfx2E9duAnxEmv         |
-    And The transaction fees are "0.001100000"
+    And The transaction fees are "0.010000000"
     And I click on the next button in the wallet send form
     And I see send money confirmation dialog
     And I enter the wallet password:


### PR DESCRIPTION
This addresses two points:

1. If a token in a transaction appears with the same value in both the input & the output, it would show as having a value of 0. It now gets filtered out instead
![image](https://user-images.githubusercontent.com/2608559/105180094-77899400-5b6d-11eb-9892-3a3e378df8d8.png)

2. I bumped the fee used to `10000000` when sending a token (about 10x the fee of a regular transaction)