### PR TITLE
Nightly / 4.5.7001

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.6.0-rc1",
+  "version": "4.5.7001",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.6.0-rc1",
+  "version": "4.5.7001",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",


### PR DESCRIPTION
## Last prod: `4.5.7`

https://github.com/Emurgo/yoroi-frontend/releases/tag/4.5.7

## Main includes after last prod

1. Hardware wallets support for Catalyst
2. Ergo p2s and data-inputs, plus latest fixes, plus migration to sigma-rust 13.3
3. UI improvements

## Full PR diff since last prod

- https://github.com/Emurgo/yoroi-frontend/pull/2081 - 'Data inputs + P2S support' [@rooooooooob]
- https://github.com/Emurgo/yoroi-frontend/pull/2087 - 'buid(yoroi-extension): buld scripts now compatible with Windows' [@danielmain]
- https://github.com/Emurgo/yoroi-frontend/pull/2096 - 'Ledger wallet Catalyst voting registration support' [@yushih]
- https://github.com/Emurgo/yoroi-frontend/pull/2100 - 'UI updates for hardware wallet Catalyst registration' [@yushih]
- https://github.com/Emurgo/yoroi-frontend/pull/2103 - 'Migration to SigmaRust 0.13.x' [@oskin1]
- https://github.com/Emurgo/yoroi-frontend/pull/2114 - 'Fix Catalyst round Info in UI' [@v-almonacid]
- https://github.com/Emurgo/yoroi-frontend/pull/2119 - 'Add github actions to do flow and lint checks' [@yushih]
- https://github.com/Emurgo/yoroi-frontend/pull/2120 - 'Sigma Rust some Flow fixes' [@vantuz-subhuman]
- https://github.com/Emurgo/yoroi-frontend/pull/2122 - 'Ergo Flow and Lint fixes' [@vantuz-subhuman]
- https://github.com/Emurgo/yoroi-frontend/pull/2151 - 'Fix for Ergo unknown address type error in develop' [@rooooooooob]
- https://github.com/Emurgo/yoroi-frontend/pull/2166 - 'Fixes for issues caused when sigma-rust was updated to 0.13.1' [@rooooooooob]
- https://github.com/Emurgo/yoroi-frontend/pull/2169 - 'ergo-lib updated to 0.13.2' [@oskin1]
- https://github.com/Emurgo/yoroi-frontend/pull/2170 - 'Ergo Connector: Fix crash when signing a TX that mints new assets' [@rooooooooob]
- https://github.com/Emurgo/yoroi-frontend/pull/2171 - 'change icon "transactions" ' [@AhmedIbrahim336]
- https://github.com/Emurgo/yoroi-frontend/pull/2172 - 'Update the eye icon in the input field and update the logic' [@AhmedIbrahim336]
- https://github.com/Emurgo/yoroi-frontend/pull/2173 - 'Enable tests in gh checks' [@vantuz-subhuman]
- https://github.com/Emurgo/yoroi-frontend/pull/2178 - 'Tab icons css tiny fix' [@vantuz-subhuman]
- https://github.com/Emurgo/yoroi-frontend/pull/2181 - 'Token metadata revamp' [@yushih]
- https://github.com/Emurgo/yoroi-frontend/pull/2182 - 'Add the showEyeIcon prop to check if render the eye icon or not' [@AhmedIbrahim336]
- https://github.com/Emurgo/yoroi-frontend/pull/2183 - 'Remove the border-radius styling from the tab button' [@AhmedIbrahim336]
- https://github.com/Emurgo/yoroi-frontend/pull/2184 - 'Remove the chart legend also every related styling and components' [@AhmedIbrahim336]
- https://github.com/Emurgo/yoroi-frontend/pull/2185 - 'Change the close icon for the verify address dialog' [@AhmedIbrahim336]
- https://github.com/Emurgo/yoroi-frontend/pull/2186 - 'Display assets under main token amount in tx list' [@yushih]
- https://github.com/Emurgo/yoroi-frontend/pull/2189 - 'Move the shelley wallet to top' [@AhmedIbrahim336]
- https://github.com/Emurgo/yoroi-frontend/pull/2213 - 'Cardano dApp-connector : Add read-access functions for cardano' [@AhmedIbrahim336]
- https://github.com/Emurgo/yoroi-frontend/pull/2214 - 'Fix Ergo connector crash' [@yushih]