### PR TITLE
Update explorer links

### DIFF
--- a/app/api/ada/lib/storage/database/explorers/tables.js
+++ b/app/api/ada/lib/storage/database/explorers/tables.js
@@ -8,6 +8,8 @@ export const Link = Object.freeze({
   address: 'address',
   transaction: 'transaction',
   pool: 'pool',
+  stakeAddress: 'stakeAddress',
+  token: 'token',
 });
 export type LinkType = $Values<typeof Link>;
 

--- a/app/api/ada/lib/storage/database/prepackaged/explorers.js
+++ b/app/api/ada/lib/storage/database/prepackaged/explorers.js
@@ -7,6 +7,40 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
   {
     ExplorerId: 1_00,
     NetworkId: networks.CardanoMainnet.NetworkId,
+    IsBackup: true,
+    Endpoints: {
+      address: 'https://cardanoscan.io/address/',
+      transaction: 'https://cardanoscan.io/transaction/',
+      pool: 'https://cardanoscan.io/pool/',
+      stakeAddress: 'https://cardanoscan.io/stakeKey/',
+      token: 'https://cardanoscan.io/token/',
+    },
+    Name: 'CardanoScan',
+  },
+  {
+    ExplorerId: 1_01,
+    NetworkId: networks.CardanoMainnet.NetworkId,
+    IsBackup: false,
+    Endpoints: {
+      address: 'https://adastat.net/addresses/',
+      transaction: 'https://adastat.net/transactions/',
+      pool: 'https://adastat.net/pools/',
+    },
+    Name: 'AdaStat',
+  },
+  {
+    ExplorerId: 1_02,
+    NetworkId: networks.CardanoMainnet.NetworkId,
+    IsBackup: false,
+    Endpoints: {
+      address: 'https://explorer.cardano.org/en/address?address=',
+      transaction: 'https://explorer.cardano.org/en/transaction?id=',
+    },
+    Name: 'CardanoExplorer',
+  },
+  {
+    ExplorerId: 1_03,
+    NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
       address: 'https://adaex.org/',
@@ -16,17 +50,7 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     Name: 'ADAex.org',
   },
   {
-    ExplorerId: 1_01,
-    NetworkId: networks.CardanoMainnet.NetworkId,
-    IsBackup: false,
-    Endpoints: {
-      address: 'https://adascan.net/address/',
-      transaction: 'https://adascan.net/transaction/',
-    },
-    Name: 'AdaScan',
-  },
-  {
-    ExplorerId: 1_02,
+    ExplorerId: 1_04,
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
@@ -34,24 +58,6 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
       transaction: 'https://blockchair.com/cardano/transaction/',
     },
     Name: 'Blockchair',
-  },
-  {
-    ExplorerId: 1_03,
-    NetworkId: networks.CardanoMainnet.NetworkId,
-    IsBackup: false,
-    Endpoints: {
-    },
-    Name: 'Clio.1',
-  },
-  {
-    ExplorerId: 1_04,
-    NetworkId: networks.CardanoMainnet.NetworkId,
-    IsBackup: false,
-    Endpoints: {
-      address: 'https://explorer.cardano.org/en/address?address=',
-      transaction: 'https://explorer.cardano.org/en/transaction?id=',
-    },
-    Name: 'CardanoExplorer',
   },
   {
     ExplorerId: 1_05,
@@ -67,33 +73,11 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
   {
     ExplorerId: 1_06,
     NetworkId: networks.CardanoMainnet.NetworkId,
-    IsBackup: true,
-    Endpoints: {
-      address: 'https://cardanoscan.io/address/',
-      transaction: 'https://cardanoscan.io/transaction/',
-      pool: 'https://cardanoscan.io/pool/',
-    },
-    Name: 'CardanoScan',
-  },
-  {
-    ExplorerId: 1_07,
-    NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
       pool: 'https://pooltool.io/pool/',
     },
     Name: 'PoolTool',
-  },
-  {
-    ExplorerId: 1_08,
-    NetworkId: networks.CardanoMainnet.NetworkId,
-    IsBackup: false,
-    Endpoints: {
-      address: 'https://adastat.net/addresses/',
-      transaction: 'https://adastat.net/transactions/',
-      pool: 'https://adastat.net/pools/',
-    },
-    Name: 'AdaStat',
   },
 ];
 

