### PR TITLE
Fix all wallets displaying the amount from the selected wallet

### DIFF
--- a/packages/yoroi-extension/app/containers/NavBarContainerRevamp.js
+++ b/packages/yoroi-extension/app/containers/NavBarContainerRevamp.js
@@ -162,6 +162,8 @@ export default class NavBarContainerRevamp extends Component<Props> {
     const balance = txRequests.requests.getBalanceRequest.result || null;
 
     const walletsMap = wallets.map(wallet => {
+      const walletTxRequests = this.generated.stores.transactions.getTxRequests(wallet);
+      const walletBalance = walletTxRequests.requests.getBalanceRequest.result || null;
       const parent = wallet.getParent();
       const settingsCache = this.generated.stores.walletSettings.getConceptualWalletSettingsCache(
         parent
@@ -176,7 +178,7 @@ export default class NavBarContainerRevamp extends Component<Props> {
       return {
         walletId: wallet.getPublicDeriverId(),
         rewards: this.getRewardBalance(publicDeriver),
-        walletAmount: balance,
+        walletAmount: walletBalance,
         getTokenInfo: genLookupOrFail(this.generated.stores.tokenInfoStore.tokenInfo),
         plate,
         wallet: settingsCache,


### PR DESCRIPTION
Wall the wallets at `walletsMap` were using the balance from the selected wallet. This PR fetches the appropriate balance for each wallet