### PR TITLE
Fix multi-background page problem in connector

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
-      - run: cd packages
-      - run: cd yoroi-extension
+      - run: cd packages/yoroi-extension
       - run: npm install
       - name: Build
         run: npm run prod:nightly

--- a/packages/yoroi-ergo-connector/src/background.js
+++ b/packages/yoroi-ergo-connector/src/background.js
@@ -1,4 +1,5 @@
 
+// note: we send a message instead of a browser action because the UI is managed by the Yoroi extension -- not be the connector
 chrome.browserAction.onClicked.addListener(function() {
     chrome.runtime.sendMessage(extensionId, { type: "open_browseraction_menu" });
 });

--- a/packages/yoroi-extension/app/ergo-connector/actions/connector-actions.js
+++ b/packages/yoroi-extension/app/ergo-connector/actions/connector-actions.js
@@ -6,6 +6,7 @@ import type { WhitelistEntry } from '../../../chrome/extension/ergo-connector/ty
 export default class ConnectorActions {
   getResponse: AsyncAction<void> = new AsyncAction();
   getSigningMsg: AsyncAction<void> = new AsyncAction();
+  refreshActiveSites: AsyncAction<void> = new AsyncAction();
   getWallets: Action<void> = new Action();
   closeWindow: Action<void> = new Action();
   getConnectorWhitelist: AsyncAction<void> = new AsyncAction();

--- a/packages/yoroi-extension/app/ergo-connector/containers/ConnectWebsitesContainer.js
+++ b/packages/yoroi-extension/app/ergo-connector/containers/ConnectWebsitesContainer.js
@@ -23,6 +23,7 @@ export default class ConnectWebsitesContainer extends Component<
 > {
   async componentDidMount() {
     this.generated.actions.connector.getWallets.trigger();
+    this.generated.actions.connector.refreshActiveSites.trigger();
     await this.generated.actions.connector.getConnectorWhitelist.trigger();
   }
 
@@ -61,7 +62,7 @@ export default class ConnectWebsitesContainer extends Component<
           accounts={this.generated.stores.connector.currentConnectorWhitelist}
           wallets={wallets}
           onRemoveWallet={this.onRemoveWallet}
-          activeSites={this.generated.stores.connector.activeSites}
+          activeSites={this.generated.stores.connector.activeSites.sites}
         />
       );
     }
@@ -73,6 +74,9 @@ export default class ConnectWebsitesContainer extends Component<
       connector: {|
         getWallets: {|
           trigger: (params: void) => void,
+        |},
+        refreshActiveSites: {|
+          trigger: (params: void) => Promise<void>,
         |},
         removeWalletFromWhitelist: {|
           trigger: (params: string) => Promise<void>,
@@ -88,7 +92,7 @@ export default class ConnectWebsitesContainer extends Component<
         currentConnectorWhitelist: ?Array<WhitelistEntry>,
         loadingWallets: $Values<typeof LoadingWalletStates>,
         errorWallets: string,
-        activeSites: Array<string>,
+        activeSites: {| sites: Array<string> |},
       |},
     |},
   |} {
@@ -112,6 +116,7 @@ export default class ConnectWebsitesContainer extends Component<
       actions: {
         connector: {
           getWallets: { trigger: actions.connector.getWallets.trigger },
+          refreshActiveSites: { trigger: actions.connector.refreshActiveSites.trigger },
           removeWalletFromWhitelist: {
             trigger: actions.connector.removeWalletFromWhitelist.trigger,
           },

--- a/packages/yoroi-extension/app/ergo-connector/containers/ConnectWebsitesContainer.stories.js
+++ b/packages/yoroi-extension/app/ergo-connector/containers/ConnectWebsitesContainer.stories.js
@@ -56,7 +56,7 @@ const genBaseProps: {|
     }]
     : [];
 
-  const activeSites = ['google.com'];
+  const activeSites = { sites: ['google.com'] };
 
   return {
     stores: {
@@ -72,6 +72,7 @@ const genBaseProps: {|
       connector: {
         getWallets: { trigger: action('getWallets') },
         removeWalletFromWhitelist: { trigger: async (req) => action('removeWalletFromWhitelist')(req) },
+        refreshActiveSites: { trigger: async (req) => action('refreshActiveSites')(req) },
         getConnectorWhitelist: { trigger: async (req) => action('getConnectorWhitelist')(req) },
       },
     },

--- a/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/always-return */
 // @flow
 import { observable, action, runInAction, computed } from 'mobx';
-import { getActiveSites, getWalletsInfo } from '../../../chrome/extension/utils';
+import { getWalletsInfo } from '../../../chrome/extension/utils';
 import Request from '../../stores/lib/LocalizedRequest';
 import Store from '../../stores/base/Store';
 import type {
@@ -11,6 +11,7 @@ import type {
   FailedSignData,
   SigningMessage,
   WhitelistEntry,
+  ConnectedSites,
 } from '../../../chrome/extension/ergo-connector/types';
 import type { ActionsMap } from '../actions/index';
 import type { StoresMap } from './index';
@@ -50,6 +51,20 @@ function sendMsgSigningTx(): Promise<SigningMessage> {
   });
 }
 
+function getConnectedSites(): Promise<ConnectedSites> {
+  return new Promise((resolve, reject) => {
+    if (!initedSigning)
+      window.chrome.runtime.sendMessage({ type: 'get_connected_sites' }, response => {
+        if (window.chrome.runtime.lastError) {
+          // eslint-disable-next-line prefer-promise-reject-errors
+          reject('Could not establish connection: get_connected_sites ');
+        }
+
+        resolve(response);
+      });
+  });
+}
+
 type GetWhitelistFunc = void => Promise<?Array<WhitelistEntry>>;
 type SetWhitelistFunc = {|
   whitelist: Array<WhitelistEntry> | void,
@@ -72,6 +87,12 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
     SetWhitelistFunc
   >(({ whitelist }) => this.api.localStorage.setWhitelist(whitelist));
 
+  @observable getConnectedSites: Request<
+    typeof getConnectedSites
+  > = new Request<typeof getConnectedSites>(
+    getConnectedSites
+  );
+
   @observable signingMessage: ?SigningMessage = null;
 
   setup(): void {
@@ -83,6 +104,7 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
     this.actions.connector.confirmSignInTx.listen(this._confirmSignInTx);
     this.actions.connector.cancelSignInTx.listen(this._cancelSignInTx);
     this.actions.connector.getSigningMsg.listen(this._getSigningMsg);
+    this.actions.connector.refreshActiveSites.listen(this._refreshActiveSites);
     this.actions.connector.closeWindow.listen(this._closeWindow);
     this._getConnectorWhitelist();
     this._getWallets();
@@ -217,8 +239,16 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
     await this.getConnectorWhitelist.execute();
   };
 
+  _refreshActiveSites: void => Promise<void> = async () => {
+    await this.getConnectedSites.execute();
+  }
+
   // ========== active websites ========== //
-  @computed get activeSites(): Array<string> {
-    return getActiveSites() ?? []
+  @computed get activeSites(): ConnectedSites {
+    let { result } = this.getConnectedSites;
+    if (result == null) {
+      result = this.getConnectedSites.execute().result;
+    }
+    return result ?? { sites: [] };
   }
 }

--- a/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/always-return */
 // @flow
 import { observable, action, runInAction, computed } from 'mobx';
-import { getActiveSites, getWalletsInfo } from '../../../chrome/extension/background';
+import { getActiveSites, getWalletsInfo } from '../../../chrome/extension/utils';
 import Request from '../../stores/lib/LocalizedRequest';
 import Store from '../../stores/base/Store';
 import type {

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -13,6 +13,9 @@ import {
 import type {
   PendingSignData,
   PendingTransaction,
+  SigningMessage,
+  ConnectingMessage,
+  ConnectedSites,
 } from './ergo-connector/types';
 import {
   APIErrorCodes,
@@ -216,10 +219,10 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
       for (const [/* uid */, responseData] of connection.pendingSigns.entries()) {
         if (!responseData.openedWindow) {
           responseData.openedWindow = true;
-          sendResponse({
+          sendResponse(({
             sign: responseData.request,
             tabId
-          });
+          }: SigningMessage));
           return;
         }
       }
@@ -231,14 +234,22 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
       if (connection.status != null && typeof connection.status === 'object') {
         if (!connection.status.openedWindow) {
           connection.status.openedWindow = true;
-          sendResponse({
+          sendResponse(({
             url: connection.url,
             tabId,
-          });
+          }: ConnectingMessage));
         }
       }
     }
     sendResponse(null);
+  } else if (request.type === 'get_connected_sites') {
+    const activeSites = []
+    for (const value of connectedSites.values()){
+      activeSites.push(value);
+    }
+    sendResponse(({
+      sites: activeSites.map(site => site.url),
+    }: ConnectedSites));
   }
 });
 

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -1,13 +1,6 @@
 // @flow
 import debounce from 'lodash/debounce';
 
-import { schema } from 'lovefield';
-import type {
-  lf$Database,
-} from 'lovefield';
-import {
-  loadLovefieldDB,
-} from '../../app/api/ada/lib/storage/database/index';
 import {
   getWallets
 } from '../../app/api/common/index';
@@ -16,13 +9,10 @@ import {
 } from '../../app/api/ada/lib/storage/models/PublicDeriver/index';
 import {
   asGetAllUtxos,
-  asGetPublicKey,
 } from '../../app/api/ada/lib/storage/models/PublicDeriver/traits';
 import type {
   PendingSignData,
   PendingTransaction,
-  RpcUid,
-  AccountInfo,
 } from './ergo-connector/types';
 import {
   APIErrorCodes,
@@ -42,11 +32,6 @@ import {
   connectorGetUsedAddresses,
   connectorGetUnusedAddresses
 } from './ergo-connector/api';
-import { GenericApiError } from '../../app/api/common/errors';
-import { isErgo, isCardanoHaskell, } from '../../app/api/ada/lib/storage/database/prepackaged/networks';
-import { Bip44Wallet } from '../../app/api/ada/lib/storage/models/Bip44Wallet/wrapper';
-import { walletChecksum, legacyWalletChecksum } from '@emurgo/cip4-js';
-import type { WalletChecksum } from '@emurgo/cip4-js';
 import { updateTransactions } from '../../app/api/ergo/lib/storage/bridge/updateTransactions';
 import { environment } from '../../app/environment';
 import { IFetcher } from '../../app/api/ergo/lib/state-fetch/IFetcher';
@@ -55,6 +40,8 @@ import { BatchedFetcher } from '../../app/api/ergo/lib/state-fetch/batchedFetche
 import LocalStorageApi from '../../app/api/localStorage/index';
 import { RustModule } from '../../app/api/ada/lib/cardanoCrypto/rustLoader';
 import { Logger } from '../../app/utils/logging';
+import { loadDB } from './utils';
+import type { AccountIndex, ConnectedSite } from './utils';
 
 /*::
 declare var chrome;
@@ -66,101 +53,12 @@ const onYoroiIconClicked = () => {
 
 chrome.browserAction.onClicked.addListener(debounce(onYoroiIconClicked, 500, { leading: true }));
 
-type PendingSign = {|
-  // data needed to complete the request
-  request: PendingSignData,
-  // if an opened window has been created for this request to show the user
-  openedWindow: boolean,
-  // resolve function from signRequest's Promise
-  resolve: any
-|}
-
-// This is a temporary workaround to DB duplicate key constraint violations
-// that is happening when multiple DBs are loaded at the same time, or possibly
-// this one being loaded while Yoroi's main App is doing DB operations.
-let loadedDB: ?lf$Database = null;
-let dbPromise: ?Promise<lf$Database> = null;
-
-async function loadDB(): Promise<lf$Database> {
-  if (loadedDB == null) {
-    if (dbPromise == null) {
-      dbPromise = loadLovefieldDB(schema.DataStoreType.INDEXED_DB)
-        .then(db => {
-          loadedDB = db;
-          return Promise.resolve(loadedDB);
-        });
-    }
-    return dbPromise;
-  }
-  return Promise.resolve(loadedDB);
-}
-
-type AccountIndex = number;
-
-// AccountIndex = successfully connected - which account the user selected
-// null = refused by user
-type ConnectedStatus = ?AccountIndex | {|
-  // response (?AccountIndex) - null means the user refused, otherwise the account they selected
-  resolve: any,
-  // if a window has fetched this to show to the user yet
-  openedWindow: boolean,
-|};
-
-type ConnectedSite = {|
-  url: string,
-  status: ConnectedStatus,
-  pendingSigns: Map<RpcUid, PendingSign>
-|};
-
-async function getChecksum(
-  publicDeriver: ReturnType<typeof asGetPublicKey>,
-): Promise<void | WalletChecksum> {
-  if (publicDeriver == null) return undefined;
-
-  const hash = (await publicDeriver.getPublicKey()).Hash;
-
-  const isLegacyWallet =
-    isCardanoHaskell(publicDeriver.getParent().getNetworkInfo()) &&
-    publicDeriver.getParent() instanceof Bip44Wallet;
-  const checksum = isLegacyWallet
-    ? legacyWalletChecksum(hash)
-    : walletChecksum(hash);
-
-  return checksum;
-}
-
 // tab id key
 const connectedSites: Map<number, ConnectedSite> = new Map();
 
 let pendingTxs: PendingTransaction[] = [];
 
-export async function getWalletsInfo(): Promise<AccountInfo[]> {
-  try {
-    const db = await loadDB();
-    const wallets = await getWallets({ db });
-    // information about each wallet to show to the user
-    const accounts = [];
-    for (const wallet of wallets) {
-      const conceptualWallet = wallet.getParent();
-      const withPubKey = asGetPublicKey(wallet);
-
-      const conceptualInfo = await conceptualWallet.getFullConceptualWalletInfo();
-      if (isErgo(conceptualWallet.getNetworkInfo())) {
-        const balance = await connectorGetBalance(wallet, pendingTxs, 'ERG');
-        accounts.push({
-          name: conceptualInfo.Name,
-          balance: balance.toString(),
-          checksum: await getChecksum(withPubKey)
-        });
-      }
-    }
-    return accounts;
-  } catch (error) {
-    throw new GenericApiError();
-  }
-}
-
-export async function getStateFetcher(): Promise<IFetcher> {
+async function getStateFetcher(): Promise<IFetcher> {
   // I don't think it's worth it to cache this? We only need it for syncs and sending tx
   const localStorgeApi = new LocalStorageApi();
   const locale = await localStorgeApi.getUserLocale() ?? 'en-US';
@@ -221,13 +119,6 @@ async function syncWallet(wallet: PublicDeriver<>): Promise<void> {
   } catch (e) {
     Logger.error(`Syncing failed: ${e}`);
   }
-}
-export function getActiveSites(): Array<string> {
-  const activeSites = []
-  for (const value of connectedSites.values()){
-    activeSites.push(value);
-  }
-  return activeSites.map(item => item.url);
 }
 
 async function getSelectedWallet(tabId: number): Promise<PublicDeriver<>> {

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/types.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/types.js
@@ -339,6 +339,9 @@ export type WhitelistEntry = {| url: string, walletIndex: number |};
 
 export type ConnectingMessage = {| tabId: number, url: string |};
 export type SigningMessage = {| sign: PendingSignData, tabId: number |};
+export type ConnectedSites = {|
+  sites: Array<string>,
+|};
 
 export type RpcUid = number;
 

--- a/packages/yoroi-extension/chrome/extension/utils.js
+++ b/packages/yoroi-extension/chrome/extension/utils.js
@@ -122,14 +122,3 @@ export async function getWalletsInfo(): Promise<AccountInfo[]> {
     throw new GenericApiError();
   }
 }
-
-export function getActiveSites(): Array<string> {
-  const activeSites = []
-  // TODO: can't get connected sites from background.js
-  // because it runs in a different context
-  const connectedSites = [];
-  for (const value of connectedSites.values()){
-    activeSites.push(value);
-  }
-  return activeSites.map(item => item.url);
-}

--- a/packages/yoroi-extension/chrome/extension/utils.js
+++ b/packages/yoroi-extension/chrome/extension/utils.js
@@ -1,0 +1,135 @@
+// @flow
+
+import { schema } from 'lovefield';
+import type {
+  lf$Database,
+} from 'lovefield';
+import {
+  loadLovefieldDB,
+} from '../../app/api/ada/lib/storage/database/index';
+import {
+  getWallets
+} from '../../app/api/common/index';
+import {
+  asGetPublicKey,
+} from '../../app/api/ada/lib/storage/models/PublicDeriver/traits';
+import type {
+  PendingSignData,
+  RpcUid,
+  AccountInfo,
+} from './ergo-connector/types';
+import {
+  connectorGetBalance,
+} from './ergo-connector/api';
+import { GenericApiError } from '../../app/api/common/errors';
+import { isErgo, isCardanoHaskell, } from '../../app/api/ada/lib/storage/database/prepackaged/networks';
+import { Bip44Wallet } from '../../app/api/ada/lib/storage/models/Bip44Wallet/wrapper';
+import { walletChecksum, legacyWalletChecksum } from '@emurgo/cip4-js';
+import type { WalletChecksum } from '@emurgo/cip4-js';
+
+/*::
+declare var chrome;
+*/
+
+type PendingSign = {|
+  // data needed to complete the request
+  request: PendingSignData,
+  // if an opened window has been created for this request to show the user
+  openedWindow: boolean,
+  // resolve function from signRequest's Promise
+  resolve: any
+|}
+
+// This is a temporary workaround to DB duplicate key constraint violations
+// that is happening when multiple DBs are loaded at the same time, or possibly
+// this one being loaded while Yoroi's main App is doing DB operations.
+let loadedDB: ?lf$Database = null;
+let dbPromise: ?Promise<lf$Database> = null;
+
+export async function loadDB(): Promise<lf$Database> {
+  if (loadedDB == null) {
+    if (dbPromise == null) {
+      dbPromise = loadLovefieldDB(schema.DataStoreType.INDEXED_DB)
+        .then(db => {
+          loadedDB = db;
+          return Promise.resolve(loadedDB);
+        });
+    }
+    return dbPromise;
+  }
+  return Promise.resolve(loadedDB);
+}
+
+export type AccountIndex = number;
+
+// AccountIndex = successfully connected - which account the user selected
+// null = refused by user
+type ConnectedStatus = ?AccountIndex | {|
+  // response (?AccountIndex) - null means the user refused, otherwise the account they selected
+  resolve: any,
+  // if a window has fetched this to show to the user yet
+  openedWindow: boolean,
+|};
+
+export type ConnectedSite = {|
+  url: string,
+  status: ConnectedStatus,
+  pendingSigns: Map<RpcUid, PendingSign>
+|};
+
+async function getChecksum(
+  publicDeriver: ReturnType<typeof asGetPublicKey>,
+): Promise<void | WalletChecksum> {
+  if (publicDeriver == null) return undefined;
+
+  const hash = (await publicDeriver.getPublicKey()).Hash;
+
+  const isLegacyWallet =
+    isCardanoHaskell(publicDeriver.getParent().getNetworkInfo()) &&
+    publicDeriver.getParent() instanceof Bip44Wallet;
+  const checksum = isLegacyWallet
+    ? legacyWalletChecksum(hash)
+    : walletChecksum(hash);
+
+  return checksum;
+}
+
+export async function getWalletsInfo(): Promise<AccountInfo[]> {
+  try {
+    const db = await loadDB();
+    const wallets = await getWallets({ db });
+    // information about each wallet to show to the user
+    const accounts = [];
+    for (const wallet of wallets) {
+      const conceptualWallet = wallet.getParent();
+      const withPubKey = asGetPublicKey(wallet);
+
+      const conceptualInfo = await conceptualWallet.getFullConceptualWalletInfo();
+      if (isErgo(conceptualWallet.getNetworkInfo())) {
+        // TODO: we can't get the pending txs from background.js from here
+        // since it runs in a different context. Need a better solution
+        const pendingTxs = [];
+        const balance = await connectorGetBalance(wallet, pendingTxs, 'ERG');
+        accounts.push({
+          name: conceptualInfo.Name,
+          balance: balance.toString(),
+          checksum: await getChecksum(withPubKey)
+        });
+      }
+    }
+    return accounts;
+  } catch (error) {
+    throw new GenericApiError();
+  }
+}
+
+export function getActiveSites(): Array<string> {
+  const activeSites = []
+  // TODO: can't get connected sites from background.js
+  // because it runs in a different context
+  const connectedSites = [];
+  for (const value of connectedSites.values()){
+    activeSites.push(value);
+  }
+  return activeSites.map(item => item.url);
+}


### PR DESCRIPTION
Due to the `ConnectorStore` including `background.js`, it was causing every Yoroi connector popup window to re-register all the Chrome listeners.

Problems that were caused by this:
- Clicking on the connector button opened two connector windows if you already had a connector window opened. This is because the onClick register was called twice (since there were two background pages)
- DB requests would cause weird issues. This is because all the DB requests were getting called twice (one for the real background page, one for the connector window's copy)