### PR TITLE
Trezor wallet Catalyst voting registration support

### DIFF
--- a/packages/yoroi-extension/app/actions/ada/voting-actions.js
+++ b/packages/yoroi-extension/app/actions/ada/voting-actions.js
@@ -4,7 +4,7 @@ import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/in
 
 export default class VotingActions {
   generateCatalystKey: AsyncAction<void> = new AsyncAction();
-  createTransaction: AsyncAction<string> = new AsyncAction();
+  createTransaction: AsyncAction<null | string> = new AsyncAction();
   signTransaction: AsyncAction<{|
     password?: string,
     publicDeriver: PublicDeriver<>,
@@ -12,7 +12,7 @@ export default class VotingActions {
   cancel: Action<void> = new Action();
   submitGenerate: Action<void> = new Action();
   goBackToGenerate: Action<void> = new Action();
-  submitConfirm: Action<void> = new Action();
+  submitConfirm: AsyncAction<void> = new AsyncAction();
   submitConfirmError: Action<void> = new Action();
   submitRegister: Action<void> = new Action();
   submitRegisterError: Action<Error> = new Action();

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/HaskellShelleyTxSignRequest.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/HaskellShelleyTxSignRequest.js
@@ -45,6 +45,10 @@ implements ISignRequest<RustModule.WalletV4.TransactionBuilder> {
     neededHashes: Set<string>, // StakeCredential
     wits: Set<string>, // Vkeywitness
   |};
+  trezorTCatalystRegistrationTxSignData: void | {|
+    votingPublicKey: string,
+    nonce: BigNumber,
+  |};
 
   constructor(data: {|
     senderUtxos: Array<CardanoAddressedUtxo>,
@@ -56,6 +60,10 @@ implements ISignRequest<RustModule.WalletV4.TransactionBuilder> {
       neededHashes: Set<string>, // StakeCredential
       wits: Set<string>, // Vkeywitness
     |},
+    trezorTCatalystRegistrationTxSignData?: void | {|
+      votingPublicKey: string,
+      nonce: BigNumber,
+    |};
   |}) {
     this.senderUtxos = data.senderUtxos;
     this.unsignedTx = data.unsignedTx;
@@ -63,6 +71,8 @@ implements ISignRequest<RustModule.WalletV4.TransactionBuilder> {
     this.metadata = data.metadata;
     this.networkSettingSnapshot = data.networkSettingSnapshot;
     this.neededStakingKeyHashes = data.neededStakingKeyHashes;
+    this.trezorTCatalystRegistrationTxSignData =
+      data.trezorTCatalystRegistrationTxSignData;
   }
 
   txId(): string {

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/trezorTx.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/trezorTx.js
@@ -111,6 +111,26 @@ export async function createTrezorSignTxPayload(
       metadata: Buffer.from(metadata.to_bytes()).toString('hex')
     };
 
+  if (signRequest.trezorTCatalystRegistrationTxSignData) {
+    const { votingPublicKey, nonce } = signRequest.trezorTCatalystRegistrationTxSignData;
+    request = {
+      ...request,
+      auxiliaryData: {
+        catalystRegistrationParameters: {
+          votingPublicKey,
+          stakingPath: getStakingKeyPath(),
+          rewardAddressParameters: {
+            addressType: ADDRESS_TYPE.Reward,
+            stakingPath: getStakingKeyPath(),
+          },
+          nonce,
+        },
+      }
+    };
+  }
+  // trezor-connect v8.1.26 doesn't support auxiliaryData. When it does, we
+  // can remove the next line:
+  // $FlowFixMe[prop-missing]
   return request;
 }
 

--- a/packages/yoroi-extension/app/containers/wallet/dialogs/voting/VotingRegistrationDialogContainer.js
+++ b/packages/yoroi-extension/app/containers/wallet/dialogs/voting/VotingRegistrationDialogContainer.js
@@ -201,7 +201,7 @@ export default class VotingRegistrationDialogContainer extends Component<Props> 
               trigger: actions.ada.voting.goBackToGenerate.trigger,
             },
             submitConfirm: {
-              trigger: actions.ada.voting.submitConfirm.trigger,
+              trigger: () => { actions.ada.voting.submitConfirm.trigger() },
             },
             submitConfirmError: {
               trigger: actions.ada.voting.submitConfirmError.trigger,


### PR DESCRIPTION
[ch8805]
Only the API level work. UI will be updated later.
## Summary of changes:

### `VotingStore.js`:
1. When the "PIN confirmation" step is submitted, if it is Trezor wallet, just call `createTransaction` action and skip the next step (asking for spending password).

2. `_createTransaction`: For hardware wallets, do not call `generateRegistration` to generate the tx metadata, because the metadata is generated by the wallet. However, we do need to pass the public voting key down (instead of the generated metadata).

###  `api/ada/transactions/shelley/HaskellShelleyTxSignRequest.js` and `api/ada/index.js`
`createVotingRegTx:` Pass the public voting key and nonce down instead of the generated metadata.

### `api/ada/transactions/shelley/trezorTx.js`
If it is a catalyst voting registration tx, construct the `auxiliaryData` of the signing request using the public voting key and nonce passed down.
