### PR TITLE
Attempt to fix a crash scenario by optimizing memory usage

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/transactionModels/multipart/api/read.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/transactionModels/multipart/api/read.js
@@ -183,7 +183,7 @@ export class CardanoShelleyAssociateTxWithIOs {
       { txIds: request.txs.map(transaction => transaction.TransactionId) },
     );
 
-    const tokens = await CardanoByronAssociateTxWithIOs.depTables.AssociateToken.join(
+    const _tokens = await CardanoByronAssociateTxWithIOs.depTables.AssociateToken.join(
       db, tx,
       {
         listIds: request.txs.flatMap(transaction => {
@@ -199,6 +199,14 @@ export class CardanoShelleyAssociateTxWithIOs {
         networkId: request.networkId,
       }
     );
+    const tokens = _tokens.map(token => ({
+      TokenList: token.TokenList,
+      Token: {
+        TokenId: token.Token.TokenId,
+        Identifier: token.Token.Identifier,
+        NetworkId: token.Token.NetworkId,
+      }
+    }));
 
     const fullTx = request.txs.map(transaction  => ({
       txType: TransactionType.CardanoShelley,
@@ -206,14 +214,7 @@ export class CardanoShelleyAssociateTxWithIOs {
       certificates: certsForTxs.get(transaction.TransactionId) ?? [],
       ...getOrThrow(utxo.get(transaction)),
       accountingInputs: getOrThrow(accounting.get(transaction)).accountingInputs,
-      tokens: tokens.map(token => ({
-        TokenList: token.TokenList,
-        Token: {
-          TokenId: token.Token.TokenId,
-          Identifier: token.Token.Identifier,
-          NetworkId: token.Token.NetworkId,
-        },
-      })),
+      tokens,
     }));
     return fullTx;
   }


### PR DESCRIPTION
I believe #2231 is due to OOM. By profiling memory allocation with Chrome dev tools, I found the hot spot to be:
https://github.com/Emurgo/yoroi-frontend/blob/develop/packages/yoroi-extension/app/api/ada/lib/storage/database/transactionModels/multipart/api/read.js#L209
There are over 800 txs in this case and each time the map functions for `request.txs.map` runs, the `tokens.map` expression consumes about 9MB of memory, eventually draining memory. But this is a constant expression over the loop and its return value is a read-only object (guaranteed by its type definition). So I lift the expression out of the map loop.

In my env, this fixes the crash of the wallet in question. 