### PR TITLE
Add missing row on Lovefield

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
@@ -583,6 +583,7 @@ export const populatePrimitivesDb = (schemaBuilder: lf$schema$Builder) => {
   // Network Table
   schemaBuilder.createTable(NetworkSchema.name)
     .addColumn(NetworkSchema.properties.NetworkId, Type.INTEGER)
+    .addColumn(NetworkSchema.properties.NetworkName, Type.STRING)
     .addColumn(NetworkSchema.properties.CoinType, Type.NUMBER)
     .addColumn(NetworkSchema.properties.Backend, Type.OBJECT)
     .addColumn(NetworkSchema.properties.BaseConfig, Type.OBJECT)


### PR DESCRIPTION
Although in IndexedDB we were saving the network name, I forgot to add this column to Lovefield. This was causing a subtle issue where if for some reason Lovefield cache was invalidated, Yoroi UI would lose access to the network name causing an empty string to appear in the wallet list where the network name is supposed to be