### PR TITLE
[hotfix/4.5.7] Ledger instruction link fix

### DIFF
--- a/packages/yoroi-extension/app/components/wallet/voting/Voting.js
+++ b/packages/yoroi-extension/app/components/wallet/voting/Voting.js
@@ -46,7 +46,7 @@ const messages = defineMessages({
   },
   ledgerNanoRequirement: {
     id: 'wallet.voting.ledgerNanoRequirement',
-    defaultMessage: '!!!<a target="_blank" rel="noopener noreferrer" href="https://emurgo.github.io/yoroi-extension-ledger-connect-vnext/catalyst#/update-ledger-app">Update</a>the Cardano app on your Ledger to version 2.3.2 or above with <a target="_blank" rel="noopener noreferrer" href="https://www.ledger.com/ledger-live"> Ledger Live</a>.',
+    defaultMessage: '!!!<a target="_blank" rel="noopener noreferrer" href="https://emurgo.github.io/yoroi-extension-ledger-connect-vnext/catalyst/update-ledger-app/">Update</a>the Cardano app on your Ledger to version 2.3.2 or above with <a target="_blank" rel="noopener noreferrer" href="https://www.ledger.com/ledger-live"> Ledger Live</a>.',
   },
 });
 

--- a/packages/yoroi-extension/app/i18n/locales/en-US.json
+++ b/packages/yoroi-extension/app/i18n/locales/en-US.json
@@ -783,7 +783,7 @@
   "wallet.voting.dialog.title": "Register for Voting",
   "wallet.voting.dialog.transactionLabel": "Transaction",
   "wallet.voting.keepDelegated": "Your voting power is how much you delegate and the voting rewards will be distributed to your delegation reward address. Please keep delegated until the voting ends.",
-  "wallet.voting.ledgerNanoRequirement": "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://emurgo.github.io/yoroi-extension-ledger-connect-vnext/catalyst#/update-ledger-app\">Update</a>the Cardano app on your Ledger to version 2.3.2 or above with <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.ledger.com/ledger-live\"> Ledger Live</a>.",
+  "wallet.voting.ledgerNanoRequirement": "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://emurgo.github.io/yoroi-extension-ledger-connect-vnext/catalyst/update-ledger-app/\">Update</a>the Cardano app on your Ledger to version 2.3.2 or above with <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.ledger.com/ledger-live\"> Ledger Live</a>.",
   "wallet.voting.line2": "Before you begin, make sure to complete steps below",
   "wallet.voting.line3": "Download the Catalyst Voting App.",
   "wallet.voting.line4": "Open the Catalyst Voting App and click on the Complete registration button.",

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",


### PR DESCRIPTION
I have accidentally skipped one commit during the Ledger Catalyst support backport in https://github.com/Emurgo/yoroi-frontend/pull/2215 ☹️ 