### PR TITLE
Use reward address for Catalyst registration

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/cardanoCrypto/catalyst.test.js
+++ b/packages/yoroi-extension/app/api/ada/lib/cardanoCrypto/catalyst.test.js
@@ -19,14 +19,13 @@ test('Generate Catalyst registration tx', async () => {
   );
 
   // eslint-disable-next-line max-len
-  // addr1qx0srp4ptag9j2e3rdtesrsxe708j80uhxv2r7utl4jaqm4rhf28yg7fkl6dd329cuxq7tqahhujtt5cmdmp9pa2t2zsp2vc6a (019f0186a15f50592b311b57980e06cf9e791dfcb998a1fb8bfd65d06ea3ba547223c9b7f4d6c545c70c0f2c1dbdf925ae98db761287aa5a85)
-  const address = RustModule.WalletV4.BaseAddress.new(
+  // stake_test1uzhr5zn6akj2affzua8ylcm8t872spuf5cf6tzjrvnmwemcehgcjm (e0ae3a0a7aeda4aea522e74e4fe36759fca80789a613a58a4364f6ecef)
+  const address = RustModule.WalletV4.RewardAddress.new(
     RustModule.WalletV4.NetworkInfo.testnet().network_id(),
-    RustModule.WalletV4.StakeCredential.from_keyhash(paymentKey.hash()),
     RustModule.WalletV4.StakeCredential.from_keyhash(stakePrivateKey.to_public().hash()),
   );
 
-  const nonce = 4;
+  const nonce = 1234;
   const result = generateRegistration({
     stakePrivateKey,
     catalystPrivateKey,
@@ -53,11 +52,11 @@ test('Generate Catalyst registration tx', async () => {
     '61284': {
       '1': '0x0036ef3e1f0d3f5989e2d155ea54bdb2a72c4c456ccb959af4c94868f473f5a0',
       '2': '0x86870efc99c453a873a16492ce87738ec79a0ebd064379a62e2c9cf4e119219e',
-      '3': '0x009f0186a15f50592b311b57980e06cf9e791dfcb998a1fb8bfd65d06eae3a0a7aeda4aea522e74e4fe36759fca80789a613a58a4364f6ecef',
+      '3': '0xe0ae3a0a7aeda4aea522e74e4fe36759fca80789a613a58a4364f6ecef',
       '4': nonce,
     },
     '61285': {
-      '1': '0xb920786bbd6954c65011ce4aefc1806900d3feb38c32fe0adf5a8ebf5e5fbd356b41b8d9a2ea7f572405d36af45ca8f86db7d819b7874869f35631dd9c393f07'
+      '1': '0x6c2312cd49067ecf0920df7e067199c55b3faef4ec0bce1bd2cfb99793972478c45876af2bc271ac759c5ce40ace5a398b9fdb0e359f3c333fe856648804780e'
     }
   };
   expect({


### PR DESCRIPTION
This uses the reward address for Catalyst registration since this is what will be used for fund4 (see https://github.com/cardano-foundation/CIPs/pull/89)

Note: there will need to be a follow-up to this PR to add a warning message on the Catalyst registration screen telling users they will need to have their staking key registered in order to register for Catalyst (and telling them not to unregister it at least until they get their rewards)