### PR TITLE
bump chromedriver version to 91

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1947,10 +1947,15 @@ export async function genCardanoAssetMap(
 
   const missingTokenIds = tokenIds.filter(token => !existingTokens.has(token));
 
-  const tokenInfoResponse = await getTokenInfo({
-    network,
-    tokenIds: missingTokenIds.map(id => id.split('.').join(''))
-  });
+  let tokenInfoResponse;
+  try {
+    tokenInfoResponse = await getTokenInfo({
+      network,
+      tokenIds: missingTokenIds.map(id => id.split('.').join(''))
+    });
+  } catch {
+    tokenInfoResponse = {};
+  }
 
   const databaseInsert = missingTokenIds
     .map(tokenId => {

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -11203,8 +11203,8 @@
     },
     "@testim/chrome-version": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
-      "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
+      "resolved": "https://registry.npm.taobao.org/@testim/chrome-version/download/@testim/chrome-version-1.0.7.tgz",
+      "integrity": "sha1-DNkVeF7EGQ8Io6asybYfw4+18ak=",
       "dev": true
     },
     "@tippyjs/react": {
@@ -11755,9 +11755,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.nlark.com/@types/yauzl/download/@types/yauzl-2.9.2.tgz",
+      "integrity": "sha1-xI5dVq/xREQJ45+hZLC01FUqe3o=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -15141,43 +15141,33 @@
       }
     },
     "chromedriver": {
-      "version": "87.0.4",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-87.0.4.tgz",
-      "integrity": "sha512-kD4N/L8c0nAzh1eEAiAbEIq6Pn5TvGvckODvP5dPqF90q5tPiAJZCoWWSOUV/mrPxiodjHPfmNeOfGERHugzug==",
+      "version": "91.0.1",
+      "resolved": "https://registry.nlark.com/chromedriver/download/chromedriver-91.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fchromedriver%2Fdownload%2Fchromedriver-91.0.1.tgz",
+      "integrity": "sha1-TXClaZAeNWyXikHeMBnEZPKo69A=",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
-        "axios": "^0.21.0",
+        "axios": "^0.21.1",
         "del": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
-        "mkdirp": "^1.0.4",
         "proxy-from-env": "^1.1.0",
         "tcp-port-used": "^1.0.1"
       },
       "dependencies": {
         "agent-base": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "resolved": "https://registry.npm.taobao.org/agent-base/download/agent-base-6.0.2.tgz?cache=0&sync_timestamp=1603479960600&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fagent-base%2Fdownload%2Fagent-base-6.0.2.tgz",
+          "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
           "dev": true,
           "requires": {
             "debug": "4"
           }
         },
-        "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
-        },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.nlark.com/debug/download/debug-4.3.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fdebug%2Fdownload%2Fdebug-4.3.2.tgz",
+          "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -15185,8 +15175,8 @@
         },
         "extract-zip": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-          "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+          "resolved": "https://registry.npm.taobao.org/extract-zip/download/extract-zip-2.0.1.tgz",
+          "integrity": "sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=",
           "dev": true,
           "requires": {
             "@types/yauzl": "^2.9.1",
@@ -15197,8 +15187,8 @@
         },
         "get-stream": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "resolved": "https://registry.npm.taobao.org/get-stream/download/get-stream-5.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fget-stream%2Fdownload%2Fget-stream-5.2.0.tgz",
+          "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -15206,30 +15196,24 @@
         },
         "https-proxy-agent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "resolved": "https://registry.nlark.com/https-proxy-agent/download/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
           "dev": true,
           "requires": {
             "agent-base": "6",
             "debug": "4"
           }
         },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&sync_timestamp=1607433912031&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         },
         "proxy-from-env": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+          "resolved": "https://registry.npm.taobao.org/proxy-from-env/download/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I=",
           "dev": true
         }
       }
@@ -16644,8 +16628,8 @@
     },
     "del": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "resolved": "https://registry.npm.taobao.org/del/download/del-6.0.0.tgz",
+      "integrity": "sha1-C0DQMyzqdD8WFPgYvk/rcXcUyVI=",
       "dev": true,
       "requires": {
         "globby": "^11.0.1",
@@ -16658,127 +16642,11 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "@nodelib/fs.stat": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
-          "dev": true
-        },
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-          "dev": true
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
-        "fast-glob": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
-          "dev": true,
-          "requires": {
-            "@nodelib/fs.stat": "^2.0.2",
-            "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
-            "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "globby": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
-            "slash": "^3.0.0"
-          }
-        },
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "version": "4.2.6",
+          "resolved": "https://registry.nlark.com/graceful-fs/download/graceful-fs-4.2.6.tgz?cache=0&sync_timestamp=1618846820463&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fgraceful-fs%2Fdownload%2Fgraceful-fs-4.2.6.tgz",
+          "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
           "dev": true
-        },
-        "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-          "dev": true
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
-        },
-        "p-map": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
         }
       }
     },
@@ -19860,12 +19728,6 @@
       "resolved": "https://registry.npmjs.org/fnv-plus/-/fnv-plus-1.3.1.tgz",
       "integrity": "sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw=="
     },
-    "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
-      "dev": true
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -21912,8 +21774,8 @@
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "resolved": "https://registry.npm.taobao.org/is-path-cwd/download/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
       "dev": true
     },
     "is-path-inside": {
@@ -22007,8 +21869,8 @@
     },
     "is-url": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "resolved": "https://registry.npm.taobao.org/is-url/download/is-url-1.2.4.tgz",
+      "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI=",
       "dev": true
     },
     "is-utf8": {
@@ -22042,9 +21904,9 @@
       "dev": true
     },
     "is2": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.6.tgz",
-      "integrity": "sha512-+Z62OHOjA6k2sUDOKXoZI3EXv7Fb1K52jpTBLbkfx62bcUeSsrTBLhEquCRDKTx0XE5XbHcG/S2vrtE3lnEDsQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.nlark.com/is2/download/is2-2.0.7.tgz",
+      "integrity": "sha1-0IThDKs71F1snf3npIWZ/LuT/Kw=",
       "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
@@ -22053,9 +21915,9 @@
       },
       "dependencies": {
         "ip-regex": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
-          "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npm.taobao.org/ip-regex/download/ip-regex-4.3.0.tgz?cache=0&sync_timestamp=1611327032630&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fip-regex%2Fdownload%2Fip-regex-4.3.0.tgz",
+          "integrity": "sha1-aHJ1qw9X+naXj/j03dyKI9WZDbU=",
           "dev": true
         }
       }
@@ -32198,8 +32060,8 @@
     },
     "tcp-port-used": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
-      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+      "resolved": "https://registry.npm.taobao.org/tcp-port-used/download/tcp-port-used-1.0.2.tgz",
+      "integrity": "sha1-llK3Q26x9M+uERx5tViiV2n2+uo=",
       "dev": true,
       "requires": {
         "debug": "4.3.1",
@@ -32208,8 +32070,8 @@
       "dependencies": {
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "resolved": "https://registry.nlark.com/debug/download/debug-4.3.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fdebug%2Fdownload%2Fdebug-4.3.1.tgz",
+          "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -32217,8 +32079,8 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&sync_timestamp=1607433912031&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
       }

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -100,7 +100,7 @@
     "cardano-wallet": "1.2.2",
     "chai": "4.3.0",
     "chai-as-promised": "7.1.1",
-    "chromedriver": "87.0.4",
+    "chromedriver": "91.0.1",
     "config": "1.31.0",
     "config-webpack": "1.0.4",
     "crx": "5.0.1",


### PR DESCRIPTION
The original chromedriver version 87 requires Chrome version 87, which is not available for Mac with M1. Hence bump it to version 91.

Also, fix a problem that fails some e2e tests.