### PR TITLE
[dapp connector]make the wallet list scrollable

### DIFF
--- a/packages/yoroi-extension/app/ergo-connector/components/connect/ConnectPage.scss
+++ b/packages/yoroi-extension/app/ergo-connector/components/connect/ConnectPage.scss
@@ -57,6 +57,7 @@
       color: var(--yoroi-palette-gray-900);
     }
   }
+  overflow: auto;
 }
 
 .bottom {


### PR DESCRIPTION
When the wallet list is too long, the contents are cropped by the viewport.
Before:
![before](https://user-images.githubusercontent.com/1028789/146707781-bd205747-8f1e-4281-8539-94b3c420568a.png)
After:
![after](https://user-images.githubusercontent.com/1028789/146707800-f75c294c-24af-4a09-8887-3cd394754eab.jpg)
