### PR TITLE
[4.8.2] Do not retain the whole tx list in memory permanently

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -1,4 +1,4 @@
-npm i \
+nvm i && npm i \
 && npm i --prefix packages/yoroi-extension \
 && npm i --prefix packages/yoroi-ergo-connector \
 && npm i --prefix packages/yoroi-ergo-connector/example-ergo \

--- a/packages/yoroi-extension/app/api/common/index.js
+++ b/packages/yoroi-extension/app/api/common/index.js
@@ -46,6 +46,7 @@ import type { CoreAddressT, } from '../ada/lib/storage/database/primitives/enums
 import { getAllTokenInfo } from './lib/tokens/utils';
 import { MultiToken } from './lib/MultiToken';
 import type { DefaultTokenEntry } from './lib/MultiToken';
+import type { UnconfirmedAmount } from '../../types/unconfirmedAmountType';
 
 // getTokenInfo
 
@@ -143,6 +144,18 @@ export type GetTransactionsResponse = {
 export type GetTransactionsFunc = (
   request: BaseGetTransactionsRequest
 ) => Promise<GetTransactionsResponse>;
+
+export type GetTransactionsDataResponse = {|
+  hash: number,
+  totalAvailable: number,
+  unconfirmedAmount: ?UnconfirmedAmount,
+  remoteTransactionIds: Set<string>,
+  timestamps: Array<number>,
+|};
+
+export type GetTransactionsDataFunc = (
+  request: BaseGetTransactionsRequest
+) => Promise<GetTransactionsDataResponse>;
 
 export type ExportTransactionsRequest = {|
   ticker: string,

--- a/packages/yoroi-extension/app/stores/base/BaseCoinPriceStore.js
+++ b/packages/yoroi-extension/app/stores/base/BaseCoinPriceStore.js
@@ -14,7 +14,6 @@ import type {
   CurrentCoinPriceResponse,
   HistoricalCoinPriceResponse,
 } from '../../api/common/lib/state-fetch/types';
-import WalletTransaction from '../../domain/WalletTransaction';
 import type { Ticker, PriceDataRow } from '../../api/ada/lib/storage/database/prices/tables';
 import { getPrice, upsertPrices, getAllPrices, getPriceKey } from '../../api/common/lib/storage/bridge/prices';
 import type { GetAllPricesFunc } from '../../api/common/lib/storage/bridge/prices';
@@ -197,12 +196,13 @@ export default class BaseCoinPriceStore
 
   updateTransactionPriceData: {|
     db: lf$Database,
-    transactions: Array<WalletTransaction>
+    timestamps: Array<number>,
   |} => Promise<void> = async (request) => {
     const { unitOfAccount } = this.stores.profile;
     if (!unitOfAccount.enabled) return;
 
-    const timestamps = Array.from(new Set(request.transactions.map(tx => tx.date.valueOf())));
+    const { timestamps } = request;
+
     const missingPrices = timestamps.filter(
       timestamp => this.priceMap.get(
         getPriceKey('ADA', unitOfAccount.currency, new Date(timestamp))

--- a/packages/yoroi-extension/app/stores/toplevel/CoinPriceStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/CoinPriceStore.js
@@ -13,11 +13,12 @@ export default class CoinPriceStore extends BaseCoinPriceStore<StoresMap, Action
       await this.refreshCurrentCoinPrice(selected.getParent().getNetworkInfo());
       const { allRequest } = this.stores.transactions
         .getTxRequests(selected).requests;
-      const transactions = allRequest.result?.transactions;
-      if (allRequest.wasExecuted && transactions != null) {
+
+      const timestamps = allRequest.result?.timestamps;
+      if (allRequest.wasExecuted && timestamps) {
         await this.stores.coinPriceStore.updateTransactionPriceData({
           db: selected.getDb(),
-          transactions,
+          timestamps,
         });
       }
     }

--- a/packages/yoroi-extension/app/stores/toplevel/WalletStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/WalletStore.js
@@ -267,7 +267,7 @@ export default class WalletStore extends Store<StoresMap, ActionsMap> {
       const { result } = txRequests.requests.allRequest;
       if (result == null)
         throw new Error(`${nameof(this.refreshWalletFromLocalOnLaunch)} should never happen`);
-      if (result.transactions.length === 0) {
+      if (result.totalAvailable === 0) {
         for (const txRequest of Object.keys(txRequests.requests)) {
           txRequests.requests[txRequest].reset();
         }

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",

--- a/packages/yoroi-extension/stories/helpers/cardano/ByronMocks.js
+++ b/packages/yoroi-extension/stories/helpers/cardano/ByronMocks.js
@@ -107,8 +107,11 @@ function genMockByronBip44Cache(dummyWallet: PublicDeriver<>) {
     total: 0,
   }));
   const allRequest = new CachedRequest(_request => Promise.resolve({
-    transactions: [],
-    total: 0,
+    hash: 0,
+    totalAvailable: 0,
+    unconfirmedAmount: null,
+    remoteTransactionIds: new Set(),
+    timestamps: [],
   }));
   const getBalanceRequest = new CachedRequest(request => request.getBalance());
   const getAssetDepositRequest = new CachedRequest(request => request.getBalance());

--- a/packages/yoroi-extension/stories/helpers/cardano/ShelleyCip1852Mocks.js
+++ b/packages/yoroi-extension/stories/helpers/cardano/ShelleyCip1852Mocks.js
@@ -62,8 +62,11 @@ function genMockShelleyCip1852Cache(dummyWallet: PublicDeriver<>) {
     total: 0,
   }));
   const allRequest = new CachedRequest(_request => Promise.resolve({
-    transactions: [],
-    total: 0,
+    hash: 0,
+    totalAvailable: 0,
+    unconfirmedAmount: null,
+    remoteTransactionIds: new Set(),
+    timestamps: [],
   }));
   const getBalanceRequest = new CachedRequest(request => request.getBalance());
   const getAssetDepositRequest = new CachedRequest(request => request.getBalance());

--- a/packages/yoroi-extension/stories/helpers/ergo/ErgoMocks.js
+++ b/packages/yoroi-extension/stories/helpers/ergo/ErgoMocks.js
@@ -50,8 +50,11 @@ function genMockErgoCache(dummyWallet: PublicDeriver<>) {
     total: 0,
   }));
   const allRequest = new CachedRequest(_request => Promise.resolve({
-    transactions: [],
-    total: 0,
+    hash: 0,
+    totalAvailable: 0,
+    unconfirmedAmount: null,
+    remoteTransactionIds: new Set(),
+    timestamps: [],
   }));
   const getBalanceRequest = new CachedRequest(request => request.getBalance());
   const getAssetDepositRequest = new CachedRequest(request => request.getBalance());

--- a/packages/yoroi-extension/stories/helpers/jormungandr/JormungandrMocks.js
+++ b/packages/yoroi-extension/stories/helpers/jormungandr/JormungandrMocks.js
@@ -59,8 +59,11 @@ function genMockJormungandrCache(dummyWallet: PublicDeriver<>) {
     total: 0,
   }));
   const allRequest = new CachedRequest(_request => Promise.resolve({
-    transactions: [],
-    total: 0,
+    hash: 0,
+    totalAvailable: 0,
+    unconfirmedAmount: null,
+    remoteTransactionIds: new Set(),
+    timestamps: [],
   }));
   const getBalanceRequest = new CachedRequest(request => request.getBalance());
   const getAssetDepositRequest = new CachedRequest(request => request.getBalance());

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,0 +1,1 @@
+. install-all.sh && npm run dev:stable --prefix packages/yoroi-extension


### PR DESCRIPTION
This is an attempt to reduce the memory footprint of wallets with lots of txs.

Previously the `TransactionsStore` stores the complete list of txs of a wallet in `allRequest` member of its `transactionsRequests`, but the list is not rendered to the UI (`recentRequest` result is). It is only used to calculate some aggregated data. This PR changes `allRequest` to retain only these aggregated data so that the complete list doesn't have to stay in memory permanently. But note that provisionally the complete list still has to be in memory when the refreshing action runs -- it's just released after the derived data are calculated. If this still can't solve the OOM problem for some Ergo wallets, we might need to take further measures. For example, to calculate the derived data at the storage layer and avoid constructing the complete tx list at all, which would be much more complex.