### PR TITLE
Fix numberOfDecimals set to NaN

### DIFF
--- a/packages/yoroi-extension/app/api/ergo/lib/state-fetch/mockNetwork.js
+++ b/packages/yoroi-extension/app/api/ergo/lib/state-fetch/mockNetwork.js
@@ -25,6 +25,7 @@ import { derivePath } from '../../../common/lib/crypto/keys/keyRepository';
 import { RollbackApiError, } from '../../../common/errors';
 import { getErgoBaseConfig } from '../../../ada/lib/storage/database/prepackaged/networks';
 import { RustModule } from '../../../ada/lib/cardanoCrypto/rustLoader';
+import { parseEIP0004Data } from '../../../../../chrome/extension/ergo-connector/utils';
 
 // note: this function assumes mainnet
 export function getErgoAddress(
@@ -208,43 +209,15 @@ export function decodeErgoTokenInfo(
   desc: string | null,
   numDecimals: number | null,
 |} {
-  /**
-  * try parsing an int (base 10) and return NaN if it fails
-  * Can't use parseInt because parseInt('1a') returns '1' instead of failing
-  */
-  const hexToIntOrNaN: string => number = (x) => {
-    return /^[0-9a-fA-F]+$/.test(x) ? Number.parseInt(x, 16) : NaN
-  }
-
-  const numDecimalsToNum: (x: string | null) => number | null = (x) => {
-    if (x == null) return x;
-    return /^[0-9]+$/.test(x) ? Number.parseInt(x, 10) : null
-  }
-
-  // note: the following code is all according to EIP-4
-  // https://github.com/ergoplatform/eips/blob/master/eip-0004.md
-  const decode = (field: void | string): null | string => {
-    if (field == null) return null;
-    // recall: every encoding start with 0e then one byte for length
-    // minimum 3 bytes: 1 for prefix, 1 for length, 1 for content
-    if (field.length < 3 * 2) return null;
-
-    const expectedSize = hexToIntOrNaN(field.substring(2, 4));
-    if (isNaN(expectedSize)) return null;
-    const content = field.substring('0eff'.length);
-    if (content.length !== 2 * expectedSize) return null;
-
-    const bytes = Buffer.from(content, 'hex');
-    const string = new TextDecoder('utf-8').decode(bytes);
-
-    return string;
-  }
+  const name = parseEIP0004Data(registers.R4);
+  const desc = parseEIP0004Data(registers.R5);
+  const numDecimals = parseInt(parseEIP0004Data(registers.R6) ?? '', 10);
 
   return {
-    name: decode(registers.R4),
-    desc: decode(registers.R5),
-    numDecimals: numDecimalsToNum(decode(registers.R6)),
-  }
+    name,
+    desc,
+    numDecimals: isNaN(numDecimals) ? null : numDecimals,
+  };
 }
 
 export function genGetAssetInfo(

--- a/packages/yoroi-extension/app/api/ergo/lib/state-fetch/mockNetwork.js
+++ b/packages/yoroi-extension/app/api/ergo/lib/state-fetch/mockNetwork.js
@@ -209,8 +209,8 @@ export function decodeErgoTokenInfo(
   desc: string | null,
   numDecimals: number | null,
 |} {
-  const name = parseEIP0004Data(registers.R4);
-  const desc = parseEIP0004Data(registers.R5);
+  const name = parseEIP0004Data(registers.R4) || null
+  const desc = parseEIP0004Data(registers.R5) || null;
   const numDecimals = parseInt(parseEIP0004Data(registers.R6) ?? '', 10);
 
   return {

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/utils.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/utils.js
@@ -4,7 +4,7 @@ import type { Tx } from './types';
 import type { TokenRow } from '../../../app/api/ada/lib/storage/database/primitives/tables';
 import { Logger } from '../../../app/utils/logging';
 
-function parseEIP0004Data(input: any): ?string {
+export function parseEIP0004Data(input: any): ?string {
   // https://github.com/ergoplatform/eips/blob/master/eip-0004.md
   // format is: 0e + vlq(len(body as bytes)) + body (as bytes formatted in hex)
   // where body is a utf8 string
@@ -51,7 +51,7 @@ export function mintedTokenInfo(tx: Tx): $ReadOnly<TokenRow>[] {
           type: 'Ergo',
           height: tx.inputs[0].creationHeight,
           boxId: tx.inputs[0].boxId,
-          numberOfDecimals: isNaN(decimals) ? null : decimals,
+          numberOfDecimals: isNaN(decimals) ? 0 : decimals,
           ticker: name,
           longName: description,
           description,

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/utils.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/utils.js
@@ -39,7 +39,7 @@ export function mintedTokenInfo(tx: Tx): $ReadOnly<TokenRow>[] {
   for (const output of tx.outputs) {
     const name = parseEIP0004Data(output.additionalRegisters.R4);
     const description = parseEIP0004Data(output.additionalRegisters.R5);
-    const decimals = parseEIP0004Data(output.additionalRegisters.R6);
+    const decimals = parseInt(parseEIP0004Data(output.additionalRegisters.R6) ?? '', 10);
     if (name != null && description != null && decimals != null) {
       tokens.push({
         TokenId: 0,
@@ -51,7 +51,7 @@ export function mintedTokenInfo(tx: Tx): $ReadOnly<TokenRow>[] {
           type: 'Ergo',
           height: tx.inputs[0].creationHeight,
           boxId: tx.inputs[0].boxId,
-          numberOfDecimals: parseInt(decimals, 10),
+          numberOfDecimals: isNaN(decimals) ? null : decimals,
           ticker: name,
           longName: description,
           description,


### PR DESCRIPTION
`parseEIP0004Data` returns `null | string`

`parseInt(null, 10)` gives `NaN`

This means that incorrectly constructed decimal fields is causing Yoroi to set NaN to the number of decimal places which causes issues down the line.

On a side note: I noticed the `parseEIP0004Data` function is just a better implementation of the code I wrote a while ago to implement EIP-4 for testing tokens so I just unified these two as well