### PR TITLE
Fix Ergo connector crash

### DIFF
--- a/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
@@ -41,7 +41,7 @@ export default class TokenInfoStore extends Store<StoresMap, ActionsMap> {
     super.setup();
     this.tokenInfo = new Map();
     // the Ergo connector doesn't have this action
-    if (this.actions.wallets?.setActiveWallet) {
+    if (this.actions.wallets.setActiveWallet) {
       this.actions.wallets.setActiveWallet.listen(
         wallet => { this._fetchMissingTokenInfo(wallet) }
       );

--- a/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
@@ -40,9 +40,12 @@ export default class TokenInfoStore extends Store<StoresMap, ActionsMap> {
   setup(): void {
     super.setup();
     this.tokenInfo = new Map();
-    this.actions.wallets.setActiveWallet.listen(
-      wallet => { this._fetchMissingTokenInfo(wallet) }
-    );
+    // the Ergo connector doesn't have this action
+    if (this.actions.wallets?.setActiveWallet) {
+      this.actions.wallets.setActiveWallet.listen(
+        wallet => { this._fetchMissingTokenInfo(wallet) }
+      );
+    }
   }
 
   @action _fetchMissingTokenInfo


### PR DESCRIPTION
The Ergo connector app (`/main_window_ergo.html`) has a different action map than the main Yoroi extension app. Accessing to `actions.wallets.setActiveWallet` in the Ergo connector app leads to crash. It is fixed by wrapping in a check.