### PR TITLE
[DO NOT MERGE] Tmp patch to make the Trezor update PR work

### DIFF
--- a/packages/yoroi-extension/.eslintignore
+++ b/packages/yoroi-extension/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 /chrome/content-scripts
 flow-typed
+features/mock-trezor-connect/index.js

--- a/packages/yoroi-extension/chrome/constants.js
+++ b/packages/yoroi-extension/chrome/constants.js
@@ -45,6 +45,7 @@ export function genCSP(request: {|
   // connectSrc.push('https://content.dropboxapi.com');
 
   frameSrc.push('https://connect.trezor.io/');
+  frameSrc.push('https://localhost:8088/');
   frameSrc.push('https://emurgo.github.io/yoroi-extension-ledger-bridge');
 
   // wasm-eval is needed to compile WebAssembly in the browser

--- a/packages/yoroi-extension/chrome/extension/index.js
+++ b/packages/yoroi-extension/chrome/extension/index.js
@@ -54,3 +54,5 @@ const initializeYoroi: void => Promise<void> = async () => {
 addCloseListener(TabIdKeys.Primary);
 
 window.addEventListener('load', initializeYoroi);
+
+window.__TREZOR_CONNECT_SRC = 'https://localhost:8088/';

--- a/packages/yoroi-extension/chrome/manifest.template.js
+++ b/packages/yoroi-extension/chrome/manifest.template.js
@@ -70,7 +70,7 @@ export default ({
     ],
     content_scripts: [
       {
-        matches: ['*://connect.trezor.io/*/popup.html'],
+        matches: ['*://connect.trezor.io/*/popup.html', 'https://localhost:8088/popup.html'],
         js: ['js/trezor-content-script.js'],
       },
       {

--- a/packages/yoroi-extension/features/mock-trezor-connect/index.js
+++ b/packages/yoroi-extension/features/mock-trezor-connect/index.js
@@ -1,4 +1,4 @@
-// @flow
+
 
 import type { DeviceEvent, KnownDevice } from 'trezor-connect/lib/types/trezor/device';
 import type { UiEvent } from 'trezor-connect/lib/types/events';

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -32560,9 +32560,8 @@
       "dev": true
     },
     "trezor-connect": {
-      "version": "8.1.29",
-      "resolved": "https://registry.nlark.com/trezor-connect/download/trezor-connect-8.1.29.tgz",
-      "integrity": "sha1-jMzw5NQQHSMx0+VtYOs50I1Vf0Q=",
+      "version": "github:yushih/trezor-connect-tmp#6321ed2c80cab82b1eb345cf8451e504a52892b9",
+      "from": "github:yushih/trezor-connect-tmp#master",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "events": "^3.2.0",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -213,7 +213,7 @@
     "semver": "7.3.4",
     "stream-browserify": "3.0.0",
     "tinycolor2": "1.4.2",
-    "trezor-connect": "8.1.29",
+    "trezor-connect": "yushih/trezor-connect-tmp#master",
     "ua-parser-js": "0.7.24",
     "unorm": "1.6.0",
     "validator": "13.5.2"


### PR DESCRIPTION
Before `connect.trezor.io`, which does the heavy lifting of signing txs, is updated to the streamed Cardano tx signing API, in order to test https://github.com/Emurgo/yoroi-frontend/pull/2373, this patch must be applied. Also, a local trezor connect needs to be on localhost:8088 using code on this branch: https://github.com/vacuumlabs/connect/pull/13.  See https://wiki.trezor.io/Developers_guide:Running_Trezor_Connect_on_localhost.