### PR TITLE
Allow overriding the SSL key and cert used to create the Webpack server

### DIFF
--- a/packages/yoroi-extension/.gitignore
+++ b/packages/yoroi-extension/.gitignore
@@ -40,3 +40,6 @@ Yoroi Shelley Testnet
 
 # Local Netlify folder
 .netlify
+
+# SSL overrides for DEV
+scripts/sslOverrides.js

--- a/packages/yoroi-extension/scripts/build.js
+++ b/packages/yoroi-extension/scripts/build.js
@@ -31,6 +31,9 @@ export function buildDev(env: string) {
   const webpackDevMiddleware = require('webpack-dev-middleware');
   const webpackHotMiddleware = require('webpack-hot-middleware');
 
+  const path = require('path');
+  const fs = require('fs');
+
   const config = require(`../webpack/devConfig`);
 
   console.log('[Build manifest]');
@@ -46,6 +49,21 @@ export function buildDev(env: string) {
   console.log('If you\'re developing Inject page,');
   console.log(`please allow 'https://localhost:${connections.Ports.WebpackDev}' connections in Google Chrome,`);
   console.log('and load unpacked extensions with `./dev` folder. (see https://developer.chrome.com/extensions/getstarted#unpacked)\n');
+
+  const serverOpts: any = {
+    host: 'localhost',
+    port: connections.Ports.WebpackDev
+  };
+
+  if (argv.type === 'debug') {
+    const sslOverridesPath = path.join(__dirname, './sslOverrides.js');
+    if (fs.existsSync(sslOverridesPath)) {
+      const sslOverrides = require(sslOverridesPath);
+      serverOpts.key = sslOverrides.key;
+      serverOpts.cert = sslOverrides.cert;
+    }
+  }
+
   createWebpackServer(
     config.baseDevConfig(
       argv.env,
@@ -55,10 +73,7 @@ export function buildDev(env: string) {
     webpack,
     webpackDevMiddleware,
     webpackHotMiddleware,
-    {
-      host: 'localhost',
-      port: connections.Ports.WebpackDev
-    },
+    serverOpts
   );
 }
 


### PR DESCRIPTION
## Abstract
This proposal aims to provide a way for developers to easily override the SSL key and certificate used in the creation of the Webpack server. (method exported from `webpack-httpolyglot-server`)

## Motivation
In my system (PureOS, Linux distro based on Debian), building the extensions with `npm run dev:build` or `npm run dev:stable` throws the following exception:
`error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small`. This PR adds a way for other people facing this error to circumvent this problem.

## Background
Inspecting the code from `webpack-httpolyglot-server`, I found out it tries getting the key and certificates from it's own package location (`./node_modules/webpack-httpolyglot-server/ssl`) and that we can also send a specific key and certificate on the last argument from the method.

I am not sure why the keys contained in the package's directory doesn't work in my system, but I assume it should be because this package was developed using a different OS than mine.

## Proposal
When running on `debug`, check if there's a file named `sslOverrides.js` at the `yoroi-extension/scripts` folder. If the file exists, load it and pass the `key` and `cert` defined there to the `serverOpts` argument from `webpack-httpolyglot-server`