### PR TITLE
Handle version migration when launching connector

### DIFF
--- a/packages/yoroi-extension/app/api/common/index.js
+++ b/packages/yoroi-extension/app/api/common/index.js
@@ -24,7 +24,6 @@ import type {
   IDisplayCutoffPopFunc,
   IDisplayCutoffPopResponse,
 } from '../ada/lib/storage/models/PublicDeriver/interfaces';
-import { migrateToLatest } from '../ada/lib/storage/adaMigration';
 import { ConceptualWallet } from '../ada/lib/storage/models/ConceptualWallet/index';
 import type { IHasLevels } from '../ada/lib/storage/models/ConceptualWallet/interfaces';
 import WalletTransaction from '../../domain/WalletTransaction';
@@ -37,7 +36,6 @@ import type {
   GetBalanceRequest, GetBalanceResponse,
   SendTokenList,
 } from './types';
-import LocalStorageApi from '../localStorage/index';
 import type {
   IRenameFunc, IRenameRequest, IRenameResponse,
   IChangePasswordRequestFunc, IChangePasswordRequest, IChangePasswordResponse,
@@ -245,16 +243,6 @@ export default class CommonApi {
       if (error instanceof LocalizableError) throw error;
       throw new GenericApiError();
     }
-  }
-
-  async migrate(
-    localstorageApi: LocalStorageApi,
-    persistentDb: lf$Database,
-  ): Promise<boolean> {
-    return await migrateToLatest(
-      localstorageApi,
-      persistentDb,
-    );
   }
 
   async exportLocalDatabase(

--- a/packages/yoroi-extension/app/api/common/migration.js
+++ b/packages/yoroi-extension/app/api/common/migration.js
@@ -1,0 +1,45 @@
+// @flow
+
+import type { lf$Database, } from 'lovefield';
+import { migrateToLatest } from '../ada/lib/storage/adaMigration';
+import LocalStorageApi from '../localStorage/index';
+
+export type MigrationRequest = {|
+  localStorageApi: LocalStorageApi,
+  persistentDb: lf$Database,
+  currVersion: string,
+|}
+
+export const migrateNoRefresh: MigrationRequest => Promise<boolean> = async (migrationRequest) => {
+  const lastLaunchVersion = await migrationRequest.localStorageApi.getLastLaunchVersion();
+  if (lastLaunchVersion === migrationRequest.currVersion) {
+    return false;
+  }
+
+  const appliedMigration = await migrateToLatest(
+    migrationRequest.localStorageApi,
+    migrationRequest.persistentDb,
+  );
+
+  // update launch version in localstorage to avoid calling migration twice
+  await migrationRequest.localStorageApi.setLastLaunchVersion(migrationRequest.currVersion);
+
+  return appliedMigration;
+};
+
+export const migrateAndRefresh: MigrationRequest => Promise<void> = async (migrationRequest) => {
+  const appliedMigration = await migrateNoRefresh(migrationRequest);
+
+  /**
+   * If a single migration step happened, then we have have to reload the UI
+   * Systems like mobx and react may not notice that the data has changed under their feed
+   */
+  if (appliedMigration) {
+    window.location.reload();
+    // we want to block until the refresh closes our page
+    // if we don't block forever here,
+    // then Yoroi would start and may get in a bad state with migrations partially applied
+    // since reload is not a blocking call we just await on a timeout
+    await (new Promise(resolve => setTimeout(resolve, 5000 /* arbitrary high number */)));
+  }
+};

--- a/packages/yoroi-extension/app/api/index.js
+++ b/packages/yoroi-extension/app/api/index.js
@@ -1,5 +1,4 @@
 // @flow
-import type { lf$Database, } from 'lovefield';
 import CommonApi from './common/index';
 import AdaApi from './ada/index';
 import ErgoApi from './ergo/index';
@@ -28,36 +27,3 @@ export const setupApi: void => Promise<Api> = async () => ({
   export: new ExportApi(),
 });
 
-export type MigrationRequest = {|
-  api: Api,
-  persistentDb: lf$Database,
-  currVersion: string,
-|}
-
-export const migrate: MigrationRequest => Promise<void> = async (migrationRequest) => {
-  const lastLaunchVersion = await migrationRequest.api.localStorage.getLastLaunchVersion();
-  if (lastLaunchVersion === migrationRequest.currVersion) {
-    return;
-  }
-
-  const appliedMigration = await migrationRequest.api.common.migrate(
-    migrationRequest.api.localStorage,
-    migrationRequest.persistentDb,
-  );
-
-  // update launch version in localstorage to avoid calling migration twice
-  await migrationRequest.api.localStorage.setLastLaunchVersion(migrationRequest.currVersion);
-
-  /**
-   * If a single migration step happened, then we have have to reload the UI
-   * Systems like mobx and react may not notice that the data has changed under their feed
-   */
-  if (appliedMigration) {
-    window.location.reload();
-    // we want to block until the refresh closes our page
-    // if we don't block forever here,
-    // then Yoroi would start and may get in a bad state with migrations partially applied
-    // since reload is not a blocking call we just await on a timeout
-    await (new Promise(resolve => setTimeout(resolve, 5000 /* arbitrary high number */)));
-  }
-};


### PR DESCRIPTION
Migration code needs to be run when the connector is opened. The Yoroi Extension handles this by forcing a page refresh after the migration is over, but that flow doesn't work for the connector since refreshing the page would lose info about what the dApp was trying to do