### PR TITLE
Fix unsorted rewards

### DIFF
--- a/packages/yoroi-extension/app/stores/ada/AdaDelegationStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaDelegationStore.js
@@ -73,17 +73,19 @@ export default class AdaDelegationStore extends Store<StoresMap, ActionsMap> {
 
         const defaultToken = publicDeriver.getParent().getDefaultToken();
         // flowlint-next-line unnecessary-optional-chain:off
-        const addressRewards = historyResult[address]?.map(info => (
-          ([info.epoch, new MultiToken(
-            [{
-              amount: new BigNumber(info.reward),
-              identifier: defaultToken.defaultIdentifier,
-              networkId: defaultToken.defaultNetworkId,
-            }],
-            defaultToken
-          ),
-          info.poolHash]: [number, MultiToken, string])
-        ));
+        const addressRewards = historyResult[address]
+          ?.sort((a,b) => a.epoch - b.epoch)
+          ?.map(info => (
+            ([info.epoch, new MultiToken(
+              [{
+                amount: new BigNumber(info.reward),
+                identifier: defaultToken.defaultIdentifier,
+                networkId: defaultToken.defaultNetworkId,
+              }],
+              defaultToken
+            ),
+            info.poolHash]: [number, MultiToken, string])
+          ));
         return addressRewards != null
           ? addressRewards
           : [];

--- a/packages/yoroi-extension/app/stores/jormungandr/JormungandrDelegationStore.js
+++ b/packages/yoroi-extension/app/stores/jormungandr/JormungandrDelegationStore.js
@@ -66,16 +66,18 @@ export default class JormungandrDelegationStore extends Store<StoresMap, Actions
         const defaultToken = publicDeriver.getParent().getDefaultToken();
 
         // flowlint-next-line unnecessary-optional-chain:off
-        const addressRewards = historyResult[address]?.map(info => (
-          ([info[0], new MultiToken(
-            [{
-              amount: new BigNumber(info[1]),
-              identifier: defaultToken.defaultIdentifier,
-              networkId: defaultToken.defaultNetworkId,
-            }],
-            defaultToken
-          ), info[2]]: [number, MultiToken, string])
-        ));
+        const addressRewards = historyResult[address]
+          ?.sort((a,b) => a[0] - b[0])
+          ?.map(info => (
+            ([info[0], new MultiToken(
+              [{
+                amount: new BigNumber(info[1]),
+                identifier: defaultToken.defaultIdentifier,
+                networkId: defaultToken.defaultNetworkId,
+              }],
+              defaultToken
+            ), info[2]]: [number, MultiToken, string])
+          ));
         return addressRewards != null
           ? addressRewards
           : [];


### PR DESCRIPTION
When a rollback happens during an epoch transition, the backend may not give us the reward information in order. Therefore, we need to sort these on the Yoroi side