--- a/app/api/ada/lib/storage/database/prepackaged/explorers.js
+++ b/app/api/ada/lib/storage/database/prepackaged/explorers.js
@@ -5,7 +5,7 @@ import type { ExplorerRow } from '../explorers/tables';
 
 const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
   {
-    ExplorerId: 1_00,
+    ExplorerId: 1_06,
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: true,
     Endpoints: {
@@ -18,10 +18,11 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     Name: 'CardanoScan',
   },
   {
-    ExplorerId: 1_01,
+    ExplorerId: 1_08,
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
+      stakeAddress: 'https://adastat.net/addresses/',
       address: 'https://adastat.net/addresses/',
       transaction: 'https://adastat.net/transactions/',
       pool: 'https://adastat.net/pools/',
@@ -29,7 +30,7 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     Name: 'AdaStat',
   },
   {
-    ExplorerId: 1_02,
+    ExplorerId: 1_04,
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
@@ -39,10 +40,11 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     Name: 'CardanoExplorer',
   },
   {
-    ExplorerId: 1_03,
+    ExplorerId: 1_00,
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
+      stakeAddress: 'https://adaex.org/',
       address: 'https://adaex.org/',
       transaction: 'https://adaex.org/',
       pool: 'https://adapools.org/pool/',
@@ -50,7 +52,7 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     Name: 'ADAex.org',
   },
   {
-    ExplorerId: 1_04,
+    ExplorerId: 1_02,
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
@@ -64,6 +66,7 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {
+      stakeAddress: 'https://adapools.org/stake/',
       address: 'https://adapools.org/address/',
       transaction: 'https://adapools.org/transactions/',
       pool: 'https://adapools.org/pool/',
@@ -71,7 +74,7 @@ const CardanoMainnetExplorers: Array<$ReadOnly<ExplorerRow>> = [
     Name: 'ADApools',
   },
   {
-    ExplorerId: 1_06,
+    ExplorerId: 1_07,
     NetworkId: networks.CardanoMainnet.NetworkId,
     IsBackup: false,
     Endpoints: {

--- a/app/api/ada/lib/storage/tests/__snapshots__/index.test.js.snap
+++ b/app/api/ada/lib/storage/tests/__snapshots__/index.test.js.snap
@@ -681,40 +681,27 @@ Object {
   "Explorer": Array [
     Object {
       "Endpoints": Object {
-        "address": "https://adaex.org/",
-        "pool": "https://adapools.org/pool/",
-        "transaction": "https://adaex.org/",
+        "address": "https://cardanoscan.io/address/",
+        "pool": "https://cardanoscan.io/pool/",
+        "stakeAddress": "https://cardanoscan.io/stakeKey/",
+        "token": "https://cardanoscan.io/token/",
+        "transaction": "https://cardanoscan.io/transaction/",
       },
-      "ExplorerId": 100,
-      "IsBackup": false,
-      "Name": "ADAex.org",
+      "ExplorerId": 106,
+      "IsBackup": true,
+      "Name": "CardanoScan",
       "NetworkId": 0,
     },
     Object {
       "Endpoints": Object {
-        "address": "https://adascan.net/address/",
-        "transaction": "https://adascan.net/transaction/",
+        "address": "https://adastat.net/addresses/",
+        "pool": "https://adastat.net/pools/",
+        "stakeAddress": "https://adastat.net/addresses/",
+        "transaction": "https://adastat.net/transactions/",
       },
-      "ExplorerId": 101,
+      "ExplorerId": 108,
       "IsBackup": false,
-      "Name": "AdaScan",
-      "NetworkId": 0,
-    },
-    Object {
-      "Endpoints": Object {
-        "address": "https://blockchair.com/cardano/address/",
-        "transaction": "https://blockchair.com/cardano/transaction/",
-      },
-      "ExplorerId": 102,
-      "IsBackup": false,
-      "Name": "Blockchair",
-      "NetworkId": 0,
-    },
-    Object {
-      "Endpoints": Object {},
-      "ExplorerId": 103,
-      "IsBackup": false,
-      "Name": "Clio.1",
+      "Name": "AdaStat",
       "NetworkId": 0,
     },
     Object {
@@ -729,8 +716,31 @@ Object {
     },
     Object {
       "Endpoints": Object {
+        "address": "https://adaex.org/",
+        "pool": "https://adapools.org/pool/",
+        "stakeAddress": "https://adaex.org/",
+        "transaction": "https://adaex.org/",
+      },
+      "ExplorerId": 100,
+      "IsBackup": false,
+      "Name": "ADAex.org",
+      "NetworkId": 0,
+    },
+    Object {
+      "Endpoints": Object {
+        "address": "https://blockchair.com/cardano/address/",
+        "transaction": "https://blockchair.com/cardano/transaction/",
+      },
+      "ExplorerId": 102,
+      "IsBackup": false,
+      "Name": "Blockchair",
+      "NetworkId": 0,
+    },
+    Object {
+      "Endpoints": Object {
         "address": "https://adapools.org/address/",
         "pool": "https://adapools.org/pool/",
+        "stakeAddress": "https://adapools.org/stake/",
         "transaction": "https://adapools.org/transactions/",
       },
       "ExplorerId": 105,
@@ -740,33 +750,11 @@ Object {
     },
     Object {
       "Endpoints": Object {
-        "address": "https://cardanoscan.io/address/",
-        "pool": "https://cardanoscan.io/pool/",
-        "transaction": "https://cardanoscan.io/transaction/",
-      },
-      "ExplorerId": 106,
-      "IsBackup": true,
-      "Name": "CardanoScan",
-      "NetworkId": 0,
-    },
-    Object {
-      "Endpoints": Object {
         "pool": "https://pooltool.io/pool/",
       },
       "ExplorerId": 107,
       "IsBackup": false,
       "Name": "PoolTool",
-      "NetworkId": 0,
-    },
-    Object {
-      "Endpoints": Object {
-        "address": "https://adastat.net/addresses/",
-        "pool": "https://adastat.net/pools/",
-        "transaction": "https://adastat.net/transactions/",
-      },
-      "ExplorerId": 108,
-      "IsBackup": false,
-      "Name": "AdaStat",
       "NetworkId": 0,
     },
     Object {

--- a/app/components/transfer/TransferSummaryPage.js
+++ b/app/components/transfer/TransferSummaryPage.js
@@ -176,7 +176,7 @@ export default class TransferSummaryPage extends Component<Props> {
                       selectedExplorer={this.props.selectedExplorer}
                       light
                       hash={this.props.addressToDisplayString(deregistration.rewardAddress)}
-                      linkType="address"
+                      linkType="stakeAddress"
                     >
                       <RawHash light>
                         <span className={addressesClasses}>

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -39,7 +39,7 @@ import { hiddenAmount } from '../../../utils/strings';
 import type {
   TokenLookupKey, TokenEntry,
 } from '../../../api/common/lib/MultiToken';
-import { getTokenName } from '../../../stores/stateless/tokenHelpers';
+import { getTokenName, getTokenIdentifierIfExists } from '../../../stores/stateless/tokenHelpers';
 import type { UnitOfAccountSettingType } from '../../../types/unitOfAccountType';
 import { parseMetadata, parseMetadataDetailed } from '../../../api/ada/lib/storage/bridge/metadataUtils';
 import CodeBlock from '../../widgets/CodeBlock';
@@ -379,6 +379,14 @@ export default class Transaction extends Component<Props, State> {
     return truncateToken(getTokenName(tokenInfo));
   };
 
+  getFingerprint: TokenEntry => string | void = tokenEntry => {
+    const tokenInfo = this.props.getTokenInfo(tokenEntry);
+    if (tokenInfo.Metadata.type === 'Cardano') {
+      return getTokenIdentifierIfExists(tokenInfo);
+    }
+    return undefined;
+  }
+
   renderRow: {|
     kind: string,
     data: WalletTransaction,
@@ -389,6 +397,7 @@ export default class Transaction extends Component<Props, State> {
     const notificationElementId = `${request.kind}-address-${request.addressIndex}-${request.data.txid}-copyNotification`;
     const divKey = (identifier) => `${request.data.txid}-${request.kind}-${request.address.address}-${request.addressIndex}-${identifier}`;
     const renderAmount = (entry) => {
+      const fingerprint = this.getFingerprint(entry);
       return (
         <div className={styles.fee}>
           {this.renderAmountDisplay({
@@ -398,7 +407,17 @@ export default class Transaction extends Component<Props, State> {
                 ? request.transform(entry.amount)
                 : entry.amount,
             },
-          })} {this.getTicker(entry)}
+          })}
+          {' '}
+          { fingerprint !== undefined ? (
+            <ExplorableHashContainer
+              selectedExplorer={this.props.selectedExplorer}
+              hash={fingerprint}
+              light
+              linkType="token"
+              ><span className={styles.rowData}>{this.getTicker(entry)}</span></ExplorableHashContainer>  
+          ): this.getTicker(entry)}
+          
         </div>
       );
     };

--- a/app/components/wallet/transactions/Transaction.js
+++ b/app/components/wallet/transactions/Transaction.js
@@ -415,7 +415,9 @@ export default class Transaction extends Component<Props, State> {
               hash={fingerprint}
               light
               linkType="token"
-              ><span className={styles.rowData}>{this.getTicker(entry)}</span></ExplorableHashContainer>  
+            >
+              <span className={styles.rowData}>{this.getTicker(entry)}</span>
+            </ExplorableHashContainer>
           ): this.getTicker(entry)}
           
         </div>


### PR DESCRIPTION
<img width="675" alt="Screenshot 2021-02-27 at 1 11 55 AM" src="https://user-images.githubusercontent.com/11515811/109347366-16a25980-7899-11eb-8066-dfd8ee1a9704.png">

- Makes only the token name part clickable to visit the explorer for token details. When the amount is bigger, this would be neat to click.
- ADA and Ergo tokens will not have the link