### PR TITLE
Ergo feedback round 2

### DIFF
--- a/app/components/topbar/NavWalletDetails.js
+++ b/app/components/topbar/NavWalletDetails.js
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react';
 import type { Node } from 'react';
 import classnames from 'classnames';
 import { intlShape, } from 'react-intl';
-import { splitAmount } from '../../utils/formatters';
+import { splitAmount, truncateToken } from '../../utils/formatters';
 
 import globalMessages from '../../i18n/global-messages';
 import styles from './NavWalletDetails.scss';
@@ -174,6 +174,6 @@ export default class NavWalletDetails extends Component<Props> {
       );
     }
 
-    return (<>{balanceDisplay} {getTokenName(tokenInfo)}</>);
+    return (<>{balanceDisplay} {truncateToken(getTokenName(tokenInfo))}</>);
   }
 }

--- a/app/components/transfer/TransferSummaryPage.js
+++ b/app/components/transfer/TransferSummaryPage.js
@@ -15,7 +15,7 @@ import { calculateAndFormatValue } from '../../utils/unit-of-account';
 import globalMessages from '../../i18n/global-messages';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import { SelectedExplorer } from '../../domain/SelectedExplorer';
-import { truncateAddress } from '../../utils/formatters';
+import { truncateAddress, truncateToken } from '../../utils/formatters';
 import type { TransferTx } from '../../types/TransferTypes';
 import { genAddressLookup } from '../../stores/stateless/addressStores';
 import {
@@ -192,9 +192,9 @@ export default class TransferSummaryPage extends Component<Props> {
               })}
               <div className={styles.refund}>
                 {intl.formatMessage(messages.unregisterExplanation, {
-                  ticker: getTokenName(this.props.getTokenInfo(
+                  ticker: truncateToken(getTokenName(this.props.getTokenInfo(
                     this.props.transferTx.recoveredBalance.getDefaultEntry()
-                  )),
+                  ))),
                   refundAmount: deregistrations.reduce(
                     (sum, curr) => (curr.refund == null ? sum : sum.joinAddCopy(curr.refund)),
                     new MultiToken([], this.props.transferTx.recoveredBalance.defaults)
@@ -357,9 +357,9 @@ export default class TransferSummaryPage extends Component<Props> {
               <div className={styles.amount}>{recoveredBalance}
                 <span className={styles.currencySymbol}>
                   &nbsp;{
-                    getTokenName(this.props.getTokenInfo(
+                    truncateToken(getTokenName(this.props.getTokenInfo(
                       transferTx.recoveredBalance.getDefaultEntry()
-                    ))
+                    )))
                   }
                 </span>
               </div>
@@ -391,9 +391,9 @@ export default class TransferSummaryPage extends Component<Props> {
               <div className={styles.fees}>{transactionFee}
                 <span className={styles.currencySymbol}>
                   &nbsp;{
-                    getTokenName(this.props.getTokenInfo(
+                    truncateToken(getTokenName(this.props.getTokenInfo(
                       transferTx.fee.getDefaultEntry()
-                    ))
+                    )))
                   }
                 </span>
               </div>
@@ -427,9 +427,9 @@ export default class TransferSummaryPage extends Component<Props> {
             <div className={styles.totalAmount}>{finalBalance}
               <span className={styles.currencySymbol}>
                 &nbsp;{
-                  getTokenName(this.props.getTokenInfo(
+                  truncateToken(getTokenName(this.props.getTokenInfo(
                     transferTx.recoveredBalance.getDefaultEntry()
-                  ))
+                  )))
                 }
               </span>
             </div>

--- a/app/components/uri/URIGenerateDialog.js
+++ b/app/components/uri/URIGenerateDialog.js
@@ -16,7 +16,7 @@ import DialogCloseButton from '../widgets/DialogCloseButton';
 import { InputOwnSkin } from '../../themes/skins/InputOwnSkin';
 import globalMessages from '../../i18n/global-messages';
 import type { TokenRow } from '../../api/ada/lib/storage/database/primitives/tables';
-import { formattedAmountToNaturalUnits } from '../../utils/formatters';
+import { formattedAmountToNaturalUnits, truncateToken } from '../../utils/formatters';
 import config from '../../config';
 import { calcMaxBeforeDot } from '../../utils/validations';
 import { getTokenName } from '../../stores/stateless/tokenHelpers';
@@ -67,7 +67,7 @@ export default class URIGenerateDialog extends Component<Props> {
 
   getAmountLabel: (() => string) = (): string => {
     const label = this.context.intl.formatMessage(messages.uriGenerateDialogAmountLabel, {
-      currency: getTokenName(this.props.tokenInfo),
+      currency: truncateToken(getTokenName(this.props.tokenInfo)),
     });
 
     return label;
@@ -81,7 +81,7 @@ export default class URIGenerateDialog extends Component<Props> {
         value: this.props.walletAddress,
       },
       amount: {
-        label: this.getAmountLabel(),
+        label: truncateToken(this.getAmountLabel()),
         placeholder: `0.${'0'.repeat(this.props.tokenInfo.Metadata.numberOfDecimals)}`,
         value: '',
         validators: [async ({ field }) => {

--- a/app/components/uri/URIVerifyDialog.js
+++ b/app/components/uri/URIVerifyDialog.js
@@ -10,7 +10,7 @@ import DialogCloseButton from '../widgets/DialogCloseButton';
 import DialogBackButton from '../widgets/DialogBackButton';
 import type { UriParams } from '../../utils/URIHandling';
 import globalMessages from '../../i18n/global-messages';
-import { truncateAddress } from '../../utils/formatters';
+import { truncateAddress, truncateToken } from '../../utils/formatters';
 import ExplorableHashContainer from '../../containers/widgets/ExplorableHashContainer';
 import RawHash from '../widgets/hashWrappers/RawHash';
 import type { UnitOfAccountSettingType } from '../../types/unitOfAccountType';
@@ -140,19 +140,19 @@ export default class URIVerifyDialog extends Component<Props> {
                 {unitOfAccountSetting.currency}
               </div>
               <div className={styles.amountSmall}>
-                {formatValue(amount.getDefaultEntry())} {getTokenName(
+                {formatValue(amount.getDefaultEntry())} {truncateToken(getTokenName(
                   this.props.getTokenInfo(
                     amount.getDefaultEntry()
-                  ))
+                  )))
                 }
               </div>
             </>
           ) : (
             <div className={styles.amount}>
-              {formatValue(amount.getDefaultEntry())} {getTokenName(
+              {formatValue(amount.getDefaultEntry())} {truncateToken(getTokenName(
                 this.props.getTokenInfo(
                   amount.getDefaultEntry()
-                ))
+                )))
               }
             </div>
           )}

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -16,7 +16,7 @@ import { addressFilter, AddressFilter, } from '../../types/AddressFilterTypes';
 import environment from '../../environment';
 import type { Notification } from '../../types/notificationType';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
-import { truncateAddressShort, splitAmount } from '../../utils/formatters';
+import { truncateAddressShort, splitAmount, truncateToken } from '../../utils/formatters';
 import type { UnitOfAccountSettingType } from '../../types/unitOfAccountType';
 import NoTransactionModernSvg from '../../assets/images/transaction/no-transactions-yet.modern.inline.svg';
 import AddLabelIcon from '../../assets/images/add-label.inline.svg';
@@ -110,7 +110,7 @@ export default class WalletReceive extends Component<Props> {
         {' '}
         {this.props.unitOfAccountSetting.enabled
           ? this.props.unitOfAccountSetting.currency
-          : getTokenName(tokenInfo)
+          : truncateToken(getTokenName(tokenInfo))
         }
       </>
     );

--- a/app/components/wallet/my-wallets/WalletDetails.js
+++ b/app/components/wallet/my-wallets/WalletDetails.js
@@ -4,7 +4,7 @@ import type { Node } from 'react';
 import { observer } from 'mobx-react';
 import { intlShape } from 'react-intl';
 import globalMessages from '../../../i18n/global-messages';
-import { splitAmount } from '../../../utils/formatters';
+import { splitAmount, truncateToken } from '../../../utils/formatters';
 import styles from './WalletDetails.scss';
 import IconEyeOpen from '../../../assets/images/my-wallets/icon_eye_open.inline.svg';
 import IconEyeClosed from '../../../assets/images/my-wallets/icon_eye_closed.inline.svg';
@@ -122,6 +122,6 @@ export default class WalletDetails extends Component<Props> {
       );
     }
 
-    return (<>{balanceDisplay} {getTokenName(tokenInfo)}</>);
+    return (<>{balanceDisplay} {truncateToken(getTokenName(tokenInfo))}</>);
   }
 }

--- a/app/components/wallet/send/HWSendConfirmationDialog.js
+++ b/app/components/wallet/send/HWSendConfirmationDialog.js
@@ -21,7 +21,7 @@ import { calculateAndFormatValue } from '../../../utils/unit-of-account';
 import { SelectedExplorer } from '../../../domain/SelectedExplorer';
 import type { UnitOfAccountSettingType } from '../../../types/unitOfAccountType';
 import styles from './HWSendConfirmationDialog.scss';
-import { truncateAddress } from '../../../utils/formatters';
+import { truncateAddress, truncateToken } from '../../../utils/formatters';
 import {
   MultiToken,
 } from '../../../api/common/lib/MultiToken';
@@ -96,7 +96,7 @@ export default class HWSendConfirmationDialog extends Component<Props> {
           </div>
           <div className={styles.amountSmall}>{formatValue(entry)}
             <span className={styles.currencySymbol}>&nbsp;{
-              getTokenName(this.props.getTokenInfo(entry))
+              truncateToken(getTokenName(this.props.getTokenInfo(entry)))
             }
             </span>
           </div>
@@ -104,7 +104,7 @@ export default class HWSendConfirmationDialog extends Component<Props> {
       ) : (
         <div className={styles.amount}>{formatValue(entry)}
           <span className={styles.currencySymbol}>&nbsp;{
-            getTokenName(this.props.getTokenInfo(entry))
+            truncateToken(getTokenName(this.props.getTokenInfo(entry)))
           }
           </span>
         </div>
@@ -125,7 +125,7 @@ export default class HWSendConfirmationDialog extends Component<Props> {
           </div>
           <div className={styles.totalAmountSmall}>{formatValue(entry)}
             <span className={styles.currencySymbol}>&nbsp;{
-              getTokenName(this.props.getTokenInfo(entry))
+              truncateToken(getTokenName(this.props.getTokenInfo(entry)))
             }
             </span>
           </div>
@@ -133,7 +133,7 @@ export default class HWSendConfirmationDialog extends Component<Props> {
       ) : (
         <div className={styles.totalAmount}>{formatValue(entry)}
           <span className={styles.currencySymbol}>&nbsp;{
-            getTokenName(this.props.getTokenInfo(entry))
+            truncateToken(getTokenName(this.props.getTokenInfo(entry)))
           }
           </span>
         </div>
@@ -155,9 +155,9 @@ export default class HWSendConfirmationDialog extends Component<Props> {
           <div className={styles.feesSmall}>
             +{formatValue(entry)}
             <span className={styles.currencySymbol}>&nbsp;{
-              getTokenName(this.props.getTokenInfo(
+              truncateToken(getTokenName(this.props.getTokenInfo(
                 entry
-              ))
+              )))
             }
             </span>
           </div>
@@ -166,9 +166,9 @@ export default class HWSendConfirmationDialog extends Component<Props> {
         <div className={styles.fees}>
           +{formatValue(entry)}
           <span className={styles.currencySymbol}>&nbsp;{
-            getTokenName(this.props.getTokenInfo(
+            truncateToken(getTokenName(this.props.getTokenInfo(
               entry
-            ))
+            )))
           }
           </span>
         </div>

--- a/app/components/wallet/send/WalletSendConfirmationDialog.js
+++ b/app/components/wallet/send/WalletSendConfirmationDialog.js
@@ -25,7 +25,7 @@ import { calculateAndFormatValue } from '../../../utils/unit-of-account';
 import WarningBox from '../../widgets/WarningBox';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import {
-  truncateAddress,
+  truncateAddress, truncateToken,
 } from '../../../utils/formatters';
 import {
   MultiToken,
@@ -134,7 +134,7 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
           </div>
           <div className={styles.amountSmall}>{formatValue(entry)}
             <span className={styles.currencySymbol}>&nbsp;{
-              getTokenName(this.props.getTokenInfo(entry))
+              truncateToken(getTokenName(this.props.getTokenInfo(entry)))
             }
             </span>
           </div>
@@ -142,7 +142,7 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
       ) : (
         <div className={styles.amount}>{formatValue(entry)}
           <span className={styles.currencySymbol}>&nbsp;{
-            getTokenName(this.props.getTokenInfo(entry))
+            truncateToken(getTokenName(this.props.getTokenInfo(entry)))
           }
           </span>
         </div>
@@ -163,7 +163,7 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
           </div>
           <div className={styles.totalAmountSmall}>{formatValue(entry)}
             <span className={styles.currencySymbol}>&nbsp;{
-              getTokenName(this.props.getTokenInfo(entry))
+              truncateToken(getTokenName(this.props.getTokenInfo(entry)))
             }
             </span>
           </div>
@@ -171,7 +171,7 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
       ) : (
         <div className={styles.totalAmount}>{formatValue(entry)}
           <span className={styles.currencySymbol}>&nbsp;{
-            getTokenName(this.props.getTokenInfo(entry))
+            truncateToken(getTokenName(this.props.getTokenInfo(entry)))
           }
           </span>
         </div>
@@ -193,9 +193,9 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
           <div className={styles.feesSmall}>
             +{formatValue(entry)}
             <span className={styles.currencySymbol}>&nbsp;{
-              getTokenName(this.props.getTokenInfo(
+              truncateToken(getTokenName(this.props.getTokenInfo(
                 entry
-              ))
+              )))
             }
             </span>
           </div>
@@ -204,9 +204,9 @@ export default class WalletSendConfirmationDialog extends Component<Props> {
         <div className={styles.fees}>
           +{formatValue(entry)}
           <span className={styles.currencySymbol}>&nbsp;{
-            getTokenName(this.props.getTokenInfo(
+            truncateToken(getTokenName(this.props.getTokenInfo(
               entry
-            ))
+            )))
           }
           </span>
         </div>

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -27,6 +27,7 @@ import {
   formattedAmountToBigNumber,
   formattedAmountToNaturalUnits,
   truncateAddressShort,
+  truncateToken,
 } from '../../../utils/formatters';
 import config from '../../../config';
 import { InputOwnSkin } from '../../../themes/skins/InputOwnSkin';
@@ -360,7 +361,7 @@ export default class WalletSendForm extends Component<Props> {
       })).map(token => ({
         value: token.info.TokenId,
         info: token.info,
-        label: getTokenStrictName(token.info) ?? '-',
+        label: truncateToken(getTokenStrictName(token.info) ?? '-'),
         id: getTokenIdentifierIfExists(token.info) ?? '-',
         amount: genFormatTokenAmount(this.props.getTokenInfo)(token.entry)
       }));
@@ -416,7 +417,9 @@ export default class WalletSendForm extends Component<Props> {
               disabled={this.props.shouldSendAll}
               error={(transactionFeeError || amountField.error)}
               // AmountInputSkin props
-              currency={getTokenName(this.props.selectedToken ?? this.props.defaultToken)}
+              currency={truncateToken(
+                getTokenName(this.props.selectedToken ?? this.props.defaultToken)
+              )}
               fees={formatValue(transactionFee.getDefaultEntry())}
               total={formatValue(this.getTokenEntry(totalAmount))}
               skin={AmountInputSkin}
@@ -426,7 +429,9 @@ export default class WalletSendForm extends Component<Props> {
           <div className={styles.checkbox}>
             <Checkbox
               label={intl.formatMessage(messages.checkboxLabel, {
-                currency: getTokenName(this.props.selectedToken ?? this.props.defaultToken)
+                currency: truncateToken(
+                  getTokenName(this.props.selectedToken ?? this.props.defaultToken)
+                )
               })}
               onChange={() => {
                 this.props.toggleSendAll();

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -362,8 +362,10 @@ export default class WalletSendForm extends Component<Props> {
       })).map(token => ({
         value: token.info.TokenId,
         info: token.info,
-        label: truncateToken(getTokenStrictName(token.info) ?? '-'),
-        id: getTokenIdentifierIfExists(token.info) ?? '-',
+        label: truncateToken(getTokenStrictName(token.info) ?? getTokenIdentifierIfExists(token.info) ?? '-'),
+        id: getTokenStrictName(token.info) == null
+          ? '-'
+          : (getTokenIdentifierIfExists(token.info) ?? '-'),
         amount: genFormatTokenAmount(this.props.getTokenInfo)(token.entry)
       }));
     })();

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -319,9 +319,10 @@ export default class WalletSendForm extends Component<Props> {
     });
 
     const totalAmount = this.props.totalInput ?? new MultiToken([{
-      identifier: this.props.defaultToken.Identifier,
-      networkId: this.props.defaultToken.NetworkId,
-      amount: formattedAmountToBigNumber(amountFieldProps.value),
+      identifier: (this.props.selectedToken ?? this.props.defaultToken).Identifier,
+      networkId: (this.props.selectedToken ?? this.props.defaultToken).NetworkId,
+      amount: formattedAmountToBigNumber(amountFieldProps.value)
+        .shiftedBy((this.props.selectedToken ?? this.props.defaultToken).Metadata.numberOfDecimals),
     }], {
       defaultIdentifier: this.props.defaultToken.Identifier,
       defaultNetworkId: this.props.defaultToken.NetworkId,

--- a/app/components/wallet/send/WalletSendForm.js
+++ b/app/components/wallet/send/WalletSendForm.js
@@ -380,9 +380,15 @@ export default class WalletSendForm extends Component<Props> {
               className={styles.currencySelect}
               options={tokenOptions}
               {...form.$('selectedToken').bind()}
-              onChange={tokenId => this.props.onAddToken(tokenOptions.find(
-                token => token.info.TokenId === tokenId
-              )?.info)}
+              onChange={tokenId => {
+                this.props.onAddToken(tokenOptions.find(
+                  token => token.info.TokenId === tokenId
+                )?.info);
+
+                // clear amount field when switching currencies
+                this.form.$('amount').clear();
+                this.props.updateAmount();
+              }}
               skin={SelectTokenSkin}
               value={this.props.selectedToken?.TokenId ?? this.props.getTokenInfo({
                 identifier: this.props.defaultToken.Identifier,

--- a/app/components/wallet/staking/DelegationTxDialog.js
+++ b/app/components/wallet/staking/DelegationTxDialog.js
@@ -23,6 +23,7 @@ import { SelectedExplorer } from '../../../domain/SelectedExplorer';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import SpendingPasswordInput from '../../widgets/forms/SpendingPasswordInput';
 import { calcMaxBeforeDot } from '../../../utils/validations';
+import { truncateToken } from '../../../utils/formatters';
 import {
   MultiToken,
 } from '../../../api/common/lib/MultiToken';
@@ -237,7 +238,7 @@ export default class DelegationTxDialog extends Component<Props> {
               .shiftedBy(-this.props.approximateReward.token.Metadata.numberOfDecimals)
               .toFormat(this.props.approximateReward.token.Metadata.numberOfDecimals)
             }&nbsp;
-            {getTokenName(this.props.approximateReward.token)}
+            {truncateToken(getTokenName(this.props.approximateReward.token))}
           </p>
         </div>
         {this.props.error

--- a/app/components/wallet/staking/dashboard/UndelegateDialog.js
+++ b/app/components/wallet/staking/dashboard/UndelegateDialog.js
@@ -27,6 +27,7 @@ import type {
 } from '../../../../api/common/lib/MultiToken';
 import type { TokenRow } from '../../../../api/ada/lib/storage/database/primitives/tables';
 import { getTokenName } from '../../../../stores/stateless/tokenHelpers';
+import { truncateToken } from '../../../../utils/formatters';
 
 import WarningBox from '../../../widgets/WarningBox';
 
@@ -163,7 +164,7 @@ export default class UndelegateDialog extends Component<Props> {
       return (
         <p className={styles.rewardAmount}>
           {formattedAmount}&nbsp;
-          {getTokenName(tokenInfo)}
+          {truncateToken(getTokenName(tokenInfo))}
         </p>
       );
     })();

--- a/app/components/wallet/staking/dashboard/UserSummary.js
+++ b/app/components/wallet/staking/dashboard/UserSummary.js
@@ -25,6 +25,7 @@ import type {
 import { getTokenName } from '../../../../stores/stateless/tokenHelpers';
 import type { TokenRow } from '../../../../api/ada/lib/storage/database/primitives/tables';
 import { hiddenAmount } from '../../../../utils/strings';
+import { truncateToken } from '../../../../utils/formatters';
 
 const messages = defineMessages({
   title: {
@@ -118,7 +119,7 @@ export default class UserSummary extends Component<Props, State> {
           <div>
             <h3 className={styles.label}>
               {intl.formatMessage(globalMessages.totalTokenLabel, {
-                ticker: getTokenName(this.props.defaultTokenInfo),
+                ticker: truncateToken(getTokenName(this.props.defaultTokenInfo)),
               })}
               :
             </h3>
@@ -228,9 +229,9 @@ export default class UserSummary extends Component<Props, State> {
                     <FormattedMessage
                       {...messages.mangledPopupDialogLine2}
                       values={{
-                        ticker: getTokenName(this.props.getTokenInfo(
+                        ticker: truncateToken(getTokenName(this.props.getTokenInfo(
                           this.props.canUnmangleSum.getDefaultEntry()
-                        )),
+                        ))),
                         transactionMessage: (
                           <span
                             className={styles.link}
@@ -315,7 +316,7 @@ export default class UserSummary extends Component<Props, State> {
       <FormattedMessage
         {...message}
         values={{
-          ticker: getTokenName(tokenInfo),
+          ticker: truncateToken(getTokenName(tokenInfo)),
           adaAmount: this.props.shouldHideBalance
             ? hiddenAmount
             : amount,
@@ -344,7 +345,7 @@ export default class UserSummary extends Component<Props, State> {
         <span>
           {amountNode}{' '}
         </span>
-        {getTokenName(tokenInfo)}
+        {truncateToken(getTokenName(tokenInfo))}
       </>
     );
   };

--- a/app/components/wallet/summary/WalletSummary.js
+++ b/app/components/wallet/summary/WalletSummary.js
@@ -12,7 +12,7 @@ import styles from './WalletSummary.scss';
 import type { UnitOfAccountSettingType } from '../../../types/unitOfAccountType';
 import { formatValue } from '../../../utils/unit-of-account';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
-import { splitAmount } from '../../../utils/formatters';
+import { splitAmount, truncateToken } from '../../../utils/formatters';
 import {
   MultiToken,
 } from '../../../api/common/lib/MultiToken';
@@ -97,7 +97,7 @@ export default class WalletSummary extends Component<Props> {
       );
     }
 
-    return (<>{balanceDisplay} {getTokenName(tokenInfo)}</>);
+    return (<>{balanceDisplay} {truncateToken(getTokenName(tokenInfo))}</>);
   }
 
   render(): Node {

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -27,7 +27,7 @@ import { TxStatusCodes, } from '../../../api/ada/lib/storage/database/primitives
 import type { TxStatusCodesType, } from '../../../api/ada/lib/storage/database/primitives/enums';
 import type { CertificateRow, TokenRow } from '../../../api/ada/lib/storage/database/primitives/tables';
 import { RustModule } from '../../../api/ada/lib/cardanoCrypto/rustLoader';
-import { splitAmount, truncateAddressShort } from '../../../utils/formatters';
+import { splitAmount, truncateAddressShort, truncateToken } from '../../../utils/formatters';
 import type { TxMemoTableRow } from '../../../api/ada/lib/storage/database/memos/tables';
 import CopyableAddress from '../../widgets/CopyableAddress';
 import type { Notification } from '../../../types/notificationType';
@@ -367,7 +367,7 @@ export default class Transaction extends Component<Props, State> {
       return this.props.unitOfAccountSetting.currency;
     }
     const tokenInfo = this.props.getTokenInfo(tokenEntry);
-    return getTokenName(tokenInfo);
+    return truncateToken(getTokenName(tokenInfo));
   };
 
   renderRow: {|

--- a/app/components/wallet/voting/VotingRegTxDialog.js
+++ b/app/components/wallet/voting/VotingRegTxDialog.js
@@ -29,6 +29,7 @@ import type {
 } from '../../../api/common/lib/MultiToken';
 import type { TokenRow, } from '../../../api/ada/lib/storage/database/primitives/tables';
 import { getTokenName, genFormatTokenAmount, } from '../../../stores/stateless/tokenHelpers';
+import { truncateToken } from '../../../utils/formatters';
 
 import WarningBox from '../../widgets/WarningBox';
 
@@ -152,7 +153,7 @@ export default class VotingRegTxDialog extends Component<Props> {
             maxAfterDot={tokenInfo.Metadata.numberOfDecimals}
             disabled
             // AmountInputSkin props
-            currency={getTokenName(tokenInfo)}
+            currency={truncateToken(getTokenName(tokenInfo))}
             fees={formatValue(this.props.transactionFee.getDefaultEntry())}
             // note: we purposely don't put "total" since it doesn't really make sense here
             // since the fee is unrelated to the amount you're about to stake

--- a/app/containers/banners/BannerContainer.js
+++ b/app/containers/banners/BannerContainer.js
@@ -17,6 +17,7 @@ import { isTestnet, isCardanoHaskell } from '../../api/ada/lib/storage/database/
 import { Bip44Wallet } from '../../api/ada/lib/storage/models/Bip44Wallet/wrapper';
 import { getTokenName, genLookupOrFail } from '../../stores/stateless/tokenHelpers';
 import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore';
+import { truncateToken } from '../../utils/formatters';
 
 export type GeneratedData = typeof BannerContainer.prototype.generated;
 
@@ -70,7 +71,7 @@ export default class BannerContainer extends Component<InjectedOrGenerated<Gener
     return (
       <ByronDeprecationBanner
         onUpgrade={undefined}
-        ticker={getTokenName(defaultTokenInfo)}
+        ticker={truncateToken(getTokenName(defaultTokenInfo))}
       />
     );
   }

--- a/app/containers/notice-board/NoticeBoardPage.js
+++ b/app/containers/notice-board/NoticeBoardPage.js
@@ -19,6 +19,7 @@ import type { GetNoticesRequestOptions } from '../../api/ada/index';
 import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver';
 import { getTokenName, genLookupOrFail } from '../../stores/stateless/tokenHelpers';
 import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore';
+import { truncateToken } from '../../utils/formatters';
 
 const messages = defineMessages({
   title: {
@@ -78,7 +79,7 @@ export default class NoticeBoardPage extends Component<InjectedOrGenerated<Gener
         noticeComp = (
           <NoNotice
             classicTheme={this.generated.stores.profile.isClassicTheme}
-            ticker={getTokenName(defaultTokenInfo)}
+            ticker={truncateToken(getTokenName(defaultTokenInfo))}
           />
         );
       }

--- a/app/containers/transfer/UpgradeTxDialogContainer.js
+++ b/app/containers/transfer/UpgradeTxDialogContainer.js
@@ -30,6 +30,7 @@ import type {
 } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
 import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore';
 import { getTokenName, genLookupOrFail } from '../../stores/stateless/tokenHelpers';
+import { truncateToken } from '../../utils/formatters';
 
 export type GeneratedData = typeof UpgradeTxDialogContainer.prototype.generated;
 
@@ -155,7 +156,7 @@ export default class UpgradeTxDialogContainer extends Component<Props> {
       <div>
         {intl.formatMessage(
           messages.explanation,
-          { ticker: getTokenName(defaultTokenInfo) }
+          { ticker: truncateToken(getTokenName(defaultTokenInfo)) }
         )}
         <br /><br />
       </div>

--- a/app/containers/transfer/WalletTransferPage.js
+++ b/app/containers/transfer/WalletTransferPage.js
@@ -21,6 +21,7 @@ import type { GeneratedData as ShelleyEraOptionDialogContainerData } from './opt
 import type { RestoreModeType } from '../../actions/common/wallet-restore-actions';
 import { genLookupOrFail, getTokenName, } from '../../stores/stateless/tokenHelpers';
 import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore';
+import { truncateToken } from '../../utils/formatters';
 
 export type GeneratedData = typeof WalletTransferPage.prototype.generated;
 
@@ -90,7 +91,7 @@ export default class WalletTransferPage extends Component<Props> {
           onShelley={
             () => actions.dialogs.open.trigger({ dialog: ShelleyEraOptionDialogContainer })
           }
-          ticker={getTokenName(defaultTokenInfo)}
+          ticker={truncateToken(getTokenName(defaultTokenInfo))}
         />
         {activeDialog}
         {icarusTransfer}

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -42,6 +42,7 @@ import type { ComplexityLevelType } from '../../types/complexityLevelType';
 import { handleExternalLinkClick } from '../../utils/routing';
 import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore';
 import { genLookupOrFail, getTokenName, } from '../../stores/stateless/tokenHelpers';
+import { truncateToken } from '../../utils/formatters';
 
 export type GeneratedData = typeof WalletReceivePage.prototype.generated;
 
@@ -170,7 +171,7 @@ export default class WalletReceivePage extends Component<Props> {
         />);
       }
       if (addressTypeStore.meta.name.group === AddressGroupTypes.reward) {
-        return (<RewardHeader ticker={getTokenName(defaultTokenInfo)} />);
+        return (<RewardHeader ticker={truncateToken(getTokenName(defaultTokenInfo))} />);
       }
       if (addressTypeStore.meta.name.subgroup === AddressSubgroup.mangled) {
         return (
@@ -179,7 +180,7 @@ export default class WalletReceivePage extends Component<Props> {
             onClick={() => this.generated.actions.dialogs.open.trigger({
               dialog: UnmangleTxDialogContainer,
             })}
-            ticker={getTokenName(defaultTokenInfo)}
+            ticker={truncateToken(getTokenName(defaultTokenInfo))}
           />
         );
       }

--- a/app/containers/wallet/staking/StakingDashboardPage.js
+++ b/app/containers/wallet/staking/StakingDashboardPage.js
@@ -70,6 +70,7 @@ import {
 } from '../../../api/common/lib/MultiToken';
 import type { TokenInfoMap } from '../../../stores/toplevel/TokenInfoStore';
 import { getTokenName, genLookupOrFail } from '../../../stores/stateless/tokenHelpers';
+import { truncateToken } from '../../../utils/formatters';
 
 export type GeneratedData = typeof StakingDashboardPage.prototype.generated;
 
@@ -160,11 +161,11 @@ export default class StakingDashboardPage extends Component<Props> {
         })}
         delegationHistory={delegationRequests.getCurrentDelegation.result?.fullHistory}
         epochLength={this.getEpochLengthInDays(publicDeriver)}
-        ticker={getTokenName(
+        ticker={truncateToken(getTokenName(
           this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
             publicDeriver.getParent().getNetworkInfo().NetworkId
           )
-        )}
+        ))}
       />
     );
 

--- a/app/stores/stateless/tokenHelpers.js
+++ b/app/stores/stateless/tokenHelpers.js
@@ -16,7 +16,7 @@ export function getTokenName(
       ...,
     },
     ...,
-  }>
+  }>,
 ): string {
   const strictName = getTokenStrictName(tokenRow);
   if (strictName != null) return strictName;
@@ -34,7 +34,7 @@ export function getTokenStrictName(
       ...,
     },
     ...,
-  }>
+  }>,
 ): void | string {
   if (tokenRow.Metadata.ticker != null) {
     return tokenRow.Metadata.ticker;

--- a/app/stores/toplevel/TransactionBuilderStore.js
+++ b/app/stores/toplevel/TransactionBuilderStore.js
@@ -240,25 +240,22 @@ export default class TransactionBuilderStore extends Store {
       const lastSync = this.stores.transactions.getTxRequests(publicDeriver).lastSyncInfo;
 
       const defaultToken = this.stores.tokenInfoStore.getDefaultTokenInfo(network.NetworkId);
-      const isSendingToken = (
-        this.selectedToken != null && this.selectedToken.TokenId !== defaultToken.TokenId
-      );
-      const txFee = isSendingToken
-        // kind of hacky.
-        // We use a larger amount for tokens in hopes it covers any smart contract execution cost
-        ? new BigNumber(10000000)
-        : new BigNumber(
-          RustModule.SigmaRust.BoxValue.SAFE_USER_MIN().as_i64().to_str()
-        ).plus(100000); // slightly higher than default fee
+      const txFee = new BigNumber(
+        RustModule.SigmaRust.BoxValue.SAFE_USER_MIN().as_i64().to_str()
+      ).plus(100000); // slightly higher than default fee
 
       const genTokenList = (userInput) => {
         const tokens = [userInput];
-          if (isSendingToken) {
+          if (this.selectedToken != null && this.selectedToken.TokenId !== defaultToken.TokenId) {
           // if the user is sending a token, we need to make sure the resulting box
           // has at least the minimum amount of ERG in it
           tokens.push({
             token: defaultToken,
-            amount: RustModule.SigmaRust.BoxValue.SAFE_USER_MIN().as_i64().to_str(),
+            // amount: RustModule.SigmaRust.BoxValue.SAFE_USER_MIN().as_i64().to_str(),
+            // kind of hacky.
+            // We use a larger amount for tokens
+            // in hopes it covers any smart contract execution cost
+            amount: new BigNumber(10000000).toString()
           });
         }
         return tokens;

--- a/app/utils/formatters.js
+++ b/app/utils/formatters.js
@@ -70,6 +70,10 @@ function truncateFormatter(addr: string, cutoff: number): string {
   return addr.substring(0, cutoff / 2) + '...' + addr.substring(addr.length - (cutoff / 2), addr.length);
 }
 
+export function truncateToken(addr: string): string {
+  return truncateFormatter(addr, 10);
+}
+
 export function truncateAddress(addr: string): string {
   // needs to be enough for any bech32 prefix & header and bech32 checksum
   // 40 empirically works well with bech32 and still fits in small spaces and dialogs

--- a/app/utils/validations.js
+++ b/app/utils/validations.js
@@ -7,6 +7,7 @@ import { defineMessages, } from 'react-intl';
 import type { NetworkRow, TokenRow } from '../api/ada/lib/storage/database/primitives/tables';
 import { isCardanoHaskell, isErgo, getCardanoHaskellBaseConfig, getErgoBaseConfig } from '../api/ada/lib/storage/database/prepackaged/networks';
 import { getTokenName } from '../stores/stateless/tokenHelpers';
+import { truncateToken } from './formatters';
 
 export const isValidWalletName: string => boolean = (walletName) => {
   const nameLength = walletName.length;
@@ -114,7 +115,7 @@ export async function validateAmount(
       false,
       formatter.formatMessage(messages.tooSmallUtxo, {
         minUtxo: minAmount.div(new BigNumber(10).pow(tokenRow.Metadata.numberOfDecimals)),
-        ticker: getTokenName(tokenRow),
+        ticker: truncateToken(getTokenName(tokenRow)),
       })
     ];
   }

--- a/features/transactions.feature
+++ b/features/transactions.feature
@@ -388,7 +388,7 @@ Feature: Send transaction
     And I see send money confirmation dialog
     And I see CONFIRM TRANSACTION Pop up:
       | address   | amount    |fee      |
-      | <address> | 0.001000000  |<fee>    |
+      | <address> | 0.010000000  |<fee>    |
     And I enter the wallet password:
       | password   |
       | asdfasdfasdf |
@@ -397,7 +397,7 @@ Feature: Send transaction
 
     Examples:
       | address                                             | amount       |fee         |
-      | 9guxMsa2S1Z4xzr5JHUHZesznThjZ4BMM9Ra5Lfx2E9duAnxEmv | 123  |0.010000000 |
+      | 9guxMsa2S1Z4xzr5JHUHZesznThjZ4BMM9Ra5Lfx2E9duAnxEmv | 123  |0.001100000 |
 
   @it-171
   Scenario: Can send all of a custom token (IT-171)
@@ -412,7 +412,7 @@ Feature: Send transaction
     And I fill the address of the form:
       | address                                                     |
       | 9guxMsa2S1Z4xzr5JHUHZesznThjZ4BMM9Ra5Lfx2E9duAnxEmv         |
-    And The transaction fees are "0.010000000"
+    And The transaction fees are "0.001100000"
     And I click on the next button in the wallet send form
     And I see send money confirmation dialog
     And I enter the wallet password:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",


### PR DESCRIPTION
Fixes the following issues:

1) Changed the minimum box entry to be `0.01` for tokens (reset the fee back to what it was before)
2) Fix the way decimals are handled in the "total" field of the send page
![image](https://user-images.githubusercontent.com/2608559/105357625-6ce80100-5c38-11eb-839c-d024eda29d00.png)
3) Reset the amount field if the user switches which token to use
4) Use the ID as the name on the token dropdown if no name is present
![image](https://user-images.githubusercontent.com/2608559/105357432-2db9b000-5c38-11eb-9d42-328c41448d23.png)
5) Ellipsize token names when they are too long
![image](https://user-images.githubusercontent.com/2608559/105357756-9e60cc80-5c38-11eb-8f70-625908cdad5a.png)
