### PR TITLE
Nightly / 4.5.7002

### DIFF
--- a/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
@@ -41,7 +41,7 @@ export default class TokenInfoStore extends Store<StoresMap, ActionsMap> {
     super.setup();
     this.tokenInfo = new Map();
     // the Ergo connector doesn't have this action
-    if (this.actions.wallets.setActiveWallet) {
+    if (this.actions.wallets?.setActiveWallet) {
       this.actions.wallets.setActiveWallet.listen(
         wallet => { this._fetchMissingTokenInfo(wallet) }
       );

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.5.7001",
+  "version": "4.5.7002",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.5.7001",
+  "version": "4.5.7002",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",


### PR DESCRIPTION
Same as "Nightly / 4.5.7001" https://github.com/Emurgo/yoroi-frontend/pull/2222

With a single safe-navigation fix included.