### PR TITLE
Fix tab close logic for connector

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/storage/adaMigration.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/adaMigration.js
@@ -19,7 +19,7 @@ import {
 } from '../../../../utils/logging';
 import satisfies from 'semver/functions/satisfies';
 import {
-  OPEN_TAB_ID_KEY,
+  TabIdKeys,
 } from '../../../../utils/tabManager';
 import { migrateFromStorageV1 } from './bridge/walletBuilder/byron';
 import { RustModule } from '../cardanoCrypto/rustLoader';
@@ -152,7 +152,7 @@ async function moveStorage(localStorageApi: LocalStorageApi): Promise<boolean> {
   if (oldStorage.length === 0) {
     return false;
   }
-  if (oldStorage.length === 1 && oldStorage[OPEN_TAB_ID_KEY] != null) {
+  if (oldStorage.length === 1 && oldStorage[TabIdKeys.Primary] != null) {
     // old storage may contain just the tab id
     // since this field is re-generated every time the app launches in the right storage
     // we can just clear it

--- a/packages/yoroi-extension/app/api/localStorage/index.js
+++ b/packages/yoroi-extension/app/api/localStorage/index.js
@@ -11,7 +11,7 @@ import {
     isEmptyStorage,
 } from './primitives';
 import {
-  OPEN_TAB_ID_KEY,
+  TabIdKeys,
 } from '../../utils/tabManager';
 import type { ComplexityLevelType } from '../../types/complexityLevelType';
 import type { WhitelistEntry } from '../../../chrome/extension/ergo-connector/types';
@@ -158,7 +158,8 @@ export default class LocalStorageApi {
     const storage = JSON.parse(await this.getStorage());
     await Object.keys(storage).forEach(async key => {
       // changing this key would cause the tab to close
-      if (key !== OPEN_TAB_ID_KEY) {
+      const isTabCloseKey = new Set(Object.values(TabIdKeys)).has(key);
+      if (!isTabCloseKey) {
         await removeLocalItem(key);
       }
     });
@@ -300,7 +301,8 @@ export default class LocalStorageApi {
   setStorage: { [key: string]: string, ... } => Promise<void> = async (localStorageData) => {
     await Object.keys(localStorageData).forEach(async key => {
       // changing this key would cause the tab to close
-      if (key !== OPEN_TAB_ID_KEY) {
+      const isTabCloseKey = new Set(Object.values(TabIdKeys)).has(key);
+      if (!isTabCloseKey) {
         await setLocalItem(key, localStorageData[key]);
       }
     });

--- a/packages/yoroi-extension/app/ergo-connector/stores/ConnectorLoadingStore.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/ConnectorLoadingStore.js
@@ -2,6 +2,9 @@
 import BaseLoadingStore from '../../stores/base/BaseLoadingStore';
 import type { ActionsMap } from '../../actions/index';
 import type { StoresMap } from './index';
+import {
+  TabIdKeys,
+} from '../../utils/tabManager';
 
 export default class ConnectorLoadingStore extends BaseLoadingStore<StoresMap, ActionsMap> {
 
@@ -11,5 +14,9 @@ export default class ConnectorLoadingStore extends BaseLoadingStore<StoresMap, A
 
   postLoadingScreenEnd(): void {
     super.postLoadingScreenEnd();
+  }
+
+  getTabIdKey(): string {
+    return TabIdKeys.ErgoConnector;
   }
 }

--- a/packages/yoroi-extension/app/stores/base/BaseLoadingStore.js
+++ b/packages/yoroi-extension/app/stores/base/BaseLoadingStore.js
@@ -42,7 +42,7 @@ export default class BaseLoadingStore<TStores, TActions> extends Store<TStores, 
         this.loadPersistentDbRequest.execute().promise
       ])
       .then(async () => {
-        await closeOtherInstances(); // TODO: make this generic
+        await closeOtherInstances(this.getTabIdKey.bind(this)()); // TODO: make this generic
         const persistentDb = this.loadPersistentDbRequest.result;
         if (persistentDb == null) throw new Error(`${nameof(BaseLoadingStore)}::${nameof(this.load)} load db was not loaded. Should never happen`);
         // TODO: does the logic in here still work if the connector is the one accessing the info?
@@ -82,6 +82,10 @@ export default class BaseLoadingStore<TStores, TActions> extends Store<TStores, 
 
   @computed get isLoading(): boolean {
     return !!this._loading;
+  }
+
+  getTabIdKey(): string {
+    throw new Error(`${nameof(BaseLoadingStore)}::${nameof(this.getTabIdKey)} child needs to override this function`);
   }
 
   async preLoadingScreenEnd(): Promise<void> {

--- a/packages/yoroi-extension/app/stores/toplevel/LoadingStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/LoadingStore.js
@@ -12,6 +12,9 @@ import { networks, defaultAssets } from '../../api/ada/lib/storage/database/prep
 import { getDefaultEntryToken } from './TokenInfoStore';
 import type { ActionsMap } from '../../actions/index';
 import type { StoresMap } from '../index';
+import {
+  TabIdKeys,
+} from '../../utils/tabManager';
 
 export default class LoadingStore extends BaseLoadingStore<StoresMap, ActionsMap> {
   /**
@@ -108,5 +111,9 @@ export default class LoadingStore extends BaseLoadingStore<StoresMap, ActionsMap
       };
     });
     this.actions.router.goToRoute.trigger({ route: ROUTES.ROOT });
+  }
+
+  getTabIdKey(): string {
+    return TabIdKeys.Primary;
   }
 }

--- a/packages/yoroi-extension/app/utils/tabManager.js
+++ b/packages/yoroi-extension/app/utils/tabManager.js
@@ -25,7 +25,10 @@ declare var chrome;
 /**
  * Name of key we use in localstorage to specify which tab is currently active
  */
-export const OPEN_TAB_ID_KEY = 'openTabId';
+export const TabIdKeys = Object.freeze({
+  Primary: 'openTabId',
+  ErgoConnector: 'openTabId-ErgoConnector',
+});
 const thisWindowId = Date.now().toString();
 
 /**
@@ -35,9 +38,11 @@ const thisWindowId = Date.now().toString();
  *
  * Note: this may cause two copies of Yoroi loading at the same time close each other
  */
-export function addCloseListener() {
+export function addCloseListener(
+  tabKeyId: $Values<typeof TabIdKeys>,
+) {
   addListener(changes => {
-    const newId = changes[OPEN_TAB_ID_KEY];
+    const newId = changes[tabKeyId];
     if (newId != null && newId.newValue !== thisWindowId) {
       // note: we don't need "tabs" permission to get or remove our own tab
       chrome.tabs.getCurrent(tab => chrome.tabs.remove(tab.id));
@@ -68,8 +73,10 @@ export function addCloseListener() {
  *
  * WARNING: You should call this function BEFORE making any other changes to localstorage
 */
-export async function closeOtherInstances() {
-  await setLocalItem(OPEN_TAB_ID_KEY, thisWindowId);
+export async function closeOtherInstances(
+  tabKeyId: $Values<typeof TabIdKeys>,
+) {
+  await setLocalItem(tabKeyId, thisWindowId);
 }
 
 export const handlersSettingUrl: string = 'chrome://settings/handlers';

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/index.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/index.js
@@ -13,7 +13,7 @@ import { Action } from '../../../app/actions/lib/Action';
 import App from '../../../app/ergo-connector/App';
 import '../../../app/themes/index.global.scss';
 import BigNumber from 'bignumber.js';
-import { addCloseListener } from '../../../app/utils/tabManager';
+import { addCloseListener, TabIdKeys } from '../../../app/utils/tabManager';
 
 // run MobX in strict mode
 configure({ enforceActions: 'always' });
@@ -47,6 +47,6 @@ const initializeErgoConnector: void => Promise<void> = async () => {
   render(<App stores={stores} actions={actions} history={history} />, root);
 };
 
-addCloseListener();
+addCloseListener(TabIdKeys.ErgoConnector);
 
 window.addEventListener('load', initializeErgoConnector);

--- a/packages/yoroi-extension/chrome/extension/index.js
+++ b/packages/yoroi-extension/chrome/extension/index.js
@@ -13,7 +13,7 @@ import { Action } from '../../app/actions/lib/Action';
 import App from '../../app/App';
 import '../../app/themes/index.global.scss';
 import BigNumber from 'bignumber.js';
-import { addCloseListener } from '../../app/utils/tabManager';
+import { addCloseListener, TabIdKeys } from '../../app/utils/tabManager';
 
 // run MobX in strict mode
 configure({ enforceActions: 'always' });
@@ -51,6 +51,6 @@ const initializeYoroi: void => Promise<void> = async () => {
   );
 };
 
-addCloseListener();
+addCloseListener(TabIdKeys.Primary);
 
 window.addEventListener('load', initializeYoroi);


### PR DESCRIPTION
Now if you open the connector when you already have a connector open, it will close the old window.