### PR TITLE
Fix not fetching token info when there is exactly one wallet

### DIFF
--- a/packages/yoroi-extension/app/stores/toplevel/WalletStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/WalletStore.js
@@ -305,7 +305,7 @@ export default class WalletStore extends Store<StoresMap, ActionsMap> {
     }
     runInAction('refresh active wallet', () => {
       if (this.selected == null && newWithCachedData.length === 1) {
-        this._setActiveWallet({
+        this.actions.wallets.setActiveWallet.trigger({
           wallet: newWithCachedData[0],
         });
       }


### PR DESCRIPTION
This is a bug of #2181. In that PR, when a wallet is selected, the token info is refreshed.  When there is only one wallet, it should also refresh the token info on launch (as if there is an auto-select action). But the bug prevents the token info from refreshing in this case.

Scope: since #2181 has gone into Nightly/4.6-rc1 and Nightly/4.5.7001, these releases are affected.


