### PR TITLE
Connector: Workaround to duplicatekey errors

### DIFF
--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -182,9 +182,11 @@ async function syncWallet(wallet: PublicDeriver<>): Promise<void> {
     const now = Date.now();
     if (lastSync.Time == null || now - lastSync.Time.getTime() > 30*1000) {
       if (syncing == null) {
-        await RustModule.load();
-        Logger.debug('sync started');
-        syncing = getStateFetcher()
+        syncing = RustModule.load()
+          .then(() => {
+            Logger.debug('sync started');
+            return getStateFetcher()
+          })
           .then(stateFetcher => updateTransactions(
             wallet.getDb(),
             wallet,

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -66,7 +66,28 @@ type PendingSign = {|
   resolve: any
 |}
 
-let db: ?lf$Database = null;
+// This is a temporary workaround to DB duplicate key constraint violations
+// that is happening when multiple DBs are loaded at the same time, or possibly
+// this one being loaded while Yoroi's main App is doing DB operations.
+let loadedDB: ?lf$Database = null;
+let dbPromise: ?Promise<lf$Database> = null;
+
+async function loadDB(): Promise<lf$Database> {
+  if (loadedDB == null) {
+    if (dbPromise == null) {
+      dbPromise = new Promise(resolve => {
+        loadLovefieldDB(schema.DataStoreType.INDEXED_DB).then(db => {
+          loadedDB = db;
+          return resolve(loadedDB);;
+        }).catch(err => {
+          Logger.error(`Failed to load DB: ${err}`);
+        });
+      });
+    }
+    return dbPromise;
+  }
+  return Promise.resolve(loadedDB);
+}
 
 type AccountIndex = number;
 
@@ -109,9 +130,7 @@ let pendingTxs: PendingTransaction[] = [];
 
 export async function getWalletsInfo(): Promise<AccountInfo[]> {
   try {
-    if (db == null) {
-      db = await loadLovefieldDB(schema.DataStoreType.INDEXED_DB);
-    }
+    const db = await loadDB();
     const wallets = await getWallets({ db });
     // information about each wallet to show to the user
     const accounts = [];
@@ -154,29 +173,48 @@ export async function getStateFetcher(): Promise<IFetcher> {
   )));
 }
 
+// This is a temporary workaround to DB duplicate key constraint violations
+// that is happening when multiple DBs are loaded at the same time, or possibly
+// this one being loaded while Yoroi's main App is doing DB operations.
+// Promise<void>
+let syncing: ?Promise<void> = null;
 async function syncWallet(wallet: PublicDeriver<>): Promise<void> {
   try {
     const lastSync = await wallet.getLastSyncInfo();
     // don't sync more than every 30 seconds
     const now = Date.now();
     if (lastSync.Time == null || now - lastSync.Time.getTime() > 30*1000) {
-      const stateFetcher = await getStateFetcher();
-      await RustModule.load();
-      await updateTransactions(
-        wallet.getDb(),
-        wallet,
-        stateFetcher.checkAddressesInUse,
-        stateFetcher.getTransactionsHistoryForAddresses,
-        stateFetcher.getAssetInfo,
-        stateFetcher.getBestBlock);
-      // to be safe we filter possibly accepted txs for up to 10 minutes
-      // this could be accepted in a variable amount of time due to Ergo's PoW
-      // but this is probably an okay amount. If it was not accepted then at worst
-      // the values are just temporarily withheld for a few minutes too long,
-      // and if it was accepted, then none of the UTXOs held would have been
-      // reuseable anyway.
-      pendingTxs = pendingTxs.filter(
-        pendingTx => Date.now() - pendingTx.submittedTime.getTime() <= 10*60*1000);
+      if (syncing == null) {
+        await RustModule.load();
+        syncing = new Promise(resolve => {
+          Logger.debug('sync started');
+          getStateFetcher()
+            .then(stateFetcher => updateTransactions(
+              wallet.getDb(),
+              wallet,
+              stateFetcher.checkAddressesInUse,
+              stateFetcher.getTransactionsHistoryForAddresses,
+              stateFetcher.getAssetInfo,
+              stateFetcher.getBestBlock))
+            .then(() => {
+              // to be safe we filter possibly accepted txs for up to 10 minutes
+              // this could be accepted in a variable amount of time due to Ergo's PoW
+              // but this is probably an okay amount. If it was not accepted then at worst
+              // the values are just temporarily withheld for a few minutes too long,
+              // and if it was accepted, then none of the UTXOs held would have been
+              // reuseable anyway.
+              pendingTxs = pendingTxs.filter(
+                pendingTx => Date.now() - pendingTx.submittedTime.getTime() <= 10*60*1000);
+              Logger.debug('sync ended');
+              syncing = null;
+              return resolve();
+            })
+            .catch(e => {
+              Logger.error(`Syncing failed: ${e}`);
+            });
+        });
+      }
+      await syncing;
     }
   } catch (e) {
     Logger.error(`Syncing failed: ${e}`);
@@ -191,9 +229,7 @@ export function getActiveSites(): Array<string> {
 }
 
 async function getSelectedWallet(tabId: number): Promise<PublicDeriver<>> {
-  if (db == null) {
-    db = await loadLovefieldDB(schema.DataStoreType.INDEXED_DB);
-  }
+  const db = await loadDB();
   const wallets = await getWallets({ db });
   const connected = connectedSites.get(tabId);
   if (connected) {


### PR DESCRIPTION
The multiple DB loads as until loadLovefieldDB() returned, db was still
null, causing it to be loaded again if any other requests for the DB
were made during this time.

I think this was part of the cause of the duplicate key errors, such as:
Constraint error: (201) Duplicate keys are not allowed, index: Key.pkKey, key: 3

This could result in very bad issues when we also had multiple syncs at
the same time from the connector.

We can look into this later but this should at least avoid this error, or at least make it far, far less likely to get, until we can figure out the root cause.