### PR TITLE
compute over batched transaction list

### DIFF
--- a/packages/yoroi-extension/app/api/common/index.js
+++ b/packages/yoroi-extension/app/api/common/index.js
@@ -154,7 +154,10 @@ export type GetTransactionsDataResponse = {|
 |};
 
 export type GetTransactionsDataFunc = (
-  request: BaseGetTransactionsRequest
+  request: {|
+    publicDeriver: IPublicDeriver<ConceptualWallet & IHasLevels> & IGetLastSyncInfo,
+    isLocalRequest: boolean,
+  |}
 ) => Promise<GetTransactionsDataResponse>;
 
 export type ExportTransactionsRequest = {|


### PR DESCRIPTION
Currently when the wallet transaction list is periodically refreshed, some data are computed over the full transaction list. Previously, #2561 makes it so that the full transaction list doesn't need to be kept in memory after the computation. This PR further optimizes the process so that at any time, only a constant-sized portion of the full transaction list are loaded from the storage layer.