### PR TITLE
[quick/4.7.310] Update to new serlib version

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -4439,14 +4439,14 @@
       "dev": true
     },
     "@emurgo/cardano-serialization-lib-browser": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-9.0.0.tgz",
-      "integrity": "sha512-sP0NARZHqvrtZLd2yybehbnsHNZcJl8B4MLU0RC4HoYFUfQsyoKicw9e0FlMON+nvN5TIsjxUUWugLKH7UyL5A=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-9.1.0.tgz",
+      "integrity": "sha512-FaNW/RalB/BPYvQbum0zkUcMxd+jKvsdwvT93GErKd/owE9W4IKhQfqI9icDZSphqFFPkDqHms2VE4XT4P7gDA=="
     },
     "@emurgo/cardano-serialization-lib-nodejs": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-9.0.0.tgz",
-      "integrity": "sha512-TH4QC9iR/bK7QMlJw9JD6YtW4QP7OgUvL4ed00mKD/nw5rmEe82P9DyVlDtkKKmCG1guhzeieaEV1zOS9FBt7A==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-9.1.0.tgz",
+      "integrity": "sha512-4gW+KqejTSm/rkNwWxK/WUJvlifWqFx5ShgCtWmPuTZ/YJAZSpROI8DP+pqTakG0gGWdxPB3BnVJIPrczNwmtA==",
       "dev": true
     },
     "@emurgo/cip14-js": {

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.7.300",
+  "version": "4.7.310",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.7.300",
+  "version": "4.7.310",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -75,7 +75,7 @@
     "@babel/register": "7.12.13",
     "@babel/runtime": "7.12.18",
     "@babel/runtime-corejs3": "7.12.18",
-    "@emurgo/cardano-serialization-lib-nodejs": "9.0.0",
+    "@emurgo/cardano-serialization-lib-nodejs": "9.1.0",
     "@emurgo/js-chain-libs-node": "0.7.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@storybook/addon-actions": "6.2.7",
@@ -155,7 +155,7 @@
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "3.1.0",
     "@download/blockies": "1.0.3",
-    "@emurgo/cardano-serialization-lib-browser": "9.0.0",
+    "@emurgo/cardano-serialization-lib-browser": "9.1.0",
     "@emurgo/cip14-js": "2.0.0",
     "@emurgo/cip4-js": "1.0.5",
     "@emurgo/js-chain-libs": "0.7.1",


### PR DESCRIPTION
Migrating to this: https://github.com/Emurgo/cardano-serialization-lib/releases/tag/9.1.0