### PR TITLE
fix occasional incorrect asset order in box

### DIFF
--- a/app/api/ada/lib/storage/database/primitives/api/read.js
+++ b/app/api/ada/lib/storage/database/primitives/api/read.js
@@ -1210,6 +1210,7 @@ export class AssociateToken {
       if (ListId == null) continue;
       const entries = result.get(ListId) ?? [];
       entries.push(row);
+      entries.sort((a,b) => a.TokenListItemId - b.TokenListItemId);
       result.set(ListId, entries);
     }
 
@@ -1252,6 +1253,6 @@ export class AssociateToken {
       Token: $ReadOnly<TokenRow>,
     |}> = await tx.attach(query);
 
-    return result;
+    return [...result].sort((a,b) => a.TokenList.TokenListItemId - b.TokenList.TokenListItemId);
   }
 }

--- a/app/api/ada/lib/storage/database/primitives/api/write.js
+++ b/app/api/ada/lib/storage/database/primitives/api/write.js
@@ -731,7 +731,7 @@ export class ModifyTokenList {
       ModifyTokenList.ownTables[Tables.TokenListSchema.name].name,
     );
 
-    return result;
+    return [...result].sort((a, b) => a.TokenListItemId - b.TokenListItemId);
   }
 
   static async remove(


### PR DESCRIPTION
This bug was caused by some missing sort calls to make sure the assets in a box created by Yoroi matches the order they appear originally on-chain (since the asset list is order sensitive)

Without these sort commands, the order of the results depends on the underlying indexeddb calls.

I added a E2E test that has a box with multiple assets, but this test doesn't actually catch this error. In practice, it looks like this bug can't be reproduced with any single box and it only manifests when the tx history contains multiple transactions at which case something probably happens under the hood in indexeddb which isn't hard to replicate inside an E2E test.

In practice this fix is both logical and I tested that it fixes the issue on the tx history of somebody affected by this bug.