### PR TITLE
Format assets on signing page

### DIFF
--- a/packages/yoroi-extension/app/api/common/lib/MultiToken.js
+++ b/packages/yoroi-extension/app/api/common/lib/MultiToken.js
@@ -5,22 +5,22 @@ import {
 } from 'bignumber.js';
 
 export type TokenLookupKey = {|
-  identifier: string,
+  +identifier: string,
   /**
     * note: avoid putting asset metadata here directly
     * since it can update over time so best not to cache it here
     */
-  networkId: number,
+  +networkId: number,
 |};
 
 export type TokenEntry = {|
   ...TokenLookupKey,
-  amount: BigNumber,
+  +amount: BigNumber,
 |};
 
 export type DefaultTokenEntry = {|
-  defaultNetworkId: number,
-  defaultIdentifier: string,
+  +defaultNetworkId: number,
+  +defaultIdentifier: string,
 |};
 
 export class MultiToken {

--- a/packages/yoroi-extension/app/components/topbar/NavWalletDetails.js
+++ b/packages/yoroi-extension/app/components/topbar/NavWalletDetails.js
@@ -33,7 +33,7 @@ type Props = {|
   +walletAmount: null | MultiToken,
   +infoText?: string,
   +showDetails?: boolean,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +defaultToken: $ReadOnly<TokenRow>,
 |};
 

--- a/packages/yoroi-extension/app/components/transfer/TransferSummaryPage.js
+++ b/packages/yoroi-extension/app/components/transfer/TransferSummaryPage.js
@@ -66,7 +66,7 @@ type Props = {|
   +error: ?LocalizableError,
   +form: ?Node,
   +unitOfAccountSetting: UnitOfAccountSettingType,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +getCurrentPrice: (from: string, to: string) => ?number,
   +addressToDisplayString: string => string,
   +addressLookup: ReturnType<typeof genAddressLookup>,

--- a/packages/yoroi-extension/app/components/uri/URIVerifyDialog.js
+++ b/packages/yoroi-extension/app/components/uri/URIVerifyDialog.js
@@ -48,7 +48,7 @@ type Props = {|
   +selectedExplorer: SelectedExplorer,
   +unitOfAccountSetting: UnitOfAccountSettingType,
   +getCurrentPrice: (from: string, to: string) => ?number,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
 |};
 
 @observer

--- a/packages/yoroi-extension/app/components/wallet/WalletReceive.js
+++ b/packages/yoroi-extension/app/components/wallet/WalletReceive.js
@@ -78,7 +78,7 @@ type Props = {|
   +onGeneratePaymentURI: void | (string => void),
   +shouldHideBalance: boolean,
   +unitOfAccountSetting: UnitOfAccountSettingType,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +addressBook: boolean,
 |};
 

--- a/packages/yoroi-extension/app/components/wallet/my-wallets/WalletDetails.js
+++ b/packages/yoroi-extension/app/components/wallet/my-wallets/WalletDetails.js
@@ -28,7 +28,7 @@ type Props = {|
   +rewards: null | void | MultiToken,
   +walletAmount: null | MultiToken,
   +infoText?: string,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
 |};
 
 @observer

--- a/packages/yoroi-extension/app/components/wallet/send/HWSendConfirmationDialog.js
+++ b/packages/yoroi-extension/app/components/wallet/send/HWSendConfirmationDialog.js
@@ -49,7 +49,7 @@ type Props = {|
   +error: ?LocalizableError,
   +onSubmit: void => PossiblyAsync<void>,
   +onCancel: void => void,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +unitOfAccountSetting: UnitOfAccountSettingType,
   +addressToDisplayString: string => string,
   +getCurrentPrice: (from: string, to: string) => ?number,

--- a/packages/yoroi-extension/app/components/wallet/send/WalletSendConfirmationDialog.js
+++ b/packages/yoroi-extension/app/components/wallet/send/WalletSendConfirmationDialog.js
@@ -50,7 +50,7 @@ type Props = {|
   +error: ?LocalizableError,
   +classicTheme: boolean,
   +unitOfAccountSetting: UnitOfAccountSettingType,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +getCurrentPrice: (from: string, to: string) => ?number,
 |};
 

--- a/packages/yoroi-extension/app/components/wallet/send/WalletSendForm.js
+++ b/packages/yoroi-extension/app/components/wallet/send/WalletSendForm.js
@@ -96,7 +96,7 @@ type Props = {|
   +resetUriParams: void => void,
   +showMemo: boolean,
   +onAddMemo: void => void,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +defaultToken: $ReadOnly<TokenRow>, // need since no guarantee input in non-null
   +onAddToken: (void | $ReadOnly<TokenRow>) => void,
   +spendableBalance: ?MultiToken,

--- a/packages/yoroi-extension/app/components/wallet/staking/DelegationTxDialog.js
+++ b/packages/yoroi-extension/app/components/wallet/staking/DelegationTxDialog.js
@@ -63,7 +63,7 @@ type Props = {|
   +selectedExplorer: SelectedExplorer,
   +poolName: null | string,
   +poolHash: string,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +amountToDelegate: MultiToken,
   +transactionFee: MultiToken,
   +approximateReward: {|

--- a/packages/yoroi-extension/app/components/wallet/staking/dashboard/UndelegateDialog.js
+++ b/packages/yoroi-extension/app/components/wallet/staking/dashboard/UndelegateDialog.js
@@ -45,7 +45,7 @@ const messages = defineMessages({
 type Props = {|
   +staleTx: boolean,
   +transactionFee: MultiToken,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +isSubmitting: boolean,
   +onCancel: void => void,
   +onSubmit: ({| password: string |}) => PossiblyAsync<void>,

--- a/packages/yoroi-extension/app/components/wallet/staking/dashboard/UserSummary.js
+++ b/packages/yoroi-extension/app/components/wallet/staking/dashboard/UserSummary.js
@@ -70,7 +70,7 @@ const messages = defineMessages({
 type Props = {|
   /** need this since we need to show the ticker names while spinner is still showing */
   +defaultTokenInfo: $ReadOnly<TokenRow>,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +totalSum: void | MultiToken,
   +totalRewards: void | MultiToken,
   +totalDelegated: void | MultiToken,

--- a/packages/yoroi-extension/app/components/wallet/summary/WalletSummary.js
+++ b/packages/yoroi-extension/app/components/wallet/summary/WalletSummary.js
@@ -61,7 +61,7 @@ type Props = {|
   +isLoadingTransactions: boolean,
   +openExportTxToFileDialog: void => void,
   +unitOfAccountSetting: UnitOfAccountSettingType,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
 |};
 
 @observer

--- a/packages/yoroi-extension/app/components/wallet/transactions/Transaction.js
+++ b/packages/yoroi-extension/app/components/wallet/transactions/Transaction.js
@@ -202,7 +202,7 @@ type Props = {|
   +onCopyAddressTooltip: (string, string) => void,
   +notification: ?Notification,
   +addressToDisplayString: string => string,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +complexityLevel: ?ComplexityLevelType,
 |};
 

--- a/packages/yoroi-extension/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/packages/yoroi-extension/app/components/wallet/transactions/WalletTransactionsList.js
@@ -54,7 +54,7 @@ type Props = {|
   +onCopyAddressTooltip: (string, string) => void,
   +notification: ?Notification,
   +addressToDisplayString: string => string,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +complexityLevel: ?ComplexityLevelType,
 |};
 

--- a/packages/yoroi-extension/app/components/wallet/voting/VotingRegTxDialog.js
+++ b/packages/yoroi-extension/app/components/wallet/voting/VotingRegTxDialog.js
@@ -53,7 +53,7 @@ type Props = {|
   +onSubmit: ({| password?: string |}) => PossiblyAsync<void>,
   +classicTheme: boolean,
   +error: ?LocalizableError,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
 |};
 
 @observer

--- a/packages/yoroi-extension/app/ergo-connector/components/connect-websites/ConnectWebsitesPage.js
+++ b/packages/yoroi-extension/app/ergo-connector/components/connect-websites/ConnectWebsitesPage.js
@@ -21,8 +21,8 @@ type Props = {|
   +activeSites: Array<string>,
   +wallets: ?Array<PublicDeriverCache>,
   +onRemoveWallet: ?string => void,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
-  shouldHideBalance: boolean,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
+  +shouldHideBalance: boolean,
 |};
 const messages = defineMessages({
   connectedWallets: {

--- a/packages/yoroi-extension/app/ergo-connector/components/connect-websites/DropdownCard.js
+++ b/packages/yoroi-extension/app/ergo-connector/components/connect-websites/DropdownCard.js
@@ -19,7 +19,7 @@ type Props = {|
   +wallet: PublicDeriverCache,
   +shouldHideBalance: boolean,
   +onRemoveWallet: ?string => void,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
 |};
 type State = {| isExpanded: boolean |};
 @observer

--- a/packages/yoroi-extension/app/ergo-connector/components/connect/ConnectPage.js
+++ b/packages/yoroi-extension/app/ergo-connector/components/connect/ConnectPage.js
@@ -55,7 +55,7 @@ type Props = {|
   +onConnect: number => Promise<void>,
   +handleSubmit: () => void,
   +selected: number,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
   +network: string,
   +shouldHideBalance: boolean,
 |};

--- a/packages/yoroi-extension/app/ergo-connector/components/connect/WalletCard.js
+++ b/packages/yoroi-extension/app/ergo-connector/components/connect/WalletCard.js
@@ -13,7 +13,7 @@ import { hiddenAmount } from '../../../utils/strings';
 type Props = {|
   +shouldHideBalance: boolean,
   +publicDeriver: PublicDeriverCache,
-  +getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>,
+  +getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>,
 |};
 
 function constructPlate(

--- a/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
@@ -31,6 +31,7 @@ import { Bip44Wallet } from '../../api/ada/lib/storage/models/Bip44Wallet/wrappe
 import { walletChecksum, legacyWalletChecksum } from '@emurgo/cip4-js';
 import type { WalletChecksum } from '@emurgo/cip4-js';
 import { MultiToken } from '../../api/common/lib/MultiToken';
+import BigNumber from 'bignumber.js';
 
 // Need to run only once - Connecting wallets
 let initedConnecting = false;
@@ -160,7 +161,7 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
   };
 
   // ========== sign tx confirmation ========== //
-  @computed get totalAmount(): ?any {
+  @computed get totalAmount(): ?BigNumber {
     const pendingSign = this.signingMessage?.sign ?? {};
     if (pendingSign.tx == null) {
       return undefined;
@@ -169,7 +170,10 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
 
     const total = txData.outputs
       .map(item => item.value)
-      .reduce((acum, currentValue) => acum + currentValue);
+      .reduce(
+        (acc, currentValue) => acc.plus(currentValue),
+        new BigNumber(0)
+      );
 
     return total;
   }

--- a/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
+++ b/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
@@ -75,8 +75,8 @@ export function getTokenIdentifierIfExists(
 
 export function genLookupOrFail(
   map: TokenInfoMap,
-): (Inexact<TokenLookupKey> => $ReadOnly<TokenRow>) {
-  return (lookup: Inexact<TokenLookupKey>): $ReadOnly<TokenRow> => {
+): ($ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>) {
+  return (lookup: $ReadOnly<Inexact<TokenLookupKey>>): $ReadOnly<TokenRow> => {
     const tokenRow = map
       .get(lookup.networkId.toString())
       ?.get(lookup.identifier);
@@ -86,7 +86,7 @@ export function genLookupOrFail(
 }
 
 export function genFormatTokenAmount(
-  getTokenInfo: Inexact<TokenLookupKey> => $ReadOnly<TokenRow>
+  getTokenInfo: $ReadOnly<Inexact<TokenLookupKey>> => $ReadOnly<TokenRow>
 ): (TokenEntry => string) {
   return (tokenEntry) => {
     const tokenInfo = getTokenInfo(tokenEntry);

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/types.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/types.js
@@ -330,7 +330,11 @@ export type PublicDeriverCache = {|
 export type WhitelistEntry = {| url: string, publicDeriverId: number |};
 
 export type ConnectingMessage = {| tabId: number, url: string, imgBase64Url: string |};
-export type SigningMessage = {| sign: PendingSignData, tabId: number |};
+export type SigningMessage = {|
+  publicDeriverId: number,
+  sign: PendingSignData,
+  tabId: number,
+|};
 export type ConnectedSites = {|
   sites: Array<string>,
 |};


### PR DESCRIPTION
This PR adds proper asset formatting on the signing page (computes token names and takes number of decimal places into account)

![image](https://user-images.githubusercontent.com/2608559/112584625-888ba580-8e3b-11eb-8cbe-16357554078e.png)

This PR does NOT look up token information from our server yet. This will be done in a follow-up PR