### PR TITLE
Catalyst Fund4 another date push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 .DS_Store
 .vscode/
+.idea/

--- a/packages/yoroi-extension/app/containers/wallet/voting/VotingPage.js
+++ b/packages/yoroi-extension/app/containers/wallet/voting/VotingPage.js
@@ -31,8 +31,8 @@ type Props = {|
 |};
 
 const roundInfo = {
-  startDate: new Date(Date.parse('13 May 2021 19:00:00 GMT')),
-  endDate: new Date(Date.parse('20 May 2021 19:00:00 GMT')),
+  startDate: new Date(Date.parse('2021-05-203T19:00:00Z')),
+  endDate: new Date(Date.parse('2021-05-27T19:00:00Z')),
   nextRound: 4,
 };
 

--- a/packages/yoroi-extension/app/containers/wallet/voting/VotingPage.js
+++ b/packages/yoroi-extension/app/containers/wallet/voting/VotingPage.js
@@ -31,7 +31,7 @@ type Props = {|
 |};
 
 const roundInfo = {
-  startDate: new Date(Date.parse('2021-05-203T19:00:00Z')),
+  startDate: new Date(Date.parse('2021-05-20T19:00:00Z')),
   endDate: new Date(Date.parse('2021-05-27T19:00:00Z')),
   nextRound: 4,
 };


### PR DESCRIPTION
Changed date-time string format and pushed the catalyst fund period time one week further.

Changed date-time format also to temove text from there and make it more formal.
Soon we are switching to getting these dates from normal APIs finally, so that's a temporary plug.