### PR TITLE
Add strict CSP for connector

### DIFF
--- a/packages/yoroi-ergo-connector/manifest/manifest.template.js
+++ b/packages/yoroi-ergo-connector/manifest/manifest.template.js
@@ -31,7 +31,7 @@ module.exports = ({
     "default_title": displayName,
     default_icon: icons,
   },
-  "content_security_policy": "default-src 'none'; style-src 'self'; script-src 'self'; connect-src 'none'; object-src 'none';",
+  "content_security_policy": "default-src 'none'; script-src 'self';",
   "permissions": [
     "activeTab",
     "storage"

--- a/packages/yoroi-ergo-connector/manifest/manifest.template.js
+++ b/packages/yoroi-ergo-connector/manifest/manifest.template.js
@@ -31,6 +31,7 @@ module.exports = ({
     "default_title": displayName,
     default_icon: icons,
   },
+  "content_security_policy": "default-src 'none'; style-src 'self'; script-src 'self'; connect-src 'none'; object-src 'none';",
   "permissions": [
     "activeTab",
     "storage"

--- a/packages/yoroi-extension/.storybook/webpack.config.js
+++ b/packages/yoroi-extension/.storybook/webpack.config.js
@@ -23,7 +23,6 @@ module.exports = async ({ config, mode } /*: {|
       networkName: ENV,
       nightly: isNightly,
       publicPath: './',
-      ergoConnectorExtensionId: '',
     })
     : devConfig.baseDevConfig(ENV, isNightly === 'true');
 


### PR DESCRIPTION
Since the connector extension itself doesn't do much other than inject code, we can basically just add a really strict CSP