### PR TITLE
Get rid of some type coersions in Ergo connector store initialization code

### DIFF
--- a/packages/yoroi-extension/app/ergo-connector/stores/index.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/index.js
@@ -39,7 +39,7 @@ export type StoresMap = {|
   coinPriceStore: ConnectorCoinPriceStore,
   loading: ConnectorLoadingStore,
   connector: ConnectorStore,
-  tokenInfoStore: TokenInfoStore,
+  tokenInfoStore: TokenInfoStore<StoresMap, ActionsMap>,
   substores: {|
     ada: AdaStoresMap,
     ergo: ErgoStoresMap,

--- a/packages/yoroi-extension/app/ergo-connector/stores/index.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/index.js
@@ -31,7 +31,7 @@ const storeClasses = Object.freeze({
 });
 
 export type StoresMap = {|
-  stateFetchStore: StateFetchStore,
+  stateFetchStore: StateFetchStore<StoresMap, ActionsMap>,
   profile: ProfileStore,
   uiDialogs: UiDialogsStore<{||}, ActionsMap>,
   uiNotifications: UiNotificationsStore<{||}, ActionsMap>,

--- a/packages/yoroi-extension/app/ergo-connector/stores/index.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/index.js
@@ -79,7 +79,7 @@ export default (action(
       if (stores[name]) stores[name].teardown();
     });
     storeNames.forEach(name => {
-      stores[name] = (new storeClasses[name]((stores: any), api, (actions: any)): any);
+      stores[name] = (new storeClasses[name]((stores: any), api, actions): any);
     });
     storeNames.forEach(name => {
       if (stores[name]) stores[name].initialize();

--- a/packages/yoroi-extension/app/ergo-connector/stores/index.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/index.js
@@ -47,7 +47,10 @@ export type StoresMap = {|
 |};
 
 /** Constant that represents the stores across the lifetime of the application */
-const stores: WithNullableFields<StoresMap> = observable({
+// Note: initially we assign a map of all-null values which violates the type (thus
+// the cast to `any`), but as soon as the below set-up code is executed, the object
+// becomes conformant to the type.
+const stores: StoresMap = (observable({
   stateFetchStore: null, // best to initialize first to avoid issues
   profile: null,
   explorers: null,
@@ -58,7 +61,7 @@ const stores: WithNullableFields<StoresMap> = observable({
   connector: null,
   tokenInfoStore: null,
   substores: null,
-});
+}): any);
 
 function initializeSubstore<T: {...}>(
   substore: T,
@@ -79,7 +82,7 @@ export default (action(
       if (stores[name]) stores[name].teardown();
     });
     storeNames.forEach(name => {
-      stores[name] = (new storeClasses[name]((stores: any), api, actions): any);
+      stores[name] = (new storeClasses[name](stores, api, actions): any);
     });
     storeNames.forEach(name => {
       if (stores[name]) stores[name].initialize();

--- a/packages/yoroi-extension/app/stores/index.js
+++ b/packages/yoroi-extension/app/stores/index.js
@@ -96,7 +96,10 @@ export type StoresMap = {|
 |};
 
 /** Constant that represents the stores across the lifetime of the application */
-const stores: WithNullableFields<StoresMap> = observable({
+// Note: initially we assign a map of all-null values which violates the type (thus
+// the cast to `any`), but as soon as the below set-up code is executed, the object
+// becomes conformant to the type.
+const stores: StoresMap = (observable({
   stateFetchStore: null, // best to initialize first to avoid issues
   coinPriceStore: null,
   tokenInfoStore: null,
@@ -123,7 +126,7 @@ const stores: WithNullableFields<StoresMap> = observable({
   explorers: null,
   substores: null,
   router: null,
-});
+}): any);
 
 function initializeSubstore<T: {...}>(
   substore: T,
@@ -160,7 +163,7 @@ export default (action(
     storeNames.forEach(name => {
       // Careful: we pass incomplete `store` down to child components
       // Any toplevel store that accesses `store` in its constructor may crash
-      stores[name] = ((new storeClasses[name]((stores: any), api, actions)): any);
+      stores[name] = ((new storeClasses[name](stores, api, actions)): any);
     });
     storeNames.forEach(name => { if (stores[name]) stores[name].initialize(); });
 

--- a/packages/yoroi-extension/app/stores/index.js
+++ b/packages/yoroi-extension/app/stores/index.js
@@ -65,7 +65,7 @@ const storeClasses = Object.freeze({
 export type StoresMap = {|
   stateFetchStore: StateFetchStore,
   coinPriceStore: CoinPriceStore,
-  tokenInfoStore: TokenInfoStore,
+  tokenInfoStore: TokenInfoStore<StoresMap, ActionsMap>,
   profile: ProfileStore,
   serverConnectionStore: ServerConnectionStore,
   app: AppStore,

--- a/packages/yoroi-extension/app/stores/index.js
+++ b/packages/yoroi-extension/app/stores/index.js
@@ -63,7 +63,7 @@ const storeClasses = Object.freeze({
 });
 
 export type StoresMap = {|
-  stateFetchStore: StateFetchStore,
+  stateFetchStore: StateFetchStore<StoresMap, ActionsMap>,
   coinPriceStore: CoinPriceStore,
   tokenInfoStore: TokenInfoStore<StoresMap, ActionsMap>,
   profile: ProfileStore,

--- a/packages/yoroi-extension/app/stores/toplevel/StateFetchStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/StateFetchStore.js
@@ -6,10 +6,17 @@ import type { IFetcher } from '../../api/common/lib/state-fetch/IFetcher';
 import { RemoteFetcher } from '../../api/common/lib/state-fetch/remoteFetcher';
 import { BatchedFetcher } from '../../api/common/lib/state-fetch/batchedFetcher';
 import environment from '../../environment';
-import type { ActionsMap } from '../../actions/index';
-import type { StoresMap } from '../index';
 
-export default class StateFetchStore extends Store<StoresMap, ActionsMap> {
+export default class StateFetchStore<
+  StoresMapType: {
+    +profile: {
+      +currentLocale: string,
+      ...
+    },
+    ...
+  },
+  ActionsMapType
+> extends Store<StoresMapType, ActionsMapType> {
 
   @observable fetcher: IFetcher;
 


### PR DESCRIPTION
Each store class references a store map object and an action map object. At first, there was only one main app and thus one store map and one action map. So all is good. Then there is the Ergo connector app, which re-uses some store classes, but passes to them the Ergo-specific store map and action map by coercing the types to `any`. This confuses flow when type checking for the Ergo connector code and create problems like #2214 and  #2228.

This PR gets rid of the casts to `any` in Ergo connector store initialization code. To achieve this, two store classes that are used by both the main app and the Ergo connector are converted to generics, with the store map and action map types as type parameters.

The changes are almost purely in type annotations except for one trivial addition of runtime nullability check.