### PR TITLE
Token metadata revamp

### DIFF
--- a/packages/yoroi-extension/app/api/ada/index.js
+++ b/packages/yoroi-extension/app/api/ada/index.js
@@ -141,6 +141,7 @@ import type {
   SignedRequest,
   AccountStateFunc,
   AddressUtxoFunc,
+  TokenInfoFunc,
 } from './lib/state-fetch/types';
 import type {
   FilterFunc,
@@ -250,6 +251,7 @@ export type AdaGetTransactionsRequest = {|
   getTransactionsHistoryForAddresses: HistoryFunc,
   checkAddressesInUse: FilterFunc,
   getBestBlock: BestBlockFunc,
+  getTokenInfo: TokenInfoFunc,
 |};
 
 // notices
@@ -655,6 +657,7 @@ export default class AdaApi {
           request.checkAddressesInUse,
           request.getTransactionsHistoryForAddresses,
           request.getBestBlock,
+          request.getTokenInfo,
         );
       }
       const fetchedTxs = await getAllTransactions({

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/mockNetwork.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/mockNetwork.js
@@ -12,6 +12,7 @@ import type {
   RemoteTransaction, RemoteUnspentOutput,
   SignedRequestInternal,
   RemoteTransactionInput,
+  TokenInfoFunc,
 } from './types';
 import type {
   FilterUsedRequest, FilterUsedResponse, FilterFunc,
@@ -665,4 +666,9 @@ export function genGetPoolInfo(
     }
     return result;
   };
+}
+
+export function genGetTokenInfo(
+): TokenInfoFunc {
+  return async (_) => ({});
 }

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
@@ -396,9 +396,13 @@ export class RemoteFetcher implements IFetcher {
         if (resp.decimals?.value) {
           v.decimals = resp.decimals.value;
         }
-        if (v.name || v.decimals) {
+        if (resp.ticker?.value) {
+          v.ticker = resp.ticker.value;
+        }
+        if (v.name || v.decimals || v.ticker) {
           res[resp.subject] = v;
         }
+
       }
       return res;
     }, {});

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/types.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/types.js
@@ -333,6 +333,7 @@ export type RemoteTokenInfo = {|
   // from token metadata (off chain)
   +name?: string,
   +decimals?: number,
+  +ticker?: string,
 |};
 export type TokenInfoResponse = {|
   [key: string]: (RemoteTokenInfo | null),

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/tests/multiwallet.test.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/tests/multiwallet.test.js
@@ -27,6 +27,7 @@ import {
   genGetTransactionsHistoryForAddresses,
   genGetBestBlock,
   getSingleAddressString,
+  genGetTokenInfo,
 } from '../../../state-fetch/mockNetwork';
 import { loadLovefieldDB } from '../../database/index';
 
@@ -422,6 +423,7 @@ async function syncingSimpleTransaction(
     network,
   );
   const getBestBlock = genGetBestBlock(txHistory);
+  const getTokenInfo = genGetTokenInfo();
 
   const withUtxos1 = asGetAllUtxos(publicDeriver1);
   expect(withUtxos1 != null).toEqual(true);
@@ -442,6 +444,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
     await checkPub1HasTx(purposeForTest, publicDeriver1);
 
@@ -480,6 +483,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     await checkPub2HasTx(purposeForTest, publicDeriver2);
@@ -506,6 +510,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
     await checkPub2IsEmpty(publicDeriver2);
     {
@@ -549,6 +554,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     await checkPub2HasTx(purposeForTest, publicDeriver2);

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/tests/shelley.test.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/tests/shelley.test.js
@@ -20,6 +20,7 @@ import {
   genGetTransactionsHistoryForAddresses,
   genGetBestBlock,
   getSingleAddressString,
+  genGetTokenInfo,
 } from '../../../state-fetch/mockNetwork';
 import {
   HARD_DERIVATION_START,
@@ -216,6 +217,7 @@ async function syncingSimpleTransaction(
     network,
   );
   const getBestBlock = genGetBestBlock(txHistory);
+  const getTokenInfo = genGetTokenInfo();
 
   const withDisplayCutoff = asDisplayCutoff(publicDeriver);
   if (!withDisplayCutoff) throw new Error('missing display cutoff functionality');
@@ -237,6 +239,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -347,6 +350,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/tests/simpleTxs.test.js
@@ -21,6 +21,7 @@ import {
   genGetTransactionsHistoryForAddresses,
   genGetBestBlock,
   getSingleAddressString,
+  genGetTokenInfo,
 } from '../../../state-fetch/mockNetwork';
 import {
   HARD_DERIVATION_START,
@@ -290,6 +291,7 @@ async function syncingSimpleTransaction(
     network,
   );
   const getBestBlock = genGetBestBlock(txHistory);
+  const getTokenInfo = genGetTokenInfo();
 
   const withDisplayCutoff = asDisplayCutoff(publicDeriver);
   if (!withDisplayCutoff) throw new Error('missing display cutoff functionality');
@@ -312,6 +314,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -422,6 +425,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     const dbDump2 = (await db.export()).tables;
@@ -581,6 +585,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -620,6 +625,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -654,6 +660,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       () => bestBlock,
+      getTokenInfo,
     );
 
     {
@@ -693,6 +700,7 @@ async function syncingSimpleTransaction(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -759,6 +767,7 @@ async function utxoCreatedAndUsed(
     network
   );
   const getBestBlock = genGetBestBlock(txHistory);
+  const getTokenInfo = genGetTokenInfo();
 
   const withDisplayCutoff = asDisplayCutoff(publicDeriver);
   if (!withDisplayCutoff) throw new Error('missing display cutoff functionality');
@@ -783,6 +792,7 @@ async function utxoCreatedAndUsed(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/tests/status.test.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/tests/status.test.js
@@ -20,6 +20,7 @@ import {
   genGetTransactionsHistoryForAddresses,
   genGetBestBlock,
   getSingleAddressString,
+  genGetTokenInfo,
 } from '../../../state-fetch/mockNetwork';
 import { loadLovefieldDB } from '../../database/index';
 import {
@@ -297,6 +298,7 @@ async function baseTest(
     network,
   );
   const getBestBlock = genGetBestBlock(networkTransactions);
+  const getTokenInfo = genGetTokenInfo();
 
   const withDisplayCutoff = asDisplayCutoff(publicDeriver);
   if (!withDisplayCutoff) throw new Error('missing display cutoff functionality');
@@ -314,6 +316,7 @@ async function baseTest(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -358,6 +361,7 @@ async function baseTest(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -482,6 +486,7 @@ async function baseTest(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -660,6 +665,7 @@ async function baseTest(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     {
@@ -827,6 +833,7 @@ async function baseTest(
       checkAddressesInUse,
       getTransactionsHistoryForAddresses,
       getBestBlock,
+      getTokenInfo,
     );
 
     expect((await db.export()).tables.Transaction).toEqual([{
@@ -925,6 +932,7 @@ async function pendingDropped(
     network
   );
   const getBestBlock = genGetBestBlock(networkTransactions);
+  const getTokenInfo = genGetTokenInfo();
 
   const basePubDeriver = asGetAllUtxos(publicDeriver);
   expect(basePubDeriver != null).toEqual(true);
@@ -939,6 +947,7 @@ async function pendingDropped(
     checkAddressesInUse,
     getTransactionsHistoryForAddresses,
     getBestBlock,
+    getTokenInfo,
   );
 
   // remove it from backend
@@ -951,6 +960,7 @@ async function pendingDropped(
     checkAddressesInUse,
     getTransactionsHistoryForAddresses,
     getBestBlock,
+    getTokenInfo,
   );
 
   expect((await db.export()).tables.Transaction).toEqual([

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1937,7 +1937,7 @@ export async function genCardanoAssetMap(
     existingDbRows.filter(
       // only tokens with lastUpdateAt are considered existing, except for default
       // asset rows, because they are never updated from network
-      row => row.lastUpdatedAt || row.IsDefault
+      row => row.Metadata.lastUpdatedAt || row.IsDefault
     ).map(row => row.Identifier)
   );
 
@@ -1975,7 +1975,6 @@ export async function genCardanoAssetMap(
         NetworkId: network.NetworkId,
         Identifier: tokenId,
         IsDefault: false,
-        lastUpdatedAt,
         Metadata: {
           type: 'Cardano',
           ticker,
@@ -1983,6 +1982,7 @@ export async function genCardanoAssetMap(
           numberOfDecimals,
           assetName: Buffer.from(parts.name.name()).toString('hex'),
           policyId: Buffer.from(parts.policyId.to_bytes()).toString('hex'),
+          lastUpdatedAt,
         }
       };
     });

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1933,15 +1933,14 @@ async function genCardanoAssetMap(
   const existingDbRows = (await deps.GetToken.fromIdentifier(
     db, dbTx,
     tokenIds
-  )).filter(row =>
-    row.NetworkId === network.NetworkId &&
-    // only rows with lastUpdateAt are considered existing, except for default asset
-    // rows, because they are never updated from network
-    row.lastUpdatedAt || row.IsDefault
-  );
+  )).filter(row => row.NetworkId === network.NetworkId);
 
   const existingTokens = new Set<string>(
-    existingDbRows.map(row => row.Identifier)
+    existingDbRows.filter(
+      // only tokens with lastUpdateAt are considered existing, except for default
+      // asset rows, because they are never updated from network
+      row => row.lastUpdatedAt || row.IsDefault
+    ).map(row => row.Identifier)
   );
 
   const missingTokenIds = tokenIds.filter(token => !existingTokens.has(token));

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1933,7 +1933,7 @@ export async function genCardanoAssetMap(
     tokenIds
   )).filter(row => row.NetworkId === network.NetworkId);
 
-  const existingRowsMap = new Map<string, TokenRow>(
+  const existingRowsMap = new Map<string, $ReadOnly<TokenRow>>(
     existingDbRows.map(row => [row.Identifier, row])
   );
 

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1933,6 +1933,10 @@ export async function genCardanoAssetMap(
     tokenIds
   )).filter(row => row.NetworkId === network.NetworkId);
 
+  const existingRowsMap = new Map<string, TokenRow>(
+    existingDbRows.map(row => [row.Identifier, row])
+  );
+
   const existingTokens = new Set<string>(
     existingDbRows.filter(
       // only tokens with lastUpdateAt are considered existing, except for default
@@ -1975,6 +1979,10 @@ export async function genCardanoAssetMap(
         NetworkId: network.NetworkId,
         Identifier: tokenId,
         IsDefault: false,
+        // must have the same TokenId, which is the primary key, as the existing
+        // token row, otherwise a new row is inserted instead of the existing row
+        // being updated
+        TokenId: existingRowsMap.get(tokenId)?.TokenId,
         Metadata: {
           type: 'Cardano',
           ticker,

--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
@@ -508,6 +508,9 @@ export type TokenInsert = {|
    * As some blockchains have multiple primary tokens
   */
   Identifier: string,
+  // If the token row is fetched from network, this is the ISO time string.
+  // Otherwise it is null or not present.
+  lastUpdatedAt?: ?string,
   Metadata: TokenMetadata,
 |};
 export type TokenRow = {|

--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
@@ -471,6 +471,9 @@ export type CommonMetadata = {|
   numberOfDecimals: number,
   ticker: null | string,
   longName: null | string,
+  // If the token row is fetched from network, this is the ISO time string.
+  // Otherwise it is null or not present.
+  lastUpdatedAt?: ?string,
 |};
 export type TokenMetadata = {|
   +type: 'Ergo',
@@ -508,9 +511,6 @@ export type TokenInsert = {|
    * As some blockchains have multiple primary tokens
   */
   Identifier: string,
-  // If the token row is fetched from network, this is the ISO time string.
-  // Otherwise it is null or not present.
-  lastUpdatedAt?: ?string,
   Metadata: TokenMetadata,
 |};
 export type TokenRow = {|

--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
@@ -513,6 +513,11 @@ export type TokenInsert = {|
   Identifier: string,
   Metadata: TokenMetadata,
 |};
+export type TokenUpsertWithDigest = TokenInsert | {|
+  TokenId?: ?number,
+  ...TokenInsert,
+|};
+export type TokenUpsert = $Diff<TokenUpsertWithDigest, {| Digest: number |}>;
 export type TokenRow = {|
   TokenId: number,
   ...TokenInsert,

--- a/packages/yoroi-extension/app/api/ergo/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ergo/lib/storage/bridge/updateTransactions.js
@@ -18,7 +18,7 @@ import type {
   AddressRow,
   ErgoTransactionInsert,
   TokenRow,
-  TokenListInsert,
+  TokenListInsert, TokenUpsert,
 } from '../../../../ada/lib/storage/database/primitives/tables';
 import {
   TransactionType,
@@ -1493,20 +1493,27 @@ async function rawAddErgoAssets(
     assetIds: tokenIdentifiers.filter(tokenIdentifier => !existingTokens.has(tokenIdentifier))
   });
 
-  const databaseInsert = Object.keys(tokenInfo).map(tokenId => ({
-    NetworkId: network.NetworkId,
-    Identifier: tokenId,
-    IsDefault: false,
-    Metadata: {
-      type: 'Ergo',
-      height: tokenInfo[tokenId].height,
-      boxId: tokenInfo[tokenId].boxId,
-      ticker: null,
-      longName: tokenInfo[tokenId].name,
-      numberOfDecimals: tokenInfo[tokenId].numDecimals || 0,
-      description: tokenInfo[tokenId].desc,
-    }
-  }));
+  const databaseInsert: Array<TokenUpsert> = Object.keys(tokenInfo).map(tokenId => {
+    const numberOfDecimals: number = tokenInfo[tokenId].numDecimals || 0;
+    const description: string | null = tokenInfo[tokenId].desc || null;
+    const boxId: string = tokenInfo[tokenId].boxId;
+    const height: number = tokenInfo[tokenId].height;
+    const longName: string | null = tokenInfo[tokenId].name || null;
+    return ({
+      NetworkId: network.NetworkId,
+      Identifier: tokenId,
+      IsDefault: false,
+      Metadata: {
+        type: 'Ergo',
+        height,
+        boxId,
+        ticker: null,
+        longName,
+        numberOfDecimals,
+        description,
+      }
+    });
+  });
 
   const newDbRows = await deps.ModifyToken.upsert(
     db, dbTx,

--- a/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaTransactionsStore.js
@@ -9,14 +9,6 @@ import type {
 } from '../../api/common';
 import type { ActionsMap } from '../../actions/index';
 import type { StoresMap } from '../index';
-import WalletTransaction from '../../domain/WalletTransaction';
-import CardanoShelleyTransaction from '../../domain/CardanoShelleyTransaction';
-import type { RemoteTokenInfo, TokenInfoResponse } from '../../api/ada/lib/state-fetch/types';
-import type { NetworkRow } from '../../api/ada/lib/storage/database/primitives/tables';
-
-function createTokenLocalStorageKey(tokenId: string, network: $ReadOnly<NetworkRow>): string {
-  return `token-metadata-${network.NetworkId}-${tokenId}`;
-}
 
 export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
 
@@ -28,39 +20,8 @@ export default class AdaTransactionsStore extends Store<StoresMap, ActionsMap> {
       getTransactionsHistoryForAddresses: stateFetcher.getTransactionsHistoryForAddresses,
       checkAddressesInUse: stateFetcher.checkAddressesInUse,
       getBestBlock: stateFetcher.getBestBlock,
+      getTokenInfo: stateFetcher.getTokenInfo,
     });
-
-    try {
-      const tokenIds = new Set<string>();
-      txs.transactions.forEach((tx: WalletTransaction) => {
-        tx.amount.values.forEach(t => tokenIds.add(t.identifier));
-        tx.addresses.from.flatMap(a => a.value.values).forEach(t => tokenIds.add(t.identifier));
-        tx.addresses.to.flatMap(a => a.value.values).forEach(t => tokenIds.add(t.identifier));
-        if (tx instanceof CardanoShelleyTransaction) {
-          tx.withdrawals.flatMap(w => w.value.values).forEach(t => tokenIds.add(t.identifier));
-        }
-      });
-      const network = request.publicDeriver.getParent().getNetworkInfo();
-      const missingMetaTokenIds = [...tokenIds]
-        .map(id => id?.split('.')?.join(''))
-        .filter(tokenId => tokenId.length > 0
-          && !localStorage.getItem(createTokenLocalStorageKey(tokenId, network)));
-      const tokenInfo: TokenInfoResponse = await stateFetcher.getTokenInfo({
-        network,
-        tokenIds: missingMetaTokenIds,
-      });
-      // $FlowFixMe[incompatible-call]
-      missingMetaTokenIds.forEach((tokenId: string) => {
-        const tokenMeta: ?RemoteTokenInfo = tokenInfo[tokenId];
-        localStorage.setItem(createTokenLocalStorageKey(tokenId, network), JSON.stringify({
-          ...tokenMeta,
-          timestamp: new Date().toISOString(),
-        }));
-      })
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Token metadata fetch failed. Reason: ', error);
-    }
 
     return txs;
   }

--- a/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
+++ b/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
@@ -81,22 +81,6 @@ export function genLookupOrFail(
       .get(lookup.networkId.toString())
       ?.get(lookup.identifier);
     if (tokenRow == null) throw new Error(`${nameof(genLookupOrFail)} no token info for ${JSON.stringify(lookup)}`);
-    // fixme: temporary solution
-    const id = lookup.identifier.split('.').join('');
-    const metadataStr = localStorage.getItem(
-      `token-metadata-${id}`
-    );
-    if (metadataStr) {
-      const clone = JSON.parse(JSON.stringify(tokenRow));
-      const metadata = JSON.parse(metadataStr);
-      if (typeof metadata.decimals === 'number') {
-        clone.Metadata.numberOfDecimals = metadata.decimals;
-      }
-      if (typeof metadata.name === 'string') {
-        clone.Metadata.assetName = Buffer.from(metadata.name).toString('hex');
-      }
-      return clone;
-    }
     return tokenRow;
   };
 }

--- a/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
+++ b/packages/yoroi-extension/app/stores/stateless/tokenHelpers.js
@@ -84,7 +84,7 @@ export function genLookupOrFail(
     // fixme: temporary solution
     const id = lookup.identifier.split('.').join('');
     const metadataStr = localStorage.getItem(
-      `token-metadata-${lookup.networkId}-${id}`
+      `token-metadata-${id}`
     );
     if (metadataStr) {
       const clone = JSON.parse(JSON.stringify(tokenRow));

--- a/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
@@ -45,7 +45,10 @@ export default class TokenInfoStore extends Store<StoresMap, ActionsMap> {
     );
   }
 
-  @action _fetchMissingTokenInfo: ({| wallet: PublicDeriver<> |}) => Promise<void> = async ({ wallet }) => {
+  @action _fetchMissingTokenInfo
+    : ({| wallet: PublicDeriver<> |}) => Promise<void>
+    = async ({ wallet }) => {
+
     const { requests } = this.stores.transactions.getTxRequests(wallet);
 
     await requests.getBalanceRequest;
@@ -82,7 +85,7 @@ export default class TokenInfoStore extends Store<StoresMap, ActionsMap> {
     const assetMap = await raii(
       db,
       depTables,
-      dbTx => (      
+      dbTx => (
         genCardanoAssetMap(
           db,
           dbTx,

--- a/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
@@ -1,19 +1,30 @@
 // @flow
 
-import { observable, runInAction } from 'mobx';
+import { observable, runInAction, action } from 'mobx';
 import Store from '../base/Store';
 
 import type {
   TokenInsert, TokenRow,
+  NetworkRow,
 } from '../../api/ada/lib/storage/database/primitives/tables';
 import {
   defaultAssets,
+  networks,
+  isCardanoHaskell,
 } from '../../api/ada/lib/storage/database/prepackaged/networks';
 import type {
   DefaultTokenEntry,
 } from '../../api/common/lib/MultiToken';
 import type { ActionsMap } from '../../actions/index';
 import type { StoresMap } from '../index';
+import {
+  getAllSchemaTables,
+  raii,
+} from '../../api/ada/lib/storage/database/utils';
+import { GetToken } from '../../api/ada/lib/storage/database/primitives/api/read';
+import { ModifyToken } from '../../api/ada/lib/storage/database/primitives/api/write';
+import { genCardanoAssetMap } from '../../api/ada/lib/storage/bridge/updateTransactions';
+import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/index'
 
 export type TokenInfoMap = Map<
   string, // network ID. String because mobx requires string for observable maps
@@ -29,27 +40,68 @@ export default class TokenInfoStore extends Store<StoresMap, ActionsMap> {
   setup(): void {
     super.setup();
     this.tokenInfo = new Map();
+    this.actions.wallets.setActiveWallet.listen(
+      wallet => { this._fetchMissingTokenInfo(wallet) }
+    );
   }
+
+  @action _fetchMissingTokenInfo: ({| wallet: PublicDeriver<> |}) => Promise<void> = async ({ wallet }) => {
+    const { requests } = this.stores.transactions.getTxRequests(wallet);
+
+    await requests.getBalanceRequest;
+    const balance = requests.getBalanceRequest.result;
+    if (!balance || !balance.size) {
+      return;
+    }
+    // expect all tokens to have an identical network id
+    const networkId = balance.values[0].networkId;
+    const tokenIds = balance.values
+      .filter(token => token.networkId === networkId)
+      .map(token => token.identifier);
+
+    const db = this.stores.loading.getDatabase();
+    if (!db) {
+      return;
+    }
+
+    const network: ?NetworkRow = (Object.values(networks): Array<any>).find(
+      ({ NetworkId }) => NetworkId === networkId
+    );
+    if (!network || !isCardanoHaskell(network)) {
+      return;
+    }
+    const deps =  Object.freeze({
+      ModifyToken,
+      GetToken,
+    });
+    const depTables = Object
+      .keys(deps)
+      .map(key => deps[key])
+      .flatMap(table => getAllSchemaTables(db, table));
+
+    const assetMap = await raii(
+      db,
+      depTables,
+      dbTx => (      
+        genCardanoAssetMap(
+          db,
+          dbTx,
+          deps,
+          tokenIds,
+          this.stores.substores.ada.stateFetchStore.fetcher.getTokenInfo,
+          network,
+        )
+      )
+    );
+    runInAction(() => { this._updateTokenInfo([...assetMap.values()]) });
+  };
 
   refreshTokenInfo: void => Promise<void> = async () => {
     const db = this.stores.loading.getDatabase();
     if (db == null) throw new Error(`${nameof(TokenInfoStore)}::${nameof(this.refreshTokenInfo)} called before storage was initialized`);
     const tokens = await this.api.common.getTokenInfo({ db });
 
-    runInAction(() => {
-      for (const token of tokens) {
-        const mapForNetwork = this.tokenInfo.get(token.NetworkId.toString());
-
-        if (mapForNetwork == null) {
-          const newMap: Map<string, $ReadOnly<TokenRow>> = observable.map();
-          newMap.set(token.Identifier, token);
-          this.tokenInfo.set(token.NetworkId.toString(), newMap);
-        } else {
-          // note: always update since cache may be out of date
-          mapForNetwork.set(token.Identifier, token);
-        }
-      }
-    });
+    runInAction(() => { this._updateTokenInfo(tokens) });
   }
 
   getDefaultTokenInfo: number => $ReadOnly<TokenRow> = (
@@ -59,6 +111,21 @@ export default class TokenInfoStore extends Store<StoresMap, ActionsMap> {
       networkId,
       this.tokenInfo
     );
+  }
+
+  _updateTokenInfo: $ReadOnlyArray<$ReadOnly<TokenRow>> => void = (tokens) => {
+    for (const token of tokens) {
+      const mapForNetwork = this.tokenInfo.get(token.NetworkId.toString());
+
+      if (mapForNetwork == null) {
+        const newMap: Map<string, $ReadOnly<TokenRow>> = observable.map();
+        newMap.set(token.Identifier, token);
+        this.tokenInfo.set(token.NetworkId.toString(), newMap);
+      } else {
+        // note: always update since cache may be out of date
+        mapForNetwork.set(token.Identifier, token);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Originally in transaction-update code, there was commented-out stub that deals with token info.

Previously Ruslan implemented the fetch functions for token metadata and stored the data in local storage as a temporary measure. 

This PR builds on top of Ruslan's fetch function and calls it in the originally designed place and stores the token metadata properly in the storage layer.

A new field `lastUpdatedAt` is added to the token row. its purpose is to distinguish the token data fetched from the network from a placeholder row so that it would be updated when the token metadata become available.