### PR TITLE
Add buy ERG functionality

### DIFF
--- a/packages/yoroi-extension/app/components/buySell/BuySellDialog.js
+++ b/packages/yoroi-extension/app/components/buySell/BuySellDialog.js
@@ -8,12 +8,12 @@ import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import { truncateAddress } from '../../utils/formatters';
 import Dialog from '../widgets/Dialog';
 import DialogCloseButton from '../widgets/DialogCloseButton';
-import ChangellyFetcher from './ChangellyFetcher';
+import ChangellyFetcher from './ChangellyFetcher'
 
 import styles from './BuySellDialog.scss';
-import VerifyIcon from '../../assets/images/verify-icon.inline.svg';
-import VerticalFlexContainer from '../layout/VerticalFlexContainer';
-import LoadingSpinner from '../widgets/LoadingSpinner';
+import VerifyIcon from '../../assets/images/verify-icon.inline.svg'
+import VerticalFlexContainer from '../layout/VerticalFlexContainer'
+import LoadingSpinner from '../widgets/LoadingSpinner'
 import globalMessages from '../../i18n/global-messages';
 
 const messages = defineMessages({
@@ -23,13 +23,11 @@ const messages = defineMessages({
   },
   dialogSelectAddress: {
     id: 'buysell.dialog.selectAddress',
-    defaultMessage:
-      '!!!Please select the receiving address. This will be shared with the third party provider called Changelly for the buy / sell of ADA. ',
+    defaultMessage: '!!!Please select the receiving address. This will be shared with the third party provider called Changelly for the buy / sell of ADA. ',
   },
   dialogDescription: {
     id: 'buysell.dialog.instructions',
-    defaultMessage:
-      '!!!Please select your preferences. On the next screen, confirm your selection by pressing the green arrow on the top right',
+    defaultMessage: '!!!Please select your preferences. On the next screen, confirm your selection by pressing the green arrow on the top right',
   },
   dialogManual: {
     id: 'buysell.dialog.manual',
@@ -41,11 +39,11 @@ export type WalletInfo = {|
   walletName: string,
   currencyName: string,
   anAddressFormatted: string,
-|};
+|}
 
 type Props = {|
   +onCancel: void => void,
-  +genWalletList: () => Promise<Array<WalletInfo>>,
+  +genWalletList: () => Promise<Array<WalletInfo>>
 |};
 
 type State = {|
@@ -56,7 +54,7 @@ type State = {|
 
 @observer
 export default class BuySellDialog extends Component<Props, State> {
-  static contextTypes: {| intl: $npm$ReactIntl$IntlFormat |} = {
+  static contextTypes: {|intl: $npm$ReactIntl$IntlFormat|} = {
     intl: intlShape.isRequired,
   };
 
@@ -66,32 +64,33 @@ export default class BuySellDialog extends Component<Props, State> {
     walletList: null,
   };
 
-  async componentDidMount() {
+  async componentDidMount () {
     const { intl } = this.context;
 
-    const resp = await this.props.genWalletList();
+    const resp = await this.props.genWalletList()
     const wallets = [
       ...resp,
       {
         walletName: intl.formatMessage(messages.dialogManual),
         currencyName: '',
         anAddressFormatted: '',
-      },
-    ];
-    this.setState({ walletList: wallets });
+      }
+    ]
+    this.setState({ walletList: wallets })
   }
 
-  createRows: ($npm$ReactIntl$IntlFormat, Array<WalletInfo>) => Node = (intl, wallets) =>
+  createRows: ($npm$ReactIntl$IntlFormat, Array<WalletInfo>) => Node = (intl, wallets) => (
     wallets.map((wallet, i) => {
       return (
         // eslint-disable-next-line react/no-array-index-key
         <div key={i} className={styles.row}>
           <div className={styles.left}>
             <div className={styles.nameAndCurrency}>
-              {wallet.currencyName ? `(${wallet.currencyName}) ` : ''}
-              {wallet.walletName}
+              { wallet.currencyName ? `(${wallet.currencyName}) ` : ''}{wallet.walletName}
             </div>
-            <div className={styles.address}>{truncateAddress(wallet.anAddressFormatted)}</div>
+            <div className={styles.address}>
+              {truncateAddress(wallet.anAddressFormatted)}
+            </div>
           </div>
           <div className={styles.right}>
             {/* Verify Address action */}
@@ -113,8 +112,9 @@ export default class BuySellDialog extends Component<Props, State> {
             {/* Action block end */}
           </div>
         </div>
-      );
-    });
+      )
+    })
+  )
 
   render(): Node {
     const { intl } = this.context;
@@ -147,7 +147,7 @@ export default class BuySellDialog extends Component<Props, State> {
             {addressNodes}
           </div>
         </Dialog>
-      );
+      )
     }
 
     return (
@@ -159,7 +159,9 @@ export default class BuySellDialog extends Component<Props, State> {
         className=""
       >
         <div className={styles.component}>
-          <div className={styles.description}>{intl.formatMessage(messages.dialogDescription)}</div>
+          <div className={styles.description}>
+            {intl.formatMessage(messages.dialogDescription)}
+          </div>
           <ChangellyFetcher
             address={this.state.addressSelected}
             currency={this.state.currencySelected}

--- a/packages/yoroi-extension/app/components/buySell/BuySellDialog.js
+++ b/packages/yoroi-extension/app/components/buySell/BuySellDialog.js
@@ -8,12 +8,12 @@ import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import { truncateAddress } from '../../utils/formatters';
 import Dialog from '../widgets/Dialog';
 import DialogCloseButton from '../widgets/DialogCloseButton';
-import ChangellyFetcher from './ChangellyFetcher'
+import ChangellyFetcher from './ChangellyFetcher';
 
 import styles from './BuySellDialog.scss';
-import VerifyIcon from '../../assets/images/verify-icon.inline.svg'
-import VerticalFlexContainer from '../layout/VerticalFlexContainer'
-import LoadingSpinner from '../widgets/LoadingSpinner'
+import VerifyIcon from '../../assets/images/verify-icon.inline.svg';
+import VerticalFlexContainer from '../layout/VerticalFlexContainer';
+import LoadingSpinner from '../widgets/LoadingSpinner';
 import globalMessages from '../../i18n/global-messages';
 
 const messages = defineMessages({
@@ -23,11 +23,13 @@ const messages = defineMessages({
   },
   dialogSelectAddress: {
     id: 'buysell.dialog.selectAddress',
-    defaultMessage: '!!!Please select the receiving address. This will be shared with the third party provider called Changelly for the buy / sell of ADA. ',
+    defaultMessage:
+      '!!!Please select the receiving address. This will be shared with the third party provider called Changelly for the buy / sell of ADA. ',
   },
   dialogDescription: {
     id: 'buysell.dialog.instructions',
-    defaultMessage: '!!!Please select your preferences. On the next screen, confirm your selection by pressing the green arrow on the top right',
+    defaultMessage:
+      '!!!Please select your preferences. On the next screen, confirm your selection by pressing the green arrow on the top right',
   },
   dialogManual: {
     id: 'buysell.dialog.manual',
@@ -39,65 +41,67 @@ export type WalletInfo = {|
   walletName: string,
   currencyName: string,
   anAddressFormatted: string,
-|}
+|};
 
 type Props = {|
   +onCancel: void => void,
-  +genWalletList: () => Promise<Array<WalletInfo>>
+  +genWalletList: () => Promise<Array<WalletInfo>>,
 |};
-
-const WIDGET_URL = 'https://widget.changelly.com?from=*&to=*&amount=200&fromDefault=usd&toDefault=ada&theme=default&merchant_id=g9qheu8vschp16jj&payment_id=&v=3'
 
 type State = {|
   addressSelected: ?string,
+  currencySelected: ?string,
   walletList: ?Array<WalletInfo>,
 |};
 
 @observer
 export default class BuySellDialog extends Component<Props, State> {
-  static contextTypes: {|intl: $npm$ReactIntl$IntlFormat|} = {
+  static contextTypes: {| intl: $npm$ReactIntl$IntlFormat |} = {
     intl: intlShape.isRequired,
   };
 
   state: State = {
     addressSelected: null,
+    currencySelected: null,
     walletList: null,
   };
 
-  async componentDidMount () {
+  async componentDidMount() {
     const { intl } = this.context;
 
-    const resp = await this.props.genWalletList()
+    const resp = await this.props.genWalletList();
     const wallets = [
       ...resp,
       {
         walletName: intl.formatMessage(messages.dialogManual),
         currencyName: '',
         anAddressFormatted: '',
-      }
-    ]
-    this.setState({ walletList: wallets })
+      },
+    ];
+    this.setState({ walletList: wallets });
   }
 
-  createRows: ($npm$ReactIntl$IntlFormat, Array<WalletInfo>) => Node = (intl, wallets) => (
+  createRows: ($npm$ReactIntl$IntlFormat, Array<WalletInfo>) => Node = (intl, wallets) =>
     wallets.map((wallet, i) => {
       return (
         // eslint-disable-next-line react/no-array-index-key
         <div key={i} className={styles.row}>
           <div className={styles.left}>
             <div className={styles.nameAndCurrency}>
-              { wallet.currencyName ? `(${wallet.currencyName}) ` : ''}{wallet.walletName}
+              {wallet.currencyName ? `(${wallet.currencyName}) ` : ''}
+              {wallet.walletName}
             </div>
-            <div className={styles.address}>
-              {truncateAddress(wallet.anAddressFormatted)}
-            </div>
+            <div className={styles.address}>{truncateAddress(wallet.anAddressFormatted)}</div>
           </div>
           <div className={styles.right}>
             {/* Verify Address action */}
             <button
               type="button"
               onClick={() =>
-                this.setState({ addressSelected: wallet.anAddressFormatted })
+                this.setState({
+                  addressSelected: wallet.anAddressFormatted,
+                  currencySelected: wallet.currencyName,
+                })
               }
             >
               <div>
@@ -109,9 +113,8 @@ export default class BuySellDialog extends Component<Props, State> {
             {/* Action block end */}
           </div>
         </div>
-      )
-    })
-  )
+      );
+    });
 
   render(): Node {
     const { intl } = this.context;
@@ -144,25 +147,25 @@ export default class BuySellDialog extends Component<Props, State> {
             {addressNodes}
           </div>
         </Dialog>
-      )
+      );
     }
 
-      return (
-        <Dialog
-          title={intl.formatMessage(messages.dialogTitle)}
-          closeOnOverlayClick={false}
-          onClose={this.props.onCancel}
-          closeButton={<DialogCloseButton />}
-          className=""
-        >
-          <div className={styles.component}>
-            <div className={styles.description}>
-              {intl.formatMessage(messages.dialogDescription)}
-            </div>
-            <ChangellyFetcher widgetURL={WIDGET_URL} address={this.state.addressSelected} />
-          </div>
-        </Dialog>
-      );
-
+    return (
+      <Dialog
+        title={intl.formatMessage(messages.dialogTitle)}
+        closeOnOverlayClick={false}
+        onClose={this.props.onCancel}
+        closeButton={<DialogCloseButton />}
+        className=""
+      >
+        <div className={styles.component}>
+          <div className={styles.description}>{intl.formatMessage(messages.dialogDescription)}</div>
+          <ChangellyFetcher
+            address={this.state.addressSelected}
+            currency={this.state.currencySelected}
+          />
+        </div>
+      </Dialog>
+    );
   }
 }

--- a/packages/yoroi-extension/app/components/buySell/ChangellyFetcher.js
+++ b/packages/yoroi-extension/app/components/buySell/ChangellyFetcher.js
@@ -3,28 +3,28 @@
 import React, { Component } from 'react';
 import type { Node } from 'react';
 import { action, observable } from 'mobx';
-import { intlShape, } from 'react-intl';
+import { intlShape } from 'react-intl';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import { observer } from 'mobx-react';
 
 type Props = {|
   +children?: Node,
-  +widgetURL: string,
   +address: ?string,
+  +currency: ?string,
 |};
 
 @observer
 export default class ChangellyFetcher extends Component<Props> {
-  static defaultProps: {|children: void|} = {
-    children: undefined
+  static defaultProps: {| children: void |} = {
+    children: undefined,
   };
 
   @observable iframe: ?HTMLIFrameElement;
   @observable frameHeight: number = 0;
 
-  @action setFrame: (null | HTMLIFrameElement) => void = (frame) => {
+  @action setFrame: (null | HTMLIFrameElement) => void = frame => {
     this.iframe = frame;
-  }
+  };
 
   componentDidMount() {
     window.addEventListener('resize', this.resize);
@@ -35,21 +35,18 @@ export default class ChangellyFetcher extends Component<Props> {
     window.removeEventListener('resize', this.resize);
   }
 
-  static contextTypes: {|intl: $npm$ReactIntl$IntlFormat|} = {
+  static contextTypes: {| intl: $npm$ReactIntl$IntlFormat |} = {
     intl: intlShape.isRequired,
   };
 
-  addAddressToWidget: (string, ?string) => string = (widgetURL, address) => {
-    if (address == null) return widgetURL
-    return widgetURL + '&address=' + address
+  getWidgetUrl(currency: ?string, address: ?string): string {
+    return `https://widget.changelly.com?from=*&to=*&amount=200&fromDefault=usd&theme=default&merchant_id=g9qheu8vschp16jj&payment_id=&v=3&toDefault=${
+      currency?.toLowerCase() || 'ada'
+    }&address=${address || ''}`;
   }
 
   render(): Node {
-    const { widgetURL, address } = this.props;
-
-    if (widgetURL == null) {
-      throw new Error('Changelly URL undefined. this should never happen');
-    }
+    const { currency, address } = this.props;
 
     return (
       <iframe
@@ -82,7 +79,7 @@ export default class ChangellyFetcher extends Component<Props> {
         referrerPolicy="no-referrer"
         ref={this.setFrame}
         title="Changelly"
-        src={`${this.addAddressToWidget(widgetURL, address)}`}
+        src={`${this.getWidgetUrl(currency, address)}`}
         frameBorder="0"
         width="100%"
         height={this.iframe != null && this.frameHeight != null ? '500px' : null}
@@ -100,5 +97,5 @@ export default class ChangellyFetcher extends Component<Props> {
       window.innerHeight - this.iframe.getBoundingClientRect().top - 30,
       0
     );
-  }
+  };
 }

--- a/packages/yoroi-extension/app/components/buySell/ChangellyFetcher.js
+++ b/packages/yoroi-extension/app/components/buySell/ChangellyFetcher.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 import type { Node } from 'react';
 import { action, observable } from 'mobx';
-import { intlShape } from 'react-intl';
+import { intlShape, } from 'react-intl';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
 import { observer } from 'mobx-react';
 
@@ -15,16 +15,16 @@ type Props = {|
 
 @observer
 export default class ChangellyFetcher extends Component<Props> {
-  static defaultProps: {| children: void |} = {
-    children: undefined,
+  static defaultProps: {|children: void|} = {
+    children: undefined
   };
 
   @observable iframe: ?HTMLIFrameElement;
   @observable frameHeight: number = 0;
 
-  @action setFrame: (null | HTMLIFrameElement) => void = frame => {
+  @action setFrame: (null | HTMLIFrameElement) => void = (frame) => {
     this.iframe = frame;
-  };
+  }
 
   componentDidMount() {
     window.addEventListener('resize', this.resize);
@@ -35,11 +35,11 @@ export default class ChangellyFetcher extends Component<Props> {
     window.removeEventListener('resize', this.resize);
   }
 
-  static contextTypes: {| intl: $npm$ReactIntl$IntlFormat |} = {
+  static contextTypes: {|intl: $npm$ReactIntl$IntlFormat|} = {
     intl: intlShape.isRequired,
   };
 
-  getWidgetUrl(currency: ?string, address: ?string): string {
+  mountWidgetUrl(currency: ?string, address: ?string): string {
     return `https://widget.changelly.com?from=*&to=*&amount=200&fromDefault=usd&theme=default&merchant_id=g9qheu8vschp16jj&payment_id=&v=3&toDefault=${
       currency?.toLowerCase() || 'ada'
     }&address=${address || ''}`;
@@ -79,7 +79,7 @@ export default class ChangellyFetcher extends Component<Props> {
         referrerPolicy="no-referrer"
         ref={this.setFrame}
         title="Changelly"
-        src={`${this.getWidgetUrl(currency, address)}`}
+        src={`${this.mountWidgetUrl(currency, address)}`}
         frameBorder="0"
         width="100%"
         height={this.iframe != null && this.frameHeight != null ? '500px' : null}

--- a/packages/yoroi-extension/app/containers/wallet/MyWalletsPage.js
+++ b/packages/yoroi-extension/app/containers/wallet/MyWalletsPage.js
@@ -168,10 +168,10 @@ export default class MyWalletsPage extends Component<Props> {
         )
         const currencyName = getTokenName(defaultToken)
 
-      if (
-        defaultToken.NetworkId !== networks.CardanoMainnet.NetworkId &&
-        defaultToken.NetworkId !== networks.ErgoMainnet.NetworkId
-      ) {
+        if (
+          defaultToken.NetworkId !== networks.CardanoMainnet.NetworkId &&
+          defaultToken.NetworkId !== networks.ErgoMainnet.NetworkId
+        ) {
           return null;
         }
 

--- a/packages/yoroi-extension/app/containers/wallet/MyWalletsPage.js
+++ b/packages/yoroi-extension/app/containers/wallet/MyWalletsPage.js
@@ -1,58 +1,57 @@
 // @flow
-import type { Node } from 'react'
-import React, { Component } from 'react'
-import { computed } from 'mobx'
-import { observer } from 'mobx-react'
-import type { $npm$ReactIntl$IntlFormat } from 'react-intl'
-import { intlShape, } from 'react-intl'
-import type { InjectedOrGenerated } from '../../types/injectedPropsType'
+import type { Node } from 'react';
+import React, { Component } from 'react';
+import { computed } from 'mobx';
+import { observer } from 'mobx-react';
+import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
+import { intlShape } from 'react-intl';
+import type { InjectedOrGenerated } from '../../types/injectedPropsType';
 
-import MyWallets from '../../components/wallet/my-wallets/MyWallets'
-import TopBarLayout from '../../components/layout/TopBarLayout'
+import MyWallets from '../../components/wallet/my-wallets/MyWallets';
+import TopBarLayout from '../../components/layout/TopBarLayout';
 
-import WalletsList from '../../components/wallet/my-wallets/WalletsList'
-import WalletRow from '../../components/wallet/my-wallets/WalletRow'
-import WalletDetails from '../../components/wallet/my-wallets/WalletDetails'
-import WalletCurrency from '../../components/wallet/my-wallets/WalletCurrency'
-import WalletSubRow from '../../components/wallet/my-wallets/WalletSubRow'
-import NavPlate from '../../components/topbar/NavPlate'
-import type { GeneratedData as SidebarContainerData } from '../SidebarContainer'
-import SidebarContainer from '../SidebarContainer'
-import type { GeneratedData as BannerContainerData } from '../banners/BannerContainer'
-import BannerContainer from '../banners/BannerContainer'
-import { ROUTES } from '../../routes-config'
-import NavBar from '../../components/topbar/NavBar'
-import NavBarTitle from '../../components/topbar/NavBarTitle'
-import WalletSync from '../../components/wallet/my-wallets/WalletSync'
-import moment from 'moment'
-import NavBarAddButton from '../../components/topbar/NavBarAddButton'
-import BuySellAdaButton from '../../components/topbar/BuySellAdaButton'
-import globalMessages from '../../i18n/global-messages'
-import { ConceptualWallet, } from '../../api/ada/lib/storage/models/ConceptualWallet/index'
-import { asGetPublicKey, } from '../../api/ada/lib/storage/models/PublicDeriver/traits'
-import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/index'
-import type { ConceptualWalletSettingsCache } from '../../stores/toplevel/WalletSettingsStore'
-import type { DelegationRequests } from '../../stores/toplevel/DelegationStore'
-import type { PublicKeyCache } from '../../stores/toplevel/WalletStore'
-import type { TxRequests } from '../../stores/toplevel/TransactionsStore'
-import type { IGetPublic } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces'
-import type { TokenRow } from '../../api/ada/lib/storage/database/primitives/tables'
-import { MultiToken } from '../../api/common/lib/MultiToken'
-import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore'
-import { genLookupOrFail, getTokenName } from '../../stores/stateless/tokenHelpers'
+import WalletsList from '../../components/wallet/my-wallets/WalletsList';
+import WalletRow from '../../components/wallet/my-wallets/WalletRow';
+import WalletDetails from '../../components/wallet/my-wallets/WalletDetails';
+import WalletCurrency from '../../components/wallet/my-wallets/WalletCurrency';
+import WalletSubRow from '../../components/wallet/my-wallets/WalletSubRow';
+import NavPlate from '../../components/topbar/NavPlate';
+import type { GeneratedData as SidebarContainerData } from '../SidebarContainer';
+import SidebarContainer from '../SidebarContainer';
+import type { GeneratedData as BannerContainerData } from '../banners/BannerContainer';
+import BannerContainer from '../banners/BannerContainer';
+import { ROUTES } from '../../routes-config';
+import NavBar from '../../components/topbar/NavBar';
+import NavBarTitle from '../../components/topbar/NavBarTitle';
+import WalletSync from '../../components/wallet/my-wallets/WalletSync';
+import moment from 'moment';
+import NavBarAddButton from '../../components/topbar/NavBarAddButton';
+import BuySellAdaButton from '../../components/topbar/BuySellAdaButton';
+import globalMessages from '../../i18n/global-messages';
+import { ConceptualWallet } from '../../api/ada/lib/storage/models/ConceptualWallet/index';
+import { asGetPublicKey } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
+import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/index';
+import type { ConceptualWalletSettingsCache } from '../../stores/toplevel/WalletSettingsStore';
+import type { DelegationRequests } from '../../stores/toplevel/DelegationStore';
+import type { PublicKeyCache } from '../../stores/toplevel/WalletStore';
+import type { TxRequests } from '../../stores/toplevel/TransactionsStore';
+import type { IGetPublic } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
+import type { TokenRow } from '../../api/ada/lib/storage/database/primitives/tables';
+import { MultiToken } from '../../api/common/lib/MultiToken';
+import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore';
+import { genLookupOrFail, getTokenName } from '../../stores/stateless/tokenHelpers';
 import { getReceiveAddress } from '../../stores/stateless/addressStores';
 import BuySellDialog from '../../components/buySell/BuySellDialog';
 import type { WalletInfo } from '../../components/buySell/BuySellDialog';
-import { addressToDisplayString } from '../../api/ada/lib/storage/bridge/utils'
-import { networks } from '../../api/ada/lib/storage/database/prepackaged/networks'
+import { addressToDisplayString } from '../../api/ada/lib/storage/bridge/utils';
+import { networks } from '../../api/ada/lib/storage/database/prepackaged/networks';
 
 export type GeneratedData = typeof MyWalletsPage.prototype.generated;
 
-type Props = InjectedOrGenerated<GeneratedData>
+type Props = InjectedOrGenerated<GeneratedData>;
 
 @observer
 export default class MyWalletsPage extends Component<Props> {
-
   static contextTypes: {| intl: $npm$ReactIntl$IntlFormat |} = {
     intl: intlShape.isRequired,
   };
@@ -61,161 +60,154 @@ export default class MyWalletsPage extends Component<Props> {
     this.generated.actions.dialogs.closeActiveDialog.trigger();
   };
 
-  openDialogWrapper: any => void = (dialog) => {
+  openDialogWrapper: any => void = dialog => {
     this.generated.actions.dialogs.open.trigger({ dialog });
-  }
+  };
 
   updateHideBalance: void => Promise<void> = async () => {
     await this.generated.actions.profile.updateHideBalance.trigger();
-  }
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     this.generated.actions.wallets.unselectWallet.trigger();
   }
 
-  handleWalletNavItemClick: PublicDeriver<> => void = (
-    publicDeriver
-  ) => {
+  handleWalletNavItemClick: (PublicDeriver<>) => void = publicDeriver => {
     this.generated.actions.router.goToRoute.trigger({
       route: ROUTES.WALLETS.ROOT,
-      publicDeriver
+      publicDeriver,
     });
   };
 
-  openToSettings: PublicDeriver<> => void = (
-    publicDeriver
-  ) => {
+  openToSettings: (PublicDeriver<>) => void = publicDeriver => {
     this.generated.actions.wallets.setActiveWallet.trigger({
-      wallet: publicDeriver
+      wallet: publicDeriver,
     });
     this.generated.actions.router.goToRoute.trigger({
       route: ROUTES.SETTINGS.WALLET,
     });
   };
 
-  render (): Node {
+  render(): Node {
     const { intl } = this.context;
     const { stores } = this.generated;
     const { uiDialogs } = stores;
 
-    const sidebarContainer = <SidebarContainer {...this.generated.SidebarContainerProps} />
+    const sidebarContainer = <SidebarContainer {...this.generated.SidebarContainerProps} />;
 
     const wallets = this.generated.stores.wallets.publicDerivers;
 
-    const navbarTitle = (
-      <NavBarTitle title={intl.formatMessage(globalMessages.sidebarWallets)} />
-    );
+    const navbarTitle = <NavBarTitle title={intl.formatMessage(globalMessages.sidebarWallets)} />;
 
     const navbarElement = (
       <NavBar
         title={navbarTitle}
-        button={<NavBarAddButton onClick={
-          () => this.generated.actions.router.goToRoute.trigger({ route: ROUTES.WALLETS.ADD })
-        }
-        />}
-        buyButton={
-          <BuySellAdaButton onBuySellClick={() =>
-            (this.openDialogWrapper(BuySellDialog))
-          }
+        button={
+          <NavBarAddButton
+            onClick={() =>
+              this.generated.actions.router.goToRoute.trigger({ route: ROUTES.WALLETS.ADD })
+            }
           />
+        }
+        buyButton={
+          <BuySellAdaButton onBuySellClick={() => this.openDialogWrapper(BuySellDialog)} />
         }
         walletDetails={undefined}
       />
     );
 
     const walletsList = (
-      <WalletsList>
-        {wallets.map(wallet => this.generateRow(wallet))}
-      </WalletsList>
+      <WalletsList>{wallets.map(wallet => this.generateRow(wallet))}</WalletsList>
     );
 
     let activeDialog = null;
     if (uiDialogs.isOpen(BuySellDialog)) {
-      activeDialog = <BuySellDialog
-        onCancel={this.onClose}
-        genWalletList={async () => {
-          return await this.generateUnusedAddressesPerWallet(wallets);
-        }}
-      />
+      activeDialog = (
+        <BuySellDialog
+          onCancel={this.onClose}
+          genWalletList={async () => {
+            return await this.generateUnusedAddressesPerWallet(wallets);
+          }}
+        />
+      );
     }
 
     return (
       <TopBarLayout
-        banner={(<BannerContainer {...this.generated.BannerContainerProps} />)}
+        banner={<BannerContainer {...this.generated.BannerContainerProps} />}
         sidebar={sidebarContainer}
         navbar={navbarElement}
         showInContainer
       >
-        <MyWallets>
-          {walletsList}
-        </MyWallets>
+        <MyWallets>{walletsList}</MyWallets>
         {activeDialog}
       </TopBarLayout>
     );
   }
 
-  generateUnusedAddressesPerWallet: Array<PublicDeriver<>> => Promise<Array<WalletInfo>> =
-    async (wallets: Array<PublicDeriver<>>) => {
-      const infoWallets = wallets.map(async (wallet: PublicDeriver<>) => {
-        // Wallet Name
-        const parent: ConceptualWallet = wallet.getParent();
-        const settingsCache: ConceptualWalletSettingsCache = this.generated.stores.walletSettings
-          .getConceptualWalletSettingsCache(parent);
+  generateUnusedAddressesPerWallet: (Array<PublicDeriver<>>) => Promise<Array<WalletInfo>> = async (
+    wallets: Array<PublicDeriver<>>
+  ) => {
+    const infoWallets = wallets.map(async (wallet: PublicDeriver<>) => {
+      // Wallet Name
+      const parent: ConceptualWallet = wallet.getParent();
+      const settingsCache: ConceptualWalletSettingsCache = this.generated.stores.walletSettings.getConceptualWalletSettingsCache(
+        parent
+      );
 
-        // Currency Name
-        const defaultToken = this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
-          wallet.getParent().getNetworkInfo().NetworkId
-        )
-        const currencyName = getTokenName(defaultToken)
+      // Currency Name
+      const defaultToken = this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
+        wallet.getParent().getNetworkInfo().NetworkId
+      );
+      const currencyName = getTokenName(defaultToken);
 
-        if (defaultToken.NetworkId !== networks.CardanoMainnet.NetworkId) {
-          return null;
-        }
+      if (
+        defaultToken.NetworkId !== networks.CardanoMainnet.NetworkId &&
+        defaultToken.NetworkId !== networks.ErgoMainnet.NetworkId
+      ) {
+        return null;
+      }
 
-        const receiveAddress = await this.generated.getReceiveAddress(wallet);
-        if (receiveAddress == null) return null;
-        const anAddressFormatted = addressToDisplayString(
-          receiveAddress.addr.Hash,
-          parent.getNetworkInfo()
-        )
+      const receiveAddress = await this.generated.getReceiveAddress(wallet);
+      if (receiveAddress == null) return null;
+      const anAddressFormatted = addressToDisplayString(
+        receiveAddress.addr.Hash,
+        parent.getNetworkInfo()
+      );
 
-        return {
-          walletName: settingsCache.conceptualWalletName,
-          currencyName,
-          anAddressFormatted,
-        }
-      })
-      return (await Promise.all(infoWallets)).reduce(
-        (acc, next) => {
-          if (next == null) return acc;
-          acc.push(next);
-          return acc;
-        },
-        []
-      )
-  }
+      return {
+        walletName: settingsCache.conceptualWalletName,
+        currencyName,
+        anAddressFormatted,
+      };
+    });
+    return (await Promise.all(infoWallets)).reduce((acc, next) => {
+      if (next == null) return acc;
+      acc.push(next);
+      return acc;
+    }, []);
+  };
 
   /*
-  * TODO: this should operator on conceptual wallets
-  * with publicDerivers acting as sub-rows
-  * but since we don't support multi-currency or multi-account yet we simplify the UI for now
-  */
-  generateRow: PublicDeriver<> => Node = (publicDeriver) => {
+   * TODO: this should operator on conceptual wallets
+   * with publicDerivers acting as sub-rows
+   * but since we don't support multi-currency or multi-account yet we simplify the UI for now
+   */
+  generateRow: (PublicDeriver<>) => Node = publicDeriver => {
     const parent = publicDeriver.getParent();
-    const settingsCache = this.generated.stores.walletSettings
-      .getConceptualWalletSettingsCache(parent);
+    const settingsCache = this.generated.stores.walletSettings.getConceptualWalletSettingsCache(
+      parent
+    );
 
     const walletSumCurrencies = (() => {
       const network = publicDeriver.getParent().getNetworkInfo();
       const defaultToken = this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
         network.NetworkId
       );
-      const defaultTokenInfo = genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)(
-        {
-          identifier: defaultToken.Identifier,
-          networkId: network.NetworkId,
-        }
-      );
+      const defaultTokenInfo = genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)({
+        identifier: defaultToken.Identifier,
+        networkId: network.NetworkId,
+      });
       return (
         <>
           <WalletCurrency
@@ -226,80 +218,71 @@ export default class MyWalletsPage extends Component<Props> {
       );
     })();
 
-    const txRequests: TxRequests = this.generated.stores.transactions
-      .getTxRequests(publicDeriver);
+    const txRequests: TxRequests = this.generated.stores.transactions.getTxRequests(publicDeriver);
     const balance = txRequests.requests.getBalanceRequest.result ?? null;
 
     const withPubKey = asGetPublicKey(publicDeriver);
-    const plate = withPubKey == null
-      ? null
-      : this.generated.stores.wallets.getPublicKeyCache(withPubKey).plate;
+    const plate =
+      withPubKey == null ? null : this.generated.stores.wallets.getPublicKeyCache(withPubKey).plate;
 
     return (
       <WalletRow
         isExpandable={false /* TODO: should be expandable if > 1 public deriver */}
         key={publicDeriver.getPublicDeriverId()}
         onRowClicked={() => this.handleWalletNavItemClick(publicDeriver)}
-        walletSumDetails={<WalletDetails
-          walletAmount={balance}
-          rewards={this.getRewardBalance(publicDeriver)}
-          // TODO: This should be probably bound to an individual wallet
-          onUpdateHideBalance={this.updateHideBalance}
-          shouldHideBalance={this.generated.stores.profile.shouldHideBalance}
-          getTokenInfo={genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)}
-        />}
-        walletSumCurrencies={walletSumCurrencies}
-        walletSubRow={() => this.createSubrow(publicDeriver)}
-        walletPlate={
-          <NavPlate
-            plate={plate}
-            wallet={settingsCache}
+        walletSumDetails={
+          <WalletDetails
+            walletAmount={balance}
+            rewards={this.getRewardBalance(publicDeriver)}
+            // TODO: This should be probably bound to an individual wallet
+            onUpdateHideBalance={this.updateHideBalance}
+            shouldHideBalance={this.generated.stores.profile.shouldHideBalance}
+            getTokenInfo={genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)}
           />
         }
+        walletSumCurrencies={walletSumCurrencies}
+        walletSubRow={() => this.createSubrow(publicDeriver)}
+        walletPlate={<NavPlate plate={plate} wallet={settingsCache} />}
         walletSync={
           <WalletSync
             time={
-              txRequests.lastSyncInfo.Time
-                ? moment(txRequests.lastSyncInfo.Time).fromNow()
-                : null
+              txRequests.lastSyncInfo.Time ? moment(txRequests.lastSyncInfo.Time).fromNow() : null
             }
           />
         }
         onSettings={() => this.openToSettings(publicDeriver)}
       />
     );
-  }
+  };
 
-  createSubrow: PublicDeriver<> => Node = (publicDeriver) => {
+  createSubrow: (PublicDeriver<>) => Node = publicDeriver => {
     const { intl } = this.context;
 
     const network = publicDeriver.getParent().getNetworkInfo();
     const defaultToken = this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
       network.NetworkId
     );
-    const defaultTokenInfo = genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)(
-      {
-        identifier: defaultToken.Identifier,
-        networkId: network.NetworkId,
-      }
-    );
+    const defaultTokenInfo = genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)({
+      identifier: defaultToken.Identifier,
+      networkId: network.NetworkId,
+    });
 
     // TODO: replace with wallet addresses
     const walletAddresses = [
       'Ae45dPwUPEZMen5UdmKCeiNqCooMVBpDQbmhM1dtFSFigvbvDTZdF4nbdf4u3',
-      'Ae2tdPwUPEZMen5UdmKCeiNqCooMVBpDQbmhM1dtFSFigvbvDTZdF4nmt4s7'
+      'Ae2tdPwUPEZMen5UdmKCeiNqCooMVBpDQbmhM1dtFSFigvbvDTZdF4nmt4s7',
     ];
 
     const addressesLength = walletAddresses.length;
 
     const parent = publicDeriver.getParent();
-    const settingsCache = this.generated.stores.walletSettings
-      .getConceptualWalletSettingsCache(parent);
+    const settingsCache = this.generated.stores.walletSettings.getConceptualWalletSettingsCache(
+      parent
+    );
 
     const withPubKey = asGetPublicKey(publicDeriver);
-    const plate = withPubKey == null
-      ? null
-      : this.generated.stores.wallets.getPublicKeyCache(withPubKey).plate;
+    const plate =
+      withPubKey == null ? null : this.generated.stores.wallets.getPublicKeyCache(withPubKey).plate;
 
     const walletSubRow = (
       <WalletSubRow
@@ -308,44 +291,40 @@ export default class MyWalletsPage extends Component<Props> {
           plate,
         }}
         // TODO: do we delete WalletDetails? Lots of duplication with Nav alternative
-        walletDetails={<WalletDetails
-          infoText={
-            `${addressesLength} ${
-              intl.formatMessage(addressesLength > 1 ?
-                globalMessages.addressesLabel : globalMessages.addressLabel)}`
-          }
-          // TODO: This should be probably bound to an individual wallet
-          onUpdateHideBalance={this.updateHideBalance}
-          shouldHideBalance={this.generated.stores.profile.shouldHideBalance}
-          rewards={null /* TODO */}
-          walletAmount={null /* TODO */}
-          getTokenInfo={genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)}
-        />}
+        walletDetails={
+          <WalletDetails
+            infoText={`${addressesLength} ${intl.formatMessage(
+              addressesLength > 1 ? globalMessages.addressesLabel : globalMessages.addressLabel
+            )}`}
+            // TODO: This should be probably bound to an individual wallet
+            onUpdateHideBalance={this.updateHideBalance}
+            shouldHideBalance={this.generated.stores.profile.shouldHideBalance}
+            rewards={null /* TODO */}
+            walletAmount={null /* TODO */}
+            getTokenInfo={genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)}
+          />
+        }
         walletNumber={1}
         walletAddresses={walletAddresses /* TODO: replace with proper hashes */}
-        walletCurrencies={<WalletCurrency
-          currency={getTokenName(defaultTokenInfo)}
-          tooltipText="0.060" // TODO
-        />}
+        walletCurrencies={
+          <WalletCurrency
+            currency={getTokenName(defaultTokenInfo)}
+            tooltipText="0.060" // TODO
+          />
+        }
       />
     );
 
     return walletSubRow;
-  }
+  };
 
   /**
    * undefined => wallet is not a reward wallet
    * null => still calculating
    * value => done calculating
    */
-  getRewardBalance: PublicDeriver<> => null | void | MultiToken = (
-    publicDeriver
-  ) => {
-    const delegationRequest = this.generated.stores
-      .delegation
-      .getDelegationRequests(
-        publicDeriver
-      );
+  getRewardBalance: (PublicDeriver<>) => null | void | MultiToken = publicDeriver => {
+    const delegationRequest = this.generated.stores.delegation.getDelegationRequests(publicDeriver);
     if (delegationRequest == null) return undefined;
 
     const balanceResult = delegationRequest.getDelegatedBalance.result;
@@ -353,35 +332,35 @@ export default class MyWalletsPage extends Component<Props> {
       return null;
     }
     return balanceResult.accountPart;
-  }
+  };
 
-  @computed get generated (): {|
+  @computed get generated(): {|
     BannerContainerProps: InjectedOrGenerated<BannerContainerData>,
     SidebarContainerProps: InjectedOrGenerated<SidebarContainerData>,
     actions: {|
       profile: {|
         updateHideBalance: {|
-          trigger: (params: void) => Promise<void>
-        |}
+          trigger: (params: void) => Promise<void>,
+        |},
       |},
       router: {|
         goToRoute: {|
           trigger: (params: {|
             publicDeriver?: null | PublicDeriver<>,
             params?: ?any,
-            route: string
-          |}) => void
-        |}
+            route: string,
+          |}) => void,
+        |},
       |},
       dialogs: {|
         closeActiveDialog: {|
-          trigger: (params: void) => void
+          trigger: (params: void) => void,
         |},
         open: {|
           trigger: (params: {|
             dialog: any,
-            params?: any
-          |}) => void
+            params?: any,
+          |}) => void,
         |},
       |},
       wallets: {|
@@ -392,30 +371,28 @@ export default class MyWalletsPage extends Component<Props> {
     stores: {|
       profile: {| shouldHideBalance: boolean |},
       uiDialogs: {|
-        isOpen: any => boolean
+        isOpen: any => boolean,
       |},
       delegation: {|
-        getDelegationRequests: (
-          PublicDeriver<>
-        ) => void | DelegationRequests
+        getDelegationRequests: (PublicDeriver<>) => void | DelegationRequests,
       |},
       tokenInfoStore: {|
         tokenInfo: TokenInfoMap,
         getDefaultTokenInfo: number => $ReadOnly<TokenRow>,
       |},
       transactions: {|
-        getTxRequests: (PublicDeriver<>) => TxRequests
+        getTxRequests: (PublicDeriver<>) => TxRequests,
       |},
       walletSettings: {|
-        getConceptualWalletSettingsCache: ConceptualWallet => ConceptualWalletSettingsCache
+        getConceptualWalletSettingsCache: ConceptualWallet => ConceptualWalletSettingsCache,
       |},
       wallets: {|
         getPublicKeyCache: IGetPublic => PublicKeyCache,
-        publicDerivers: Array<PublicDeriver<>>
-      |}
+        publicDerivers: Array<PublicDeriver<>>,
+      |},
     |},
     getReceiveAddress: typeof getReceiveAddress,
-    |} {
+  |} {
     if (this.props.generated !== undefined) {
       return this.props.generated;
     }
@@ -445,8 +422,7 @@ export default class MyWalletsPage extends Component<Props> {
           getTxRequests: stores.transactions.getTxRequests,
         },
         walletSettings: {
-          getConceptualWalletSettingsCache:
-            stores.walletSettings.getConceptualWalletSettingsCache,
+          getConceptualWalletSettingsCache: stores.walletSettings.getConceptualWalletSettingsCache,
         },
         delegation: {
           getDelegationRequests: stores.delegation.getDelegationRequests,
@@ -472,9 +448,7 @@ export default class MyWalletsPage extends Component<Props> {
           setActiveWallet: { trigger: actions.wallets.setActiveWallet.trigger },
         },
       },
-      SidebarContainerProps: (
-        { actions, stores }: InjectedOrGenerated<SidebarContainerData>
-      ),
+      SidebarContainerProps: ({ actions, stores }: InjectedOrGenerated<SidebarContainerData>),
       BannerContainerProps: ({ actions, stores }: InjectedOrGenerated<BannerContainerData>),
     });
   }

--- a/packages/yoroi-extension/app/containers/wallet/MyWalletsPage.js
+++ b/packages/yoroi-extension/app/containers/wallet/MyWalletsPage.js
@@ -1,57 +1,58 @@
 // @flow
-import type { Node } from 'react';
-import React, { Component } from 'react';
-import { computed } from 'mobx';
-import { observer } from 'mobx-react';
-import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
-import { intlShape } from 'react-intl';
-import type { InjectedOrGenerated } from '../../types/injectedPropsType';
+import type { Node } from 'react'
+import React, { Component } from 'react'
+import { computed } from 'mobx'
+import { observer } from 'mobx-react'
+import type { $npm$ReactIntl$IntlFormat } from 'react-intl'
+import { intlShape, } from 'react-intl'
+import type { InjectedOrGenerated } from '../../types/injectedPropsType'
 
-import MyWallets from '../../components/wallet/my-wallets/MyWallets';
-import TopBarLayout from '../../components/layout/TopBarLayout';
+import MyWallets from '../../components/wallet/my-wallets/MyWallets'
+import TopBarLayout from '../../components/layout/TopBarLayout'
 
-import WalletsList from '../../components/wallet/my-wallets/WalletsList';
-import WalletRow from '../../components/wallet/my-wallets/WalletRow';
-import WalletDetails from '../../components/wallet/my-wallets/WalletDetails';
-import WalletCurrency from '../../components/wallet/my-wallets/WalletCurrency';
-import WalletSubRow from '../../components/wallet/my-wallets/WalletSubRow';
-import NavPlate from '../../components/topbar/NavPlate';
-import type { GeneratedData as SidebarContainerData } from '../SidebarContainer';
-import SidebarContainer from '../SidebarContainer';
-import type { GeneratedData as BannerContainerData } from '../banners/BannerContainer';
-import BannerContainer from '../banners/BannerContainer';
-import { ROUTES } from '../../routes-config';
-import NavBar from '../../components/topbar/NavBar';
-import NavBarTitle from '../../components/topbar/NavBarTitle';
-import WalletSync from '../../components/wallet/my-wallets/WalletSync';
-import moment from 'moment';
-import NavBarAddButton from '../../components/topbar/NavBarAddButton';
-import BuySellAdaButton from '../../components/topbar/BuySellAdaButton';
-import globalMessages from '../../i18n/global-messages';
-import { ConceptualWallet } from '../../api/ada/lib/storage/models/ConceptualWallet/index';
-import { asGetPublicKey } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
-import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/index';
-import type { ConceptualWalletSettingsCache } from '../../stores/toplevel/WalletSettingsStore';
-import type { DelegationRequests } from '../../stores/toplevel/DelegationStore';
-import type { PublicKeyCache } from '../../stores/toplevel/WalletStore';
-import type { TxRequests } from '../../stores/toplevel/TransactionsStore';
-import type { IGetPublic } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces';
-import type { TokenRow } from '../../api/ada/lib/storage/database/primitives/tables';
-import { MultiToken } from '../../api/common/lib/MultiToken';
-import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore';
-import { genLookupOrFail, getTokenName } from '../../stores/stateless/tokenHelpers';
+import WalletsList from '../../components/wallet/my-wallets/WalletsList'
+import WalletRow from '../../components/wallet/my-wallets/WalletRow'
+import WalletDetails from '../../components/wallet/my-wallets/WalletDetails'
+import WalletCurrency from '../../components/wallet/my-wallets/WalletCurrency'
+import WalletSubRow from '../../components/wallet/my-wallets/WalletSubRow'
+import NavPlate from '../../components/topbar/NavPlate'
+import type { GeneratedData as SidebarContainerData } from '../SidebarContainer'
+import SidebarContainer from '../SidebarContainer'
+import type { GeneratedData as BannerContainerData } from '../banners/BannerContainer'
+import BannerContainer from '../banners/BannerContainer'
+import { ROUTES } from '../../routes-config'
+import NavBar from '../../components/topbar/NavBar'
+import NavBarTitle from '../../components/topbar/NavBarTitle'
+import WalletSync from '../../components/wallet/my-wallets/WalletSync'
+import moment from 'moment'
+import NavBarAddButton from '../../components/topbar/NavBarAddButton'
+import BuySellAdaButton from '../../components/topbar/BuySellAdaButton'
+import globalMessages from '../../i18n/global-messages'
+import { ConceptualWallet, } from '../../api/ada/lib/storage/models/ConceptualWallet/index'
+import { asGetPublicKey, } from '../../api/ada/lib/storage/models/PublicDeriver/traits'
+import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/index'
+import type { ConceptualWalletSettingsCache } from '../../stores/toplevel/WalletSettingsStore'
+import type { DelegationRequests } from '../../stores/toplevel/DelegationStore'
+import type { PublicKeyCache } from '../../stores/toplevel/WalletStore'
+import type { TxRequests } from '../../stores/toplevel/TransactionsStore'
+import type { IGetPublic } from '../../api/ada/lib/storage/models/PublicDeriver/interfaces'
+import type { TokenRow } from '../../api/ada/lib/storage/database/primitives/tables'
+import { MultiToken } from '../../api/common/lib/MultiToken'
+import type { TokenInfoMap } from '../../stores/toplevel/TokenInfoStore'
+import { genLookupOrFail, getTokenName } from '../../stores/stateless/tokenHelpers'
 import { getReceiveAddress } from '../../stores/stateless/addressStores';
 import BuySellDialog from '../../components/buySell/BuySellDialog';
 import type { WalletInfo } from '../../components/buySell/BuySellDialog';
-import { addressToDisplayString } from '../../api/ada/lib/storage/bridge/utils';
-import { networks } from '../../api/ada/lib/storage/database/prepackaged/networks';
+import { addressToDisplayString } from '../../api/ada/lib/storage/bridge/utils'
+import { networks } from '../../api/ada/lib/storage/database/prepackaged/networks'
 
 export type GeneratedData = typeof MyWalletsPage.prototype.generated;
 
-type Props = InjectedOrGenerated<GeneratedData>;
+type Props = InjectedOrGenerated<GeneratedData>
 
 @observer
 export default class MyWalletsPage extends Component<Props> {
+
   static contextTypes: {| intl: $npm$ReactIntl$IntlFormat |} = {
     intl: intlShape.isRequired,
   };
@@ -60,154 +61,164 @@ export default class MyWalletsPage extends Component<Props> {
     this.generated.actions.dialogs.closeActiveDialog.trigger();
   };
 
-  openDialogWrapper: any => void = dialog => {
+  openDialogWrapper: any => void = (dialog) => {
     this.generated.actions.dialogs.open.trigger({ dialog });
-  };
+  }
 
   updateHideBalance: void => Promise<void> = async () => {
     await this.generated.actions.profile.updateHideBalance.trigger();
-  };
+  }
 
-  componentDidMount() {
+  componentDidMount () {
     this.generated.actions.wallets.unselectWallet.trigger();
   }
 
-  handleWalletNavItemClick: (PublicDeriver<>) => void = publicDeriver => {
+  handleWalletNavItemClick: PublicDeriver<> => void = (
+    publicDeriver
+  ) => {
     this.generated.actions.router.goToRoute.trigger({
       route: ROUTES.WALLETS.ROOT,
-      publicDeriver,
+      publicDeriver
     });
   };
 
-  openToSettings: (PublicDeriver<>) => void = publicDeriver => {
+  openToSettings: PublicDeriver<> => void = (
+    publicDeriver
+  ) => {
     this.generated.actions.wallets.setActiveWallet.trigger({
-      wallet: publicDeriver,
+      wallet: publicDeriver
     });
     this.generated.actions.router.goToRoute.trigger({
       route: ROUTES.SETTINGS.WALLET,
     });
   };
 
-  render(): Node {
+  render (): Node {
     const { intl } = this.context;
     const { stores } = this.generated;
     const { uiDialogs } = stores;
 
-    const sidebarContainer = <SidebarContainer {...this.generated.SidebarContainerProps} />;
+    const sidebarContainer = <SidebarContainer {...this.generated.SidebarContainerProps} />
 
     const wallets = this.generated.stores.wallets.publicDerivers;
 
-    const navbarTitle = <NavBarTitle title={intl.formatMessage(globalMessages.sidebarWallets)} />;
+    const navbarTitle = (
+      <NavBarTitle title={intl.formatMessage(globalMessages.sidebarWallets)} />
+    );
 
     const navbarElement = (
       <NavBar
         title={navbarTitle}
-        button={
-          <NavBarAddButton
-            onClick={() =>
-              this.generated.actions.router.goToRoute.trigger({ route: ROUTES.WALLETS.ADD })
-            }
-          />
+        button={<NavBarAddButton onClick={
+          () => this.generated.actions.router.goToRoute.trigger({ route: ROUTES.WALLETS.ADD })
         }
+        />}
         buyButton={
-          <BuySellAdaButton onBuySellClick={() => this.openDialogWrapper(BuySellDialog)} />
+          <BuySellAdaButton onBuySellClick={() =>
+            (this.openDialogWrapper(BuySellDialog))
+          }
+          />
         }
         walletDetails={undefined}
       />
     );
 
     const walletsList = (
-      <WalletsList>{wallets.map(wallet => this.generateRow(wallet))}</WalletsList>
+      <WalletsList>
+        {wallets.map(wallet => this.generateRow(wallet))}
+      </WalletsList>
     );
 
     let activeDialog = null;
     if (uiDialogs.isOpen(BuySellDialog)) {
-      activeDialog = (
-        <BuySellDialog
-          onCancel={this.onClose}
-          genWalletList={async () => {
-            return await this.generateUnusedAddressesPerWallet(wallets);
-          }}
-        />
-      );
+      activeDialog = <BuySellDialog
+        onCancel={this.onClose}
+        genWalletList={async () => {
+          return await this.generateUnusedAddressesPerWallet(wallets);
+        }}
+      />
     }
 
     return (
       <TopBarLayout
-        banner={<BannerContainer {...this.generated.BannerContainerProps} />}
+        banner={(<BannerContainer {...this.generated.BannerContainerProps} />)}
         sidebar={sidebarContainer}
         navbar={navbarElement}
         showInContainer
       >
-        <MyWallets>{walletsList}</MyWallets>
+        <MyWallets>
+          {walletsList}
+        </MyWallets>
         {activeDialog}
       </TopBarLayout>
     );
   }
 
-  generateUnusedAddressesPerWallet: (Array<PublicDeriver<>>) => Promise<Array<WalletInfo>> = async (
-    wallets: Array<PublicDeriver<>>
-  ) => {
-    const infoWallets = wallets.map(async (wallet: PublicDeriver<>) => {
-      // Wallet Name
-      const parent: ConceptualWallet = wallet.getParent();
-      const settingsCache: ConceptualWalletSettingsCache = this.generated.stores.walletSettings.getConceptualWalletSettingsCache(
-        parent
-      );
+  generateUnusedAddressesPerWallet: Array<PublicDeriver<>> => Promise<Array<WalletInfo>> =
+    async (wallets: Array<PublicDeriver<>>) => {
+      const infoWallets = wallets.map(async (wallet: PublicDeriver<>) => {
+        // Wallet Name
+        const parent: ConceptualWallet = wallet.getParent();
+        const settingsCache: ConceptualWalletSettingsCache = this.generated.stores.walletSettings
+          .getConceptualWalletSettingsCache(parent);
 
-      // Currency Name
-      const defaultToken = this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
-        wallet.getParent().getNetworkInfo().NetworkId
-      );
-      const currencyName = getTokenName(defaultToken);
+        // Currency Name
+        const defaultToken = this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
+          wallet.getParent().getNetworkInfo().NetworkId
+        )
+        const currencyName = getTokenName(defaultToken)
 
       if (
         defaultToken.NetworkId !== networks.CardanoMainnet.NetworkId &&
         defaultToken.NetworkId !== networks.ErgoMainnet.NetworkId
       ) {
-        return null;
-      }
+          return null;
+        }
 
-      const receiveAddress = await this.generated.getReceiveAddress(wallet);
-      if (receiveAddress == null) return null;
-      const anAddressFormatted = addressToDisplayString(
-        receiveAddress.addr.Hash,
-        parent.getNetworkInfo()
-      );
+        const receiveAddress = await this.generated.getReceiveAddress(wallet);
+        if (receiveAddress == null) return null;
+        const anAddressFormatted = addressToDisplayString(
+          receiveAddress.addr.Hash,
+          parent.getNetworkInfo()
+        )
 
-      return {
-        walletName: settingsCache.conceptualWalletName,
-        currencyName,
-        anAddressFormatted,
-      };
-    });
-    return (await Promise.all(infoWallets)).reduce((acc, next) => {
-      if (next == null) return acc;
-      acc.push(next);
-      return acc;
-    }, []);
-  };
+        return {
+          walletName: settingsCache.conceptualWalletName,
+          currencyName,
+          anAddressFormatted,
+        }
+      })
+      return (await Promise.all(infoWallets)).reduce(
+        (acc, next) => {
+          if (next == null) return acc;
+          acc.push(next);
+          return acc;
+        },
+        []
+      )
+  }
 
   /*
-   * TODO: this should operator on conceptual wallets
-   * with publicDerivers acting as sub-rows
-   * but since we don't support multi-currency or multi-account yet we simplify the UI for now
-   */
-  generateRow: (PublicDeriver<>) => Node = publicDeriver => {
+  * TODO: this should operator on conceptual wallets
+  * with publicDerivers acting as sub-rows
+  * but since we don't support multi-currency or multi-account yet we simplify the UI for now
+  */
+  generateRow: PublicDeriver<> => Node = (publicDeriver) => {
     const parent = publicDeriver.getParent();
-    const settingsCache = this.generated.stores.walletSettings.getConceptualWalletSettingsCache(
-      parent
-    );
+    const settingsCache = this.generated.stores.walletSettings
+      .getConceptualWalletSettingsCache(parent);
 
     const walletSumCurrencies = (() => {
       const network = publicDeriver.getParent().getNetworkInfo();
       const defaultToken = this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
         network.NetworkId
       );
-      const defaultTokenInfo = genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)({
-        identifier: defaultToken.Identifier,
-        networkId: network.NetworkId,
-      });
+      const defaultTokenInfo = genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)(
+        {
+          identifier: defaultToken.Identifier,
+          networkId: network.NetworkId,
+        }
+      );
       return (
         <>
           <WalletCurrency
@@ -218,71 +229,80 @@ export default class MyWalletsPage extends Component<Props> {
       );
     })();
 
-    const txRequests: TxRequests = this.generated.stores.transactions.getTxRequests(publicDeriver);
+    const txRequests: TxRequests = this.generated.stores.transactions
+      .getTxRequests(publicDeriver);
     const balance = txRequests.requests.getBalanceRequest.result ?? null;
 
     const withPubKey = asGetPublicKey(publicDeriver);
-    const plate =
-      withPubKey == null ? null : this.generated.stores.wallets.getPublicKeyCache(withPubKey).plate;
+    const plate = withPubKey == null
+      ? null
+      : this.generated.stores.wallets.getPublicKeyCache(withPubKey).plate;
 
     return (
       <WalletRow
         isExpandable={false /* TODO: should be expandable if > 1 public deriver */}
         key={publicDeriver.getPublicDeriverId()}
         onRowClicked={() => this.handleWalletNavItemClick(publicDeriver)}
-        walletSumDetails={
-          <WalletDetails
-            walletAmount={balance}
-            rewards={this.getRewardBalance(publicDeriver)}
-            // TODO: This should be probably bound to an individual wallet
-            onUpdateHideBalance={this.updateHideBalance}
-            shouldHideBalance={this.generated.stores.profile.shouldHideBalance}
-            getTokenInfo={genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)}
-          />
-        }
+        walletSumDetails={<WalletDetails
+          walletAmount={balance}
+          rewards={this.getRewardBalance(publicDeriver)}
+          // TODO: This should be probably bound to an individual wallet
+          onUpdateHideBalance={this.updateHideBalance}
+          shouldHideBalance={this.generated.stores.profile.shouldHideBalance}
+          getTokenInfo={genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)}
+        />}
         walletSumCurrencies={walletSumCurrencies}
         walletSubRow={() => this.createSubrow(publicDeriver)}
-        walletPlate={<NavPlate plate={plate} wallet={settingsCache} />}
+        walletPlate={
+          <NavPlate
+            plate={plate}
+            wallet={settingsCache}
+          />
+        }
         walletSync={
           <WalletSync
             time={
-              txRequests.lastSyncInfo.Time ? moment(txRequests.lastSyncInfo.Time).fromNow() : null
+              txRequests.lastSyncInfo.Time
+                ? moment(txRequests.lastSyncInfo.Time).fromNow()
+                : null
             }
           />
         }
         onSettings={() => this.openToSettings(publicDeriver)}
       />
     );
-  };
+  }
 
-  createSubrow: (PublicDeriver<>) => Node = publicDeriver => {
+  createSubrow: PublicDeriver<> => Node = (publicDeriver) => {
     const { intl } = this.context;
 
     const network = publicDeriver.getParent().getNetworkInfo();
     const defaultToken = this.generated.stores.tokenInfoStore.getDefaultTokenInfo(
       network.NetworkId
     );
-    const defaultTokenInfo = genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)({
-      identifier: defaultToken.Identifier,
-      networkId: network.NetworkId,
-    });
+    const defaultTokenInfo = genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)(
+      {
+        identifier: defaultToken.Identifier,
+        networkId: network.NetworkId,
+      }
+    );
 
     // TODO: replace with wallet addresses
     const walletAddresses = [
       'Ae45dPwUPEZMen5UdmKCeiNqCooMVBpDQbmhM1dtFSFigvbvDTZdF4nbdf4u3',
-      'Ae2tdPwUPEZMen5UdmKCeiNqCooMVBpDQbmhM1dtFSFigvbvDTZdF4nmt4s7',
+      'Ae2tdPwUPEZMen5UdmKCeiNqCooMVBpDQbmhM1dtFSFigvbvDTZdF4nmt4s7'
     ];
 
     const addressesLength = walletAddresses.length;
 
     const parent = publicDeriver.getParent();
-    const settingsCache = this.generated.stores.walletSettings.getConceptualWalletSettingsCache(
-      parent
-    );
+    const settingsCache = this.generated.stores.walletSettings
+      .getConceptualWalletSettingsCache(parent);
 
     const withPubKey = asGetPublicKey(publicDeriver);
-    const plate =
-      withPubKey == null ? null : this.generated.stores.wallets.getPublicKeyCache(withPubKey).plate;
+    const plate = withPubKey == null
+      ? null
+      : this.generated.stores.wallets.getPublicKeyCache(withPubKey).plate;
 
     const walletSubRow = (
       <WalletSubRow
@@ -291,40 +311,44 @@ export default class MyWalletsPage extends Component<Props> {
           plate,
         }}
         // TODO: do we delete WalletDetails? Lots of duplication with Nav alternative
-        walletDetails={
-          <WalletDetails
-            infoText={`${addressesLength} ${intl.formatMessage(
-              addressesLength > 1 ? globalMessages.addressesLabel : globalMessages.addressLabel
-            )}`}
-            // TODO: This should be probably bound to an individual wallet
-            onUpdateHideBalance={this.updateHideBalance}
-            shouldHideBalance={this.generated.stores.profile.shouldHideBalance}
-            rewards={null /* TODO */}
-            walletAmount={null /* TODO */}
-            getTokenInfo={genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)}
-          />
-        }
+        walletDetails={<WalletDetails
+          infoText={
+            `${addressesLength} ${
+              intl.formatMessage(addressesLength > 1 ?
+                globalMessages.addressesLabel : globalMessages.addressLabel)}`
+          }
+          // TODO: This should be probably bound to an individual wallet
+          onUpdateHideBalance={this.updateHideBalance}
+          shouldHideBalance={this.generated.stores.profile.shouldHideBalance}
+          rewards={null /* TODO */}
+          walletAmount={null /* TODO */}
+          getTokenInfo={genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo)}
+        />}
         walletNumber={1}
         walletAddresses={walletAddresses /* TODO: replace with proper hashes */}
-        walletCurrencies={
-          <WalletCurrency
-            currency={getTokenName(defaultTokenInfo)}
-            tooltipText="0.060" // TODO
-          />
-        }
+        walletCurrencies={<WalletCurrency
+          currency={getTokenName(defaultTokenInfo)}
+          tooltipText="0.060" // TODO
+        />}
       />
     );
 
     return walletSubRow;
-  };
+  }
 
   /**
    * undefined => wallet is not a reward wallet
    * null => still calculating
    * value => done calculating
    */
-  getRewardBalance: (PublicDeriver<>) => null | void | MultiToken = publicDeriver => {
-    const delegationRequest = this.generated.stores.delegation.getDelegationRequests(publicDeriver);
+  getRewardBalance: PublicDeriver<> => null | void | MultiToken = (
+    publicDeriver
+  ) => {
+    const delegationRequest = this.generated.stores
+      .delegation
+      .getDelegationRequests(
+        publicDeriver
+      );
     if (delegationRequest == null) return undefined;
 
     const balanceResult = delegationRequest.getDelegatedBalance.result;
@@ -332,35 +356,35 @@ export default class MyWalletsPage extends Component<Props> {
       return null;
     }
     return balanceResult.accountPart;
-  };
+  }
 
-  @computed get generated(): {|
+  @computed get generated (): {|
     BannerContainerProps: InjectedOrGenerated<BannerContainerData>,
     SidebarContainerProps: InjectedOrGenerated<SidebarContainerData>,
     actions: {|
       profile: {|
         updateHideBalance: {|
-          trigger: (params: void) => Promise<void>,
-        |},
+          trigger: (params: void) => Promise<void>
+        |}
       |},
       router: {|
         goToRoute: {|
           trigger: (params: {|
             publicDeriver?: null | PublicDeriver<>,
             params?: ?any,
-            route: string,
-          |}) => void,
-        |},
+            route: string
+          |}) => void
+        |}
       |},
       dialogs: {|
         closeActiveDialog: {|
-          trigger: (params: void) => void,
+          trigger: (params: void) => void
         |},
         open: {|
           trigger: (params: {|
             dialog: any,
-            params?: any,
-          |}) => void,
+            params?: any
+          |}) => void
         |},
       |},
       wallets: {|
@@ -371,28 +395,30 @@ export default class MyWalletsPage extends Component<Props> {
     stores: {|
       profile: {| shouldHideBalance: boolean |},
       uiDialogs: {|
-        isOpen: any => boolean,
+        isOpen: any => boolean
       |},
       delegation: {|
-        getDelegationRequests: (PublicDeriver<>) => void | DelegationRequests,
+        getDelegationRequests: (
+          PublicDeriver<>
+        ) => void | DelegationRequests
       |},
       tokenInfoStore: {|
         tokenInfo: TokenInfoMap,
         getDefaultTokenInfo: number => $ReadOnly<TokenRow>,
       |},
       transactions: {|
-        getTxRequests: (PublicDeriver<>) => TxRequests,
+        getTxRequests: (PublicDeriver<>) => TxRequests
       |},
       walletSettings: {|
-        getConceptualWalletSettingsCache: ConceptualWallet => ConceptualWalletSettingsCache,
+        getConceptualWalletSettingsCache: ConceptualWallet => ConceptualWalletSettingsCache
       |},
       wallets: {|
         getPublicKeyCache: IGetPublic => PublicKeyCache,
-        publicDerivers: Array<PublicDeriver<>>,
-      |},
+        publicDerivers: Array<PublicDeriver<>>
+      |}
     |},
     getReceiveAddress: typeof getReceiveAddress,
-  |} {
+    |} {
     if (this.props.generated !== undefined) {
       return this.props.generated;
     }
@@ -422,7 +448,8 @@ export default class MyWalletsPage extends Component<Props> {
           getTxRequests: stores.transactions.getTxRequests,
         },
         walletSettings: {
-          getConceptualWalletSettingsCache: stores.walletSettings.getConceptualWalletSettingsCache,
+          getConceptualWalletSettingsCache:
+            stores.walletSettings.getConceptualWalletSettingsCache,
         },
         delegation: {
           getDelegationRequests: stores.delegation.getDelegationRequests,
@@ -448,7 +475,9 @@ export default class MyWalletsPage extends Component<Props> {
           setActiveWallet: { trigger: actions.wallets.setActiveWallet.trigger },
         },
       },
-      SidebarContainerProps: ({ actions, stores }: InjectedOrGenerated<SidebarContainerData>),
+      SidebarContainerProps: (
+        { actions, stores }: InjectedOrGenerated<SidebarContainerData>
+      ),
       BannerContainerProps: ({ actions, stores }: InjectedOrGenerated<BannerContainerData>),
     });
   }


### PR DESCRIPTION
Adds the buy ERG functionality via the following changes:

   - Changed  `generateUnusedAddressesPerWallet()` at  `MyWalletsPage.js` to also list Ergo addresses
   - Removed `WIDGET_URL` const from `BuySellDialog.js`
   - Added `currency` prop to accept currency type and removed `widgetURL` prop from `ChangellyFetcher` component
   - Changed `addAddressToWidget(widgetURL, address)` to `mountWidgetUrl(currency, address)` at `ChangellyFetcher.js` in order to dynamically mount the widget URL based on the selected address.

## To-do
- [x] Base implementation
- [ ] UI changes

## Comments
   - ~~It appears that prettier changed a lot of things, if isn't a desirable behavior, please let me know so I can disable it.~~
   - What's the preferable way to reflect these changes at UI level? I'm thinking to rename the 'BUY ADA' button to something like 'BUY ADA/ERG' or just 'BUY', any thoughts?

## Screenshots
<img src="https://user-images.githubusercontent.com/87387688/136086787-ba5de3e8-b5b5-4c1d-9496-95e54174eca5.png" align="center"  width="600">