### PR TITLE
Connector full api

### DIFF
--- a/packages/yoroi-ergo-connector/example/index.js
+++ b/packages/yoroi-ergo-connector/example/index.js
@@ -84,7 +84,7 @@ if (typeof ergo_request_read_access === "undefined") {
                     const changeValue = utxosValue - amountToSend - wasm.TxBuilder.SUGGESTED_TX_FEE().as_i64().as_num();
                     console.log(`${changeValue} | cv.ts() = ${changeValue.toString()}`);
                     const changeValueBoxValue = wasm.BoxValue.from_i64(wasm.I64.from_str(changeValue.toString()));
-                    const changeAddr = (await ergo.get_unused_addresses())[0];
+                    const changeAddr = await ergo.get_change_address();
                     console.log(`changeAddr = ${JSON.stringify(changeAddr)}`);
                     const selector = new wasm.SimpleBoxSelector();
                     const boxSelection = selector.select(

--- a/packages/yoroi-ergo-connector/inject.js
+++ b/packages/yoroi-ergo-connector/inject.js
@@ -1,5 +1,3 @@
-// replace "*" with location.origin before committing on all postMessage calls
-
 // sets up RPC communication with the connector + access check/request functions
 const initialInject = `
 var timeout = 0;
@@ -23,9 +21,17 @@ function ergo_request_read_access() {
         return new Promise(function(resolve, reject) {
             window.postMessage({
                 type: "connector_connect_request",
-            }, "*");
+            }, location.origin);
             connectRequests.push({ resolve: resolve, reject: reject });
         });
+    }
+}
+
+function ergo_check_read_access() {
+    if (typeof ergo !== "undefined") {
+        return ergo._ergo_rpc_call("ping", []);
+    } else {
+        return Promise.resolve(false);
     }
 }
 
@@ -105,16 +111,15 @@ class ErgoAPI {
         return this._ergo_rpc_call("sign_tx_input", [tx, index]);
     }
 
-    sign_data(addr, message) {
-        return this._ergo_rpc_call("sign_data", [addr, message]);
-    }
+    // This is unsupported by current version of Yoroi
+    // and the details of it are not finalized yet in the EIP-012
+    // dApp bridge spec.
+    // sign_data(addr, message) {
+    //     return this._ergo_rpc_call("sign_data", [addr, message]);
+    // }
 
     submit_tx(tx) {
         return this._ergo_rpc_call("submit_tx", [tx]);
-    }
-
-    add_external_box(box_id) {
-        return this._ergo_rpc_call("add_external_box", [box_id]);
     }
 
     _ergo_rpc_call(func, params) {
@@ -124,7 +129,7 @@ class ErgoAPI {
                 uid: rpcUid,
                 function: func,
                 params: params
-            }, "*");
+            }, location.origin);
             console.log("rpcUid = " + rpcUid);
             rpcResolver.set(rpcUid, { resolve: resolve, reject: reject });
             rpcUid += 1;
@@ -169,7 +174,7 @@ if (shouldInject()) {
     yoroiPort.onMessage.addListener(message => {
         //alert("content script message: " + JSON.stringify(message));
         if (message.type == "connector_rpc_response") {
-            window.postMessage(message, "*");
+            window.postMessage(message, location.origin);
         } else if (message.type == "yoroi_connect_response") {
             if (message.success) {
                 // inject full API here
@@ -183,7 +188,7 @@ if (shouldInject()) {
             window.postMessage({
                 type: "connector_connected",
                 success: message.success
-            }, "*");
+            }, location.origin);
         }
     });
 

--- a/packages/yoroi-ergo-connector/inject.js
+++ b/packages/yoroi-ergo-connector/inject.js
@@ -93,6 +93,10 @@ class ErgoAPI {
         return this._ergo_rpc_call("get_unused_addresses", []);
     }
 
+    get_change_address() {
+        return this._ergo_rpc_call("get_change_address", []);
+    }
+
     sign_tx(tx) {
         return this._ergo_rpc_call("sign_tx", [tx]);
     }

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -26,6 +26,7 @@ import type {
 } from './ergo-connector/types';
 import {
   connectorGetBalance,
+  connectorGetChangeAddress,
   connectorGetUtxos,
   connectorSendTx,
   connectorSignTx,
@@ -477,9 +478,13 @@ chrome.runtime.onConnectExternal.addListener(port => {
             }
             break;
           case `get_change_address`:
-            rpcResponse({
-              ok: ['9fYK9twHtAfPj6xspbX9emk2E7YmrrDH3PVSBaTzZ3TeSrxWEXv']
-            });
+            {
+              const wallet = await getSelectedWallet(tabId);
+              const change = await connectorGetChangeAddress(wallet);
+              rpcResponse({
+                ok: change
+              });
+            }
             break;
           case 'submit_tx':
             try {

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -500,11 +500,6 @@ chrome.runtime.onConnectExternal.addListener(port => {
               });
             }
             break;
-          case 'add_external_box':
-            rpcResponse({
-              ok: true
-            });
-            break;
           case 'ping':
             rpcResponse({
               ok: true,


### PR DESCRIPTION
Injected API changes:

`sign_data` will be implemented later but the EIP-012 spec is still a WIP
with regard to it so we don't even try and support it lest we end up
with dApps using a version of it that might get changed

`add_external_box` will be removed from the EIP-012 spec

`ergo_check_read_access` was implemented here - timeout logic will be applied
in a later PR for all ergo RPCs so in the case something goes wrong it
will be automatically handled there

`get_change_address` was added as it is a pretty useful endpoint instead of trying to use `get_used_addresses` and/or `get_unused_addresses`.

the "*" origins were temporary for local testing on file:// before but now even the test
dApp isn't using the file:// location so we have no reason to use "*",
as that was the reason it was temporarily set to that before. This also improves privacy.