### PR TITLE
Connector: Whitelist storage fix

### DIFF
--- a/app/ergo-connector/containers/ConnectContainer.js
+++ b/app/ergo-connector/containers/ConnectContainer.js
@@ -50,9 +50,9 @@ export default class ConnectContainer extends Component<
     const chromeMessage = this.generated.stores.connector.connectingMessage;
 
     chrome.storage.local.get('connector_whitelist', async result => {
-      const whitelist = Object.keys(result).length === 0 ? [] : result.connector_whitelist;
+      const whitelist = Object.keys(result).length === 0 ? [] : JSON.parse(result.connector_whitelist);
       whitelist.push({ url: chromeMessage?.url, walletIndex });
-      chrome.storage.local.set({ connector_whitelist: whitelist });
+      chrome.storage.local.set({ connector_whitelist: JSON.stringify(whitelist) });
     });
 
     chrome.runtime.sendMessage({


### PR DESCRIPTION
Via the Local Storage api we are storing as strings and doing json
parse/stringify to get to from that to WhitelistEntry, however we access
the whitelist in 2 areas that are not using this:
1) background.js (does not init any stores/api/etc)
2) ConnectContainer.js - I'm not sure if we have access to
   ConnectorStore from here so I just kept the raw chrome.storage.local
   API call here.

We converted to/from JSON strings in (1) like with the Local Storage API, but not in (2)