### PR TITLE
Ergo Connector Version bump 0.4.0

### DIFF
--- a/packages/yoroi-ergo-connector/package-lock.json
+++ b/packages/yoroi-ergo-connector/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-ergo-connector",
-  "version": "0.2.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-ergo-connector/package.json
+++ b/packages/yoroi-ergo-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-ergo-connector",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "scripts": {
     "keygen": "crx keygen",


### PR DESCRIPTION
Bumping the ergo-connector version to `0.4.0` (still nightly only) after this merge: https://github.com/Emurgo/yoroi-frontend/pull/2081