### PR TITLE
Fix word list sorting

### DIFF
--- a/packages/yoroi-extension/app/components/common/Autocomplete.js
+++ b/packages/yoroi-extension/app/components/common/Autocomplete.js
@@ -50,8 +50,11 @@ function Autocomplete({
 }: Props): Node {
   const [inputValue, setInputValue] = useState<string>('');
   const inputRef = useRef();
+  const lowerInputVal = inputValue.toLowerCase();
   const filteredList = options.filter(
-    item => !inputValue || item.toLowerCase().includes(inputValue.toLowerCase())
+    item => !inputValue || item.toLowerCase().includes(lowerInputVal)
+  ).sort(
+    (a, b) => b.startsWith(lowerInputVal) - a.startsWith(lowerInputVal)
   );
   const sliceArrayItems = slice(filteredList, 0, maxVisibleOptions);
 


### PR DESCRIPTION
This PR sorts the filtered word list at `AutoComplete` so that the word starting with the input value is pulled to the top of the list avoiding situations like when a word like "ring" is typed and it keeps hidden on the list due to other words that also containing "ring" chars like "bo**ring**", for example.

## Actual behavior
![Screenshot 2021-10-29 19 57 40](https://user-images.githubusercontent.com/87387688/139513254-8b178c1d-3f09-4e70-a20a-c0a770c2d31a.png)

## Behavior proposed by this PR
![Screenshot 2021-10-29 21 12 20](https://user-images.githubusercontent.com/87387688/139513277-1b643d42-7b96-4b27-847a-0591dd6b1f1e.png)

