### PR TITLE
[TEMP] Switch the building of unsigned TX to Yoroi Lib

### DIFF
--- a/packages/yoroi-extension/.flowconfig
+++ b/packages/yoroi-extension/.flowconfig
@@ -8,6 +8,9 @@
 <PROJECT_ROOT>/dev/.*
 <PROJECT_ROOT>/build/.*
 
+[declarations]
+.*/node_modules/@emurgo/yoroi-lib-core/.*
+
 [include]
 ../node_modules/eslint-plugin-jsx-a11y
 

--- a/packages/yoroi-extension/app/api/common/lib/transactions/ISignRequest.js
+++ b/packages/yoroi-extension/app/api/common/lib/transactions/ISignRequest.js
@@ -4,6 +4,15 @@ import {
   MultiToken,
 } from '../MultiToken';
 
+export type SignedTx = {|
+  id: string;
+  encodedTx: Uint8Array;
+|}
+
+export type TxMetadata = {|
+  label: string, data: any
+|}
+
 export interface ISignRequest<T> {
   inputs(): Array<{|
     address: string,
@@ -21,4 +30,12 @@ export interface ISignRequest<T> {
   isEqual(tx: ?mixed): boolean;
   self(): T;
   +size?: () => {| full: number, outputs: number[] |};
+  +sign?: (keyLevel: number,
+    privateKey: string,
+    stakingKeyWits: Set<string>,
+    metadata: TxMetadata[]) => Promise<SignedTx>;
+  neededStakingKeyHashes?: {|
+    neededHashes: Set<string>, // StakeCredential
+    wits: Set<string>, // Vkeywitness
+  |}
 }

--- a/packages/yoroi-extension/app/stores/ada/AdaWalletsStore.js
+++ b/packages/yoroi-extension/app/stores/ada/AdaWalletsStore.js
@@ -7,6 +7,7 @@ import type {
   GenerateWalletRecoveryPhraseFunc
 } from '../../api/ada/index';
 import { HaskellShelleyTxSignRequest } from '../../api/ada/transactions/shelley/HaskellShelleyTxSignRequest';
+import type { ISignRequest } from '../../api/common/lib/transactions/ISignRequest';
 import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/index';
 import { buildCheckAndCall } from '../lib/check';
 import { getApiForNetwork, ApiOptions } from '../../api/common/utils';
@@ -40,7 +41,7 @@ export default class AdaWalletsStore extends Store<StoresMap, ActionsMap> {
     broadcastRequest: {|
       normal: {|
         publicDeriver: PublicDeriver<>,
-        signRequest: HaskellShelleyTxSignRequest,
+        signRequest: ISignRequest<any>,
         password: string,
       |}
     |} | {|

--- a/packages/yoroi-extension/app/stores/toplevel/TransactionBuilderStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TransactionBuilderStore.js
@@ -257,7 +257,7 @@ export default class TransactionBuilderStore extends Store<StoresMap, ActionsMap
       }
 
       if (amount == null && shouldSendAll === true) {
-        await this.createUnsignedTx.execute(() => this.api.ada.createUnsignedTx({
+        await this.createUnsignedTx.execute(() => this.api.ada.createUnsignedTxUsingYoroiLib({
           publicDeriver: withHasUtxoChains,
           receiver,
           tokens: genTokenList({
@@ -270,7 +270,7 @@ export default class TransactionBuilderStore extends Store<StoresMap, ActionsMap
           metadata: this.metadata,
         }));
       } else if (amount != null) {
-        await this.createUnsignedTx.execute(() => this.api.ada.createUnsignedTx({
+        await this.createUnsignedTx.execute(() => this.api.ada.createUnsignedTxUsingYoroiLib({
           publicDeriver: withHasUtxoChains,
           receiver,
           tokens: genTokenList({

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1709,6 +1709,21 @@
         "@cardano-foundation/ledgerjs-hw-app-cardano": "4.0.0"
       }
     },
+    "@emurgo/yoroi-lib-browser": {
+      "version": "file:../../../yoroi-lib/packages/yoroi-lib-browser/emurgo-yoroi-lib-browser-0.0.1-alpha.0.tgz",
+      "integrity": "sha512-af3spR0//p2iwBLfXxjdqgU8iNW+fnX8DLb7kbHrrZsAwbietmgxpzCaJSpuDgGvTP71P2fY40yPqXchyjDnvg==",
+      "requires": {
+        "@emurgo/cardano-serialization-lib-browser": "^9.1.0"
+      }
+    },
+    "@emurgo/yoroi-lib-core": {
+      "version": "file:../../../yoroi-lib/packages/yoroi-lib-core/emurgo-yoroi-lib-core-0.0.1-alpha.0.tgz",
+      "integrity": "sha512-utC0hQlRDghWt9nxQ52Ofm6sVPsP6kjSjuY3SL0vtFxIDAzsmucFNcrImYM51W6l6nfdbd/7jW+rzFb3tJ8ZWg==",
+      "requires": {
+        "bignumber.js": "^9.0.1",
+        "hash-wasm": "^4.9.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -16316,6 +16331,11 @@
         "readable-stream": "^3.6.0",
         "safe-buffer": "^5.2.0"
       }
+    },
+    "hash-wasm": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
+      "integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
     },
     "hash.js": {
       "version": "1.1.7",

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1718,7 +1718,7 @@
     },
     "@emurgo/yoroi-lib-core": {
       "version": "file:../../../yoroi-lib/packages/yoroi-lib-core/emurgo-yoroi-lib-core-0.0.1-alpha.0.tgz",
-      "integrity": "sha512-utC0hQlRDghWt9nxQ52Ofm6sVPsP6kjSjuY3SL0vtFxIDAzsmucFNcrImYM51W6l6nfdbd/7jW+rzFb3tJ8ZWg==",
+      "integrity": "sha512-QRpRbhH4Vyn9dTHa4v6skXDFgK9j32PrfmxRyZ79+2mE53yWgMvBZjNX/zSgXit942AT9FP9V31eUiy9pG2aOw==",
       "requires": {
         "bignumber.js": "^9.0.1",
         "hash-wasm": "^4.9.0"

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -162,6 +162,8 @@
     "@emurgo/cip4-js": "1.0.5",
     "@emurgo/js-chain-libs": "0.7.1",
     "@emurgo/ledger-connect-handler": "6.0.0",
+    "@emurgo/yoroi-lib-browser": "file:../../../yoroi-lib/packages/yoroi-lib-browser/emurgo-yoroi-lib-browser-0.0.1-alpha.0.tgz",
+    "@emurgo/yoroi-lib-core": "file:../../../yoroi-lib/packages/yoroi-lib-core/emurgo-yoroi-lib-core-0.0.1-alpha.0.tgz",
     "@mui/lab": "^5.0.0-alpha.51",
     "@mui/material": "^5.0.4",
     "@svgr/webpack": "5.5.0",


### PR DESCRIPTION
Note this is a draft PR, raised mainly so anyone interested can keep following how the migration to [Yoroi Lib](https://github.com/Emurgo/yoroi-lib) is going.

**IMPORTANT**:
- this PR is based on the [feature/add-more-info-to-unsigned-tx](https://github.com/Emurgo/yoroi-lib/tree/feature/add-more-info-to-unsigned-tx) branch;
- to try out these changes locally you will have to build the `yoroi-lib-browser` package from the branch above and install it into the extension. This is very simple, just do:
  - run `yarn pack-tar` from the `packages/yoroi-lib-browser` directory (in the `yoroi-lib` repo);
  - the above will create a `.tgz` file. Now, from the `packages/yoroi-extension` directory, run `yarn add {path_to_tgz}`.
- and most important, **this PR breaks the sending of ADA**, as we are returning the unsigned TX from yoroi-lib but we didn't make the appropriate changes in the extension to sign this TX yet. Please don't mark it as "Ready for Review" unless you're absolutely sure of what you're doing :)