### PR TITLE
Performance improvement on wallets with many addresses in tx history

### DIFF
--- a/packages/yoroi-extension/app/stores/stateless/addressStores.js
+++ b/packages/yoroi-extension/app/stores/stateless/addressStores.js
@@ -26,7 +26,7 @@ import {
 } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
 import { Bip44Wallet } from '../../api/ada/lib/storage/models/Bip44Wallet/wrapper';
 import { Cip1852Wallet } from '../../api/ada/lib/storage/models/Cip1852Wallet/wrapper';
-import { getAddressPayload } from '../../api/ada/lib/storage/bridge/utils';
+import { addressToDisplayString } from '../../api/ada/lib/storage/bridge/utils';
 import type { AddressFilterKind, StandardAddress, AddressTypeName } from '../../types/AddressFilterTypes';
 import {
   AddressFilter,
@@ -437,8 +437,9 @@ export function genAddressStoreLookup(
       const request = addressSubgroupMap.get(addressStore.class);
       if (request == null) throw new Error('Should never happen');
 
+      const displayAddress = addressToDisplayString(address, networkInfo);
       const addressInfo = request.all.find(
-        addressInStore => getAddressPayload(addressInStore.address, networkInfo) === address
+        addressInStore => addressInStore.address === displayAddress
       );
       if (addressInfo != null) {
         return {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -10,7 +10,7 @@
     "prod:build": "rimraf build/ && NODE_ENV=production babel-node scripts/build --type=prod",
     "prod:compress": "babel-node ../../scripts/compress",
     "prod:unsigned": "npm run prod:build -- --env ${CARDANO_NETWORK:-testnet} && npm run prod:compress -- --env ${CARDANO_NETWORK:-testnet} --app-id yoroi-${CARDANO_NETWORK:-testnet} --zip-only --codebase https://yoroiwallet.com/dw/yoroi-${CARDANO_NETWORK:-testnet}-extension.crx",
-    "prod:nightly": "npm run prod:build -- --env 'mainnet' --nightly && npm run -s prod:compress -- --env 'mainnet' --app-id 'yoroi-nightly' --zip-only --codebase 'https://yoroiwallet.com/dw/yoroi-nightly-extension.crx' --key \"'${YOROI_NIGHTLY_PEM:-./nightly-key.pem}'\"",
+    "prod:nightly": "npm run prod:build -- --env 'mainnet' --nightly --ergoConnectorExtensionId=chifollcalpmjdiokipacefnpmbgjnle && npm run -s prod:compress -- --env 'mainnet' --app-id 'yoroi-nightly' --zip-only --codebase 'https://yoroiwallet.com/dw/yoroi-nightly-extension.crx' --key \"'${YOROI_NIGHTLY_PEM:-./nightly-key.pem}'\"",
     "prod:stable": "npm run prod:build -- --env 'mainnet' && npm run prod:compress -- --env 'mainnet' --app-id 'yoroi' --zip-only --codebase 'https://yoroiwallet.com/dw/yoroi-extension.crx' --key ./production-key.pem",
     "keygen": "crx keygen",
     "clean": "rimraf build/ dev/ *.zip *.crx",


### PR DESCRIPTION
It turns out that Ergo users experiencing slowdowns was caused by mining pool payouts consisting of transactions with >100 addresses inside them, causing the user's tx history to easily go up into to thousands of addresses.

The code for detecting whether an address belongs to the user was slow, so I improved it. It's much faster now, but still not lighting fast so we can look into improving it more in the future.