### PR TITLE
Release / 4.5.5 (Tokens metadata integration v1)

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/IFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/IFetcher.js
@@ -10,6 +10,7 @@ import type {
   SignedRequest, SignedResponse,
   PoolInfoRequest, PoolInfoResponse,
   BestBlockRequest, BestBlockResponse,
+  TokenInfoRequest, TokenInfoResponse,
 } from './types';
 import type {
   FilterUsedRequest, FilterUsedResponse,
@@ -25,5 +26,6 @@ export interface IFetcher {
   sendTx(body: SignedRequest): Promise<SignedResponse>;
   getAccountState(body: AccountStateRequest): Promise<AccountStateResponse>;
   getPoolInfo(body: PoolInfoRequest): Promise<PoolInfoResponse>;
+  getTokenInfo(body: TokenInfoRequest): Promise<TokenInfoResponse>;
   checkAddressesInUse(body: FilterUsedRequest): Promise<FilterUsedResponse>;
 }

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
@@ -378,18 +378,18 @@ export class RemoteFetcher implements IFetcher {
       {
         method: 'get',
         timeout: 2 * CONFIG.app.walletRefreshInterval,
-        headers: {
-          'yoroi-version': this.getLastLaunchVersion(),
-          'yoroi-locale': this.getCurrentLocale()
-        }
       }
     ).then(response => response.data)
       .catch((error) => {
-        Logger.error(`${nameof(RemoteFetcher)}::${nameof(this.getTokenInfo)} error: ` + stringifyError(error));
-        throw new GetTokenInfoApiError();
+        if (error.response.status) {
+          Logger.info(`${nameof(RemoteFetcher)}::${nameof(this.getTokenInfo)} 404: no token meta found for subject: ` + id);
+        } else {
+          Logger.error(`${nameof(RemoteFetcher)}::${nameof(this.getTokenInfo)} error: ` + stringifyError(error));
+        }
+        return null;
       }));
     return (await Promise.all(promises)).reduce((res, resp) => {
-      if (resp && resp.subject) {
+      if (resp?.subject) {
         const v = {};
         if (resp.name?.value) {
           v.name = resp.name.value;

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
@@ -1,42 +1,48 @@
 // @flow
 
 import type {
-  AddressUtxoRequest, AddressUtxoResponse,
-  TxBodiesRequest, TxBodiesResponse,
-  UtxoSumRequest, UtxoSumResponse,
-  HistoryRequest, HistoryResponse,
-  AccountStateRequest, AccountStateResponse,
-  RewardHistoryRequest, RewardHistoryResponse,
-  BestBlockRequest, BestBlockResponse,
-  SignedRequest, SignedResponse,
-  PoolInfoRequest, PoolInfoResponse,
-  SignedRequestInternal,
+  AccountStateRequest,
+  AccountStateResponse,
+  AddressUtxoRequest,
+  AddressUtxoResponse,
+  BestBlockRequest,
+  BestBlockResponse,
+  HistoryRequest,
+  HistoryResponse,
+  PoolInfoRequest,
+  PoolInfoResponse,
   RemoteTransaction,
+  RewardHistoryRequest,
+  RewardHistoryResponse,
+  SignedRequest,
+  SignedRequestInternal,
+  SignedResponse,
+  TokenInfoRequest,
+  TokenInfoResponse,
+  TxBodiesRequest,
+  TxBodiesResponse,
+  UtxoSumRequest,
+  UtxoSumResponse,
 } from './types';
-import type {
-  FilterUsedRequest, FilterUsedResponse,
-} from '../../../common/lib/state-fetch/currencySpecificTypes';
+import type { FilterUsedRequest, FilterUsedResponse, } from '../../../common/lib/state-fetch/currencySpecificTypes';
 
 import type { IFetcher } from './IFetcher';
 
 import axios from 'axios';
+import { Logger, stringifyError } from '../../../../utils/logging';
 import {
-  Logger,
-  stringifyError
-} from '../../../../utils/logging';
-import {
+  CheckAddressesInUseApiError,
+  GetAccountStateApiError,
+  GetBestBlockError,
+  GetPoolInfoApiError,
+  GetRewardHistoryApiError,
+  GetTxHistoryForAddressesApiError,
   GetTxsBodiesForUTXOsApiError,
   GetUtxosForAddressesApiError,
   GetUtxosSumsForAddressesApiError,
-  GetTxHistoryForAddressesApiError,
-  GetRewardHistoryApiError,
-  GetPoolInfoApiError,
-  GetAccountStateApiError,
-  GetBestBlockError,
-  SendTransactionApiError,
-  CheckAddressesInUseApiError,
   InvalidWitnessError,
   RollbackApiError,
+  SendTransactionApiError,
 } from '../../../common/errors';
 import { RustModule } from '../cardanoCrypto/rustLoader';
 
@@ -361,5 +367,40 @@ export class RemoteFetcher implements IFetcher {
         Logger.error(`${nameof(RemoteFetcher)}::${nameof(this.getPoolInfo)} error: ` + stringifyError(error));
         throw new GetPoolInfoApiError();
       });
+  }
+
+  getTokenInfo: TokenInfoRequest => Promise<TokenInfoResponse> = async (body) => {
+    const { TokenInfoService } = body.network.Backend;
+    if (TokenInfoService == null) return {};
+    const promises = body.tokenIds.map(id => axios(
+      `${TokenInfoService}/metadata/${id}`,
+      {
+        method: 'get',
+        timeout: 2 * CONFIG.app.walletRefreshInterval,
+        // headers: {
+        //   'yoroi-version': this.getLastLaunchVersion(),
+        //   'yoroi-locale': this.getCurrentLocale()
+        // }
+      }
+    ).then(response => response.data)
+      .catch((error) => {
+        Logger.error(`${nameof(RemoteFetcher)}::${nameof(this.getTokenInfo)} error: ` + stringifyError(error));
+        throw new GetPoolInfoApiError();
+      }));
+    return (await Promise.all(promises)).reduce((res, resp) => {
+      if (resp && resp.subject) {
+        const v = {};
+        if (resp.name?.value) {
+          v.name = resp.name.value;
+        }
+        if (resp.decimals?.value) {
+          v.decimals = resp.decimals.value;
+        }
+        if (v.name || v.decimals) {
+          res[resp.subject] = v;
+        }
+      }
+      return res;
+    }, {});
   }
 }

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
@@ -371,17 +371,17 @@ export class RemoteFetcher implements IFetcher {
   }
 
   getTokenInfo: TokenInfoRequest => Promise<TokenInfoResponse> = async (body) => {
-    const { TokenInfoService } = body.network.Backend;
+    const { TokenInfoService } = body?.network?.Backend;
     if (TokenInfoService == null) return {};
     const promises = body.tokenIds.map(id => axios(
       `${TokenInfoService}/metadata/${id}`,
       {
         method: 'get',
         timeout: 2 * CONFIG.app.walletRefreshInterval,
-        // headers: {
-        //   'yoroi-version': this.getLastLaunchVersion(),
-        //   'yoroi-locale': this.getCurrentLocale()
-        // }
+        headers: {
+          'yoroi-version': this.getLastLaunchVersion(),
+          'yoroi-locale': this.getCurrentLocale()
+        }
       }
     ).then(response => response.data)
       .catch((error) => {

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
@@ -36,6 +36,7 @@ import {
   GetBestBlockError,
   GetPoolInfoApiError,
   GetRewardHistoryApiError,
+  GetTokenInfoApiError,
   GetTxHistoryForAddressesApiError,
   GetTxsBodiesForUTXOsApiError,
   GetUtxosForAddressesApiError,
@@ -385,7 +386,7 @@ export class RemoteFetcher implements IFetcher {
     ).then(response => response.data)
       .catch((error) => {
         Logger.error(`${nameof(RemoteFetcher)}::${nameof(this.getTokenInfo)} error: ` + stringifyError(error));
-        throw new GetPoolInfoApiError();
+        throw new GetTokenInfoApiError();
       }));
     return (await Promise.all(promises)).reduce((res, resp) => {
       if (resp && resp.subject) {

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/types.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/types.js
@@ -304,6 +304,10 @@ export type PoolInfoRequest = {|
   ...BackendNetworkInfo,
   poolIds: Array<string>
 |};
+export type TokenInfoRequest = {|
+  ...BackendNetworkInfo,
+  tokenIds: Array<string>
+|};
 export type RemotePoolInfo = {|
   // from pool metadata (off chain)
   +name?: string,
@@ -323,5 +327,14 @@ export type RemotePool = {|
 |};
 export type PoolInfoResponse = {|
   [key: string]: (RemotePool | null),
+|};
+
+export type RemoteTokenInfo = {|
+  // from token metadata (off chain)
+  +name?: string,
+  +decimals?: number,
+|};
+export type TokenInfoResponse = {|
+  [key: string]: (RemoteTokenInfo | null),
 |};
 export type PoolInfoFunc = (body: PoolInfoRequest) => Promise<PoolInfoResponse>;

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/types.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/types.js
@@ -338,3 +338,4 @@ export type TokenInfoResponse = {|
   [key: string]: (RemoteTokenInfo | null),
 |};
 export type PoolInfoFunc = (body: PoolInfoRequest) => Promise<PoolInfoResponse>;
+export type TokenInfoFunc = (body: TokenInfoRequest) => Promise<TokenInfoResponse>;

--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/prepackaged/networks.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/prepackaged/networks.js
@@ -33,6 +33,8 @@ export const networks = Object.freeze({
       WebSocket: environment.isTest()
         ? 'ws://localhost:21000'
         : 'wss://iohk-mainnet.yoroiwallet.com:443',
+      TokenInfoService:
+        'https://tokens.cardano.org',
     },
     BaseConfig: ([
       Object.freeze({
@@ -127,6 +129,8 @@ export const networks = Object.freeze({
       WebSocket: environment.isTest()
         ? 'ws://localhost:21000'
         : 'wss://testnet-backend.yoroiwallet.com:443',
+      TokenInfoService:
+        'https://stage-cdn.yoroiwallet.com',
     },
     BaseConfig: ([
       Object.freeze({

--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/prepackaged/networks.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/prepackaged/networks.js
@@ -34,7 +34,7 @@ export const networks = Object.freeze({
         ? 'ws://localhost:21000'
         : 'wss://iohk-mainnet.yoroiwallet.com:443',
       TokenInfoService:
-        'https://tokens.cardano.org',
+        'https://cdn.yoroiwallet.com',
     },
     BaseConfig: ([
       Object.freeze({

--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
@@ -108,6 +108,7 @@ export type NetworkInsert = {|
   CoinType: CoinTypesT,
   Backend: {|
     BackendService?: string,
+    TokenInfoService?: string,
     WebSocket?: string,
   |},
   /**

--- a/packages/yoroi-extension/app/api/ada/lib/storage/tests/__snapshots__/index.test.js.snap
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/tests/__snapshots__/index.test.js.snap
@@ -1188,6 +1188,7 @@ Object {
     Object {
       "Backend": Object {
         "BackendService": "https://iohk-mainnet.yoroiwallet.com",
+        "TokenInfoService": "https://cdn.yoroiwallet.com",
         "WebSocket": "wss://iohk-mainnet.yoroiwallet.com:443",
       },
       "BaseConfig": Array [
@@ -1269,6 +1270,7 @@ Object {
     Object {
       "Backend": Object {
         "BackendService": "https://testnet-backend.yoroiwallet.com",
+        "TokenInfoService": "https://stage-cdn.yoroiwallet.com",
         "WebSocket": "wss://testnet-backend.yoroiwallet.com:443",
       },
       "BaseConfig": Array [

--- a/packages/yoroi-extension/app/api/common/errors.js
+++ b/packages/yoroi-extension/app/api/common/errors.js
@@ -507,8 +507,8 @@ export class GetPoolInfoApiError extends LocalizableError {
 export class GetTokenInfoApiError extends LocalizableError {
   constructor() {
     super({
-      id: messages.getPoolInfoApiError.id,
-      defaultMessage: messages.getPoolInfoApiError.defaultMessage || '',
+      id: messages.getTokenInfoApiError.id,
+      defaultMessage: messages.getTokenInfoApiError.defaultMessage || '',
     });
   }
 }

--- a/packages/yoroi-extension/app/api/common/errors.js
+++ b/packages/yoroi-extension/app/api/common/errors.js
@@ -156,6 +156,10 @@ const messages = defineMessages({
     id: 'api.errors.getPoolInfoApiError',
     defaultMessage: '!!!Error received from server while getting pool info.',
   },
+  getTokenInfoApiError: {
+    id: 'api.errors.getTokenInfoApiError',
+    defaultMessage: '!!!Error received from server while getting token info.',
+  },
   poolMissingApiError: {
     id: 'api.errors.poolMissingApiError',
     defaultMessage: '!!!Could not find this pool. Double-check the ID and make sure the pool was not deregistered.',
@@ -493,6 +497,14 @@ export class GetAccountStateApiError extends LocalizableError {
 }
 
 export class GetPoolInfoApiError extends LocalizableError {
+  constructor() {
+    super({
+      id: messages.getPoolInfoApiError.id,
+      defaultMessage: messages.getPoolInfoApiError.defaultMessage || '',
+    });
+  }
+}
+export class GetTokenInfoApiError extends LocalizableError {
   constructor() {
     super({
       id: messages.getPoolInfoApiError.id,

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -11,7 +11,7 @@ import type { ActionsMap } from '../../actions/index';
 import type { StoresMap } from '../index';
 import WalletTransaction from '../../domain/WalletTransaction';
 import CardanoShelleyTransaction from '../../domain/CardanoShelleyTransaction';
-import type { RemoteTokenInfo } from '../../api/ada/lib/state-fetch/types';
+import type { RemoteTokenInfo, TokenInfoResponse } from '../../api/ada/lib/state-fetch/types';
 import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
 
 function createTokenLocalStorageKey(tokenId: string, network: $ReadOnly<NetworkRow>): string {
@@ -45,13 +45,13 @@ export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
         .map(id => id?.split('.')?.join(''))
         .filter(tokenId => tokenId.length > 0
           && !localStorage.getItem(createTokenLocalStorageKey(tokenId, network)));
-      const tokenInfo = await stateFetcher.getTokenInfo({
+      const tokenInfo: TokenInfoResponse = await stateFetcher.getTokenInfo({
         network,
         tokenIds: missingMetaTokenIds,
       });
       // $FlowFixMe[incompatible-call]
       missingMetaTokenIds.forEach((tokenId: string) => {
-        const tokenMeta: RemoteTokenInfo = tokenInfo[tokenId];
+        const tokenMeta: ?RemoteTokenInfo = tokenInfo[tokenId];
         localStorage.setItem(createTokenLocalStorageKey(tokenId, network), JSON.stringify({
           ...tokenMeta,
           timestamp: new Date().toISOString(),

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -35,7 +35,7 @@ export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
         }
       });
       const missingMetaTokenIds = [...tokenIds]
-        .filter(tokenId => !localStorage.getItem(`token-metadata-${tokenId}`))
+        .filter(tokenId => tokenId?.length > 0 && !localStorage.getItem(`token-metadata-${tokenId}`))
         .map(id => id.split('.')[0]);
       const tokenInfo = await stateFetcher.getTokenInfo({
         network: request.publicDeriver.getParent().getNetworkInfo(),

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -2,23 +2,55 @@
 
 import Store from '../base/Store';
 import type {
-  GetTransactionsFunc,
+  GetTransactionsFunc, GetTransactionsResponse,
   RefreshPendingTransactionsFunc,
 } from '../../api/common';
 import type { ActionsMap } from '../../actions/index';
 import type { StoresMap } from '../index';
+import WalletTransaction from '../../domain/WalletTransaction';
+import CardanoShelleyTransaction from '../../domain/CardanoShelleyTransaction';
+import type { BaseGetTransactionsRequest } from '../../api/common';
+import type { RemoteTokenInfo } from '../../api/ada/lib/state-fetch/types';
 
 export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
 
-  refreshTransactions: GetTransactionsFunc = (request) => {
+  refreshTransactions: GetTransactionsFunc = async (request: BaseGetTransactionsRequest) => {
     const stateFetcher = this.stores.substores.ada.stateFetchStore.fetcher;
 
-    return this.api.ada.refreshTransactions({
+    const txs: GetTransactionsResponse = await this.api.ada.refreshTransactions({
       ...request,
       getTransactionsHistoryForAddresses: stateFetcher.getTransactionsHistoryForAddresses,
       checkAddressesInUse: stateFetcher.checkAddressesInUse,
       getBestBlock: stateFetcher.getBestBlock,
     });
+
+    try {
+      const tokenIds = new Set<string>();
+      txs.transactions.forEach((tx: WalletTransaction) => {
+        tx.amount.values.forEach(t => tokenIds.add(t.identifier));
+        if (tx instanceof CardanoShelleyTransaction) {
+          tx.withdrawals.flatMap(w => w.value.values).forEach(t => tokenIds.add(t.identifier));
+        }
+      });
+      const missingMetaTokenIds = [...tokenIds]
+        .filter(tokenId => !!localStorage.getItem(`token-metadata-${tokenId}`));
+      const tokenInfo = await stateFetcher.getTokenInfo({
+        network: request.publicDeriver.getParent().getNetworkInfo(),
+        tokenIds: missingMetaTokenIds,
+      });
+      // $FlowFixMe[incompatible-call]
+      Object.entries(tokenInfo).forEach(([tokenId, tokenMeta]: [string, RemoteTokenInfo]) => {
+        localStorage.setItem(`token-metadata-${tokenId}`, JSON.stringify({
+          ...tokenMeta,
+          timestamp: new Date().toISOString(),
+        }));
+      })
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Token metadata fetch failed. Reason: ', error);
+    }
+
+    return txs;
   }
 
   refreshPendingTransactions: RefreshPendingTransactionsFunc = (request) => {

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -28,12 +28,15 @@ export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
       const tokenIds = new Set<string>();
       txs.transactions.forEach((tx: WalletTransaction) => {
         tx.amount.values.forEach(t => tokenIds.add(t.identifier));
+        tx.addresses.from.flatMap(a => a.value.values).forEach(t => tokenIds.add(t.identifier));
+        tx.addresses.to.flatMap(a => a.value.values).forEach(t => tokenIds.add(t.identifier));
         if (tx instanceof CardanoShelleyTransaction) {
           tx.withdrawals.flatMap(w => w.value.values).forEach(t => tokenIds.add(t.identifier));
         }
       });
       const missingMetaTokenIds = [...tokenIds]
-        .filter(tokenId => !!localStorage.getItem(`token-metadata-${tokenId}`));
+        .filter(tokenId => !localStorage.getItem(`token-metadata-${tokenId}`))
+        .map(id => id.split('.')[0]);
       const tokenInfo = await stateFetcher.getTokenInfo({
         network: request.publicDeriver.getParent().getNetworkInfo(),
         tokenIds: missingMetaTokenIds,

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -2,9 +2,10 @@
 
 import Store from '../base/Store';
 import type {
-  GetTransactionsFunc, GetTransactionsResponse,
-  RefreshPendingTransactionsFunc,
   BaseGetTransactionsRequest,
+  GetTransactionsFunc,
+  GetTransactionsResponse,
+  RefreshPendingTransactionsFunc,
 } from '../../api/common';
 import type { ActionsMap } from '../../actions/index';
 import type { StoresMap } from '../index';
@@ -41,9 +42,9 @@ export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
       });
       const network = request.publicDeriver.getParent().getNetworkInfo();
       const missingMetaTokenIds = [...tokenIds]
+        .map(id => id?.split('.')?.join(''))
         .filter(tokenId => tokenId.length > 0
-          && !localStorage.getItem(createTokenLocalStorageKey(tokenId, network)))
-        .map(id => id.split('.').join(''));
+          && !localStorage.getItem(createTokenLocalStorageKey(tokenId, network)));
       const tokenInfo = await stateFetcher.getTokenInfo({
         network,
         tokenIds: missingMetaTokenIds,

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -4,12 +4,12 @@ import Store from '../base/Store';
 import type {
   GetTransactionsFunc, GetTransactionsResponse,
   RefreshPendingTransactionsFunc,
+  BaseGetTransactionsRequest,
 } from '../../api/common';
 import type { ActionsMap } from '../../actions/index';
 import type { StoresMap } from '../index';
 import WalletTransaction from '../../domain/WalletTransaction';
 import CardanoShelleyTransaction from '../../domain/CardanoShelleyTransaction';
-import type { BaseGetTransactionsRequest } from '../../api/common';
 import type { RemoteTokenInfo } from '../../api/ada/lib/state-fetch/types';
 
 export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -39,9 +39,9 @@ export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
           tx.withdrawals.flatMap(w => w.value.values).forEach(t => tokenIds.add(t.identifier));
         }
       });
-      let network = request.publicDeriver.getParent().getNetworkInfo();
+      const network = request.publicDeriver.getParent().getNetworkInfo();
       const missingMetaTokenIds = [...tokenIds]
-        .filter(tokenId => tokenId?.length > 0
+        .filter(tokenId => tokenId.length > 0
           && !localStorage.getItem(createTokenLocalStorageKey(tokenId, network)))
         .map(id => id.split('.')[0]);
       const tokenInfo = await stateFetcher.getTokenInfo({

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -50,7 +50,8 @@ export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
         tokenIds: missingMetaTokenIds,
       });
       // $FlowFixMe[incompatible-call]
-      Object.entries(tokenInfo).forEach(([tokenId, tokenMeta]: [string, RemoteTokenInfo]) => {
+      missingMetaTokenIds.forEach((tokenId: string) => {
+        const tokenMeta: RemoteTokenInfo = tokenInfo[tokenId];
         localStorage.setItem(createTokenLocalStorageKey(tokenId, network), JSON.stringify({
           ...tokenMeta,
           timestamp: new Date().toISOString(),

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -14,7 +14,7 @@ import type { RemoteTokenInfo } from '../../api/ada/lib/state-fetch/types';
 import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
 
 function createTokenLocalStorageKey(tokenId: string, network: $ReadOnly<NetworkRow>): string {
-  return `token-metadata-${network.NetworkName}-${tokenId}`;
+  return `token-metadata-${network.NetworkId}-${tokenId}`;
 }
 
 export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -43,7 +43,7 @@ export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
       const missingMetaTokenIds = [...tokenIds]
         .filter(tokenId => tokenId.length > 0
           && !localStorage.getItem(createTokenLocalStorageKey(tokenId, network)))
-        .map(id => id.split('.')[0]);
+        .map(id => id.split('.').join(''));
       const tokenInfo = await stateFetcher.getTokenInfo({
         network,
         tokenIds: missingMetaTokenIds,

--- a/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
+++ b/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
@@ -84,7 +84,7 @@ export function genLookupOrFail(
     // fixme: temporary solution
     const id = lookup.identifier.split('.')[0];
     const metadataStr = localStorage.getItem(
-      `token-metadata-${id}`
+      `token-metadata-${lookup.networkId}-${id}`
     );
     if (metadataStr) {
       const clone = JSON.parse(JSON.stringify(tokenRow));

--- a/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
+++ b/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
@@ -82,7 +82,7 @@ export function genLookupOrFail(
       ?.get(lookup.identifier);
     if (tokenRow == null) throw new Error(`${nameof(genLookupOrFail)} no token info for ${JSON.stringify(lookup)}`);
     // fixme: temporary solution
-    const id = lookup.identifier.split('.')[0];
+    const id = lookup.identifier.split('.').join('');
     const metadataStr = localStorage.getItem(
       `token-metadata-${lookup.networkId}-${id}`
     );

--- a/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
+++ b/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
@@ -81,6 +81,22 @@ export function genLookupOrFail(
       .get(lookup.networkId.toString())
       ?.get(lookup.identifier);
     if (tokenRow == null) throw new Error(`${nameof(genLookupOrFail)} no token info for ${JSON.stringify(lookup)}`);
+    // fixme: temporary solution
+    const id = lookup.identifier.split('.')[0];
+    const metadataStr = localStorage.getItem(
+      `token-metadata-${id}`
+    );
+    if (metadataStr) {
+      const clone = JSON.parse(JSON.stringify(tokenRow));
+      const metadata = JSON.parse(metadataStr);
+      if (typeof metadata.decimals === 'number') {
+        clone.Metadata.numberOfDecimals = metadata.decimals;
+      }
+      if (typeof metadata.name === 'string') {
+        clone.Metadata.assetName = Buffer.from(metadata.name).toString('hex');
+      }
+      return clone;
+    }
     return tokenRow;
   };
 }

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",


### PR DESCRIPTION
Milestone: https://github.com/Emurgo/yoroi-frontend/milestone/9?closed=1

New feature is implemented so that when the wallet history is being restored, for each token that has ever been mentioned - we query the off-chain metadata registry and if some metadata is found there - we store it in the local storage (ought to be changed to indexed DB) and then use it on the sending page to display the name of the token and the correct value, considering the decimals value.