### PR TITLE
[low priority]remove unused FlowFixMe

### DIFF
--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/ledgerTx.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/ledgerTx.js
@@ -347,7 +347,6 @@ export function toLedgerAddressParameters(request: {|
         }
         const hashInAddress = Buffer.from(wasmHash.to_bytes()).toString('hex');
 
-        // $FlowFixMe
         return {
           // can't always know staking key path since address may not belong to the wallet
           // (mangled address)

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/ledgerTx.test.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/ledgerTx.test.js
@@ -87,7 +87,6 @@ test('Generate address parameters', async () => {
       path,
       addressingMap: () => undefined,
     }))
-    // $FlowFixMe
     .toEqual(({
       type: AddressType.BASE_PAYMENT_KEY_STAKE_KEY,
       params: {


### PR DESCRIPTION
The FlowFixMe statements were added in PR https://github.com/Emurgo/yoroi-frontend/pull/2424 to make the flow check pass. Not sure why flow complained there. But now it is unused. To avoid masking real code error, I'm removing them.