### PR TITLE
Changed nightly build action to use `nightly` branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Publish to Nightly
 on:
   push:
     branches:
-      - develop
+      - nightly
 
 jobs:
   build:


### PR DESCRIPTION
We are changing the process a bit so in `develop` branch the version will only be updated after the release is done, so for nightly releases a new branch `nightly` is created and releases with a separate version format will be pushed there.