### PR TITLE
Update token info

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1973,6 +1973,8 @@ export async function getTokenMintMetadata(
   return tokensMintMetadata;
 };
 
+const TOKEN_INFO_CACHE_TIME = 1 * 60 * 60 * 1000;
+
 export async function genCardanoAssetMap(
   db: lf$Database,
   dbTx: lf$Transaction,
@@ -1989,49 +1991,70 @@ export async function genCardanoAssetMap(
     db, dbTx,
     tokenIds
   )).filter(row => row.NetworkId === network.NetworkId);
-
   const existingRowsMap = new Map<string, $ReadOnly<TokenRow>>(
     existingDbRows.map(row => [row.Identifier, row])
   );
 
-  const existingTokens = new Set<string>(
-    existingDbRows.filter(
-      // only tokens with lastUpdateAt are considered existing, except for default
-      // asset rows, because they are never updated from network
-      row => (row.Metadata.lastUpdatedAt != null) || row.IsDefault
-    ).map(row => row.Identifier)
+  const noNeedForUpdateTokens = new Set<string>(
+    existingDbRows.filter(row => {
+      // default token rows are never updated from the network
+      if (row.IsDefault) {
+        return true;
+      }
+      // tokens rows that have never been queried from the network
+      const { lastUpdatedAt } = row.Metadata;
+      if (!lastUpdatedAt) {
+        return false;
+      }
+      // fresh enough, no need for updating this time
+      if (Date.now() - Date.parse(lastUpdatedAt) < TOKEN_INFO_CACHE_TIME) {
+        return true;
+      }
+      return false;
+    }).map(row => row.Identifier)
   );
 
-  const missingTokenIds = tokenIds.filter(token => !existingTokens.has(token));
+  const updatingTokenIds = tokenIds.filter(token => !noNeedForUpdateTokens.has(token));
 
   let tokenInfoResponse;
   try {
     tokenInfoResponse = await getTokenInfo({
       network,
-      tokenIds: missingTokenIds.map(id => id.split('.').join(''))
+      tokenIds: updatingTokenIds.map(id => id.split('.').join(''))
     });
   } catch {
     tokenInfoResponse = {};
   }
-
   const metadata = await getTokenMintMetadata(tokenIds, getMultiAssetMetadata, network);
 
-  const databaseInsert = missingTokenIds
+  const databaseInsert = updatingTokenIds
     .map(tokenId => {
-      // If fetched token metadata from network, store in db; otherwise store a
-      // placeholder row. The field `lastUpdateAt` differentiates the two cases.
+      const id = tokenId.split('.').join('');
+
       let numberOfDecimals;
       let ticker;
       let lastUpdatedAt;
       let longName;
 
-      const tokenInfo = tokenInfoResponse[tokenId.split('.').join('')];
+      const tokenInfo = tokenInfoResponse[id];
       if (tokenInfo) {
         numberOfDecimals = tokenInfo.decimals ?? 0;
         ticker = tokenInfo.ticker ?? null;
         lastUpdatedAt = new Date().toISOString();
         longName = tokenInfo.name ?? null;
+      } else if (tokenInfo === null) {
+        // the token is not registered
+        numberOfDecimals = 0;
+        ticker = null;
+        lastUpdatedAt = new Date().toISOString();
+        longName = null;
       } else {
+        // failed to fetch token info
+        if (existingRowsMap.has(tokenId)) {
+          // the token entry exists, do not update
+          return null;
+        }
+        // the token entry doesn't exists, insert a placeholder row
         numberOfDecimals = 0;
         ticker = null;
         lastUpdatedAt = null;
@@ -2083,7 +2106,7 @@ export async function genCardanoAssetMap(
           assetMintMetadata
         },
       };
-    });
+    }).filter(Boolean);
 
   const newDbRows = await deps.ModifyToken.upsert(
     db, dbTx,

--- a/packages/yoroi-extension/app/api/common/index.js
+++ b/packages/yoroi-extension/app/api/common/index.js
@@ -151,6 +151,7 @@ export type GetTransactionsDataResponse = {|
   unconfirmedAmount: ?UnconfirmedAmount,
   remoteTransactionIds: Set<string>,
   timestamps: Array<number>,
+  assetIds: Array<string>,
 |};
 
 export type GetTransactionsDataFunc = (

--- a/packages/yoroi-extension/app/containers/wallet/NFTDetailPageRevamp.js
+++ b/packages/yoroi-extension/app/containers/wallet/NFTDetailPageRevamp.js
@@ -63,7 +63,6 @@ class NFTDetailPageRevamp extends Component<AllProps> {
                 assetName: token.entry.identifier.split('.')[1] ?? '',
                 id: getTokenIdentifierIfExists(token.info) ?? '-',
                 amount: genFormatTokenAmount(getTokenInfo)(token.entry),
-                // $FlowFixMe[prop-missing]
                 nftMetadata: token.info.Metadata.assetMintMetadata
                   && token.info.Metadata.assetMintMetadata.length > 0
                   && token.info.Metadata.assetMintMetadata[0]['721']

--- a/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
@@ -80,22 +80,16 @@ export default class TokenInfoStore<
 
     const { requests } = this.stores.transactions.getTxRequests(wallet);
 
-    await requests.getBalanceRequest;
-    const balance = requests.getBalanceRequest.result;
-    if (!balance || !balance.size) {
-      return;
-    }
-    // expect all tokens to have an identical network id
-    const networkId = balance.values[0].networkId;
-    const tokenIds = balance.values
-      .filter(token => token.networkId === networkId)
-      .map(token => token.identifier);
+    await requests.allRequest;
+
+    const tokenIds = Array.from(requests.allRequest.result.assetIds);
 
     const db = this.stores.loading.getDatabase();
     if (!db) {
       return;
     }
 
+    const networkId = wallet.getParent().networkInfo.NetworkId;
     const network: ?NetworkRow = (Object.values(networks): Array<any>).find(
       ({ NetworkId }) => NetworkId === networkId
     );

--- a/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TokenInfoStore.js
@@ -82,7 +82,7 @@ export default class TokenInfoStore<
 
     await requests.allRequest;
 
-    const tokenIds = Array.from(requests.allRequest.result.assetIds);
+    const tokenIds = Array.from(requests.allRequest.result?.assetIds ?? []);
 
     const db = this.stores.loading.getDatabase();
     if (!db) {

--- a/packages/yoroi-extension/app/stores/toplevel/TransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TransactionsStore.js
@@ -589,7 +589,7 @@ export default class TransactionsStore extends Store<StoresMap, ActionsMap> {
         unconfirmedAmount: reducers[2].result,
         remoteTransactionIds: reducers[3].result,
         timestamps: reducers[4].result,
-        assetIds: reducers[5].result,
+        assetIds: [...reducers[5].result],
       };
     };
   }

--- a/packages/yoroi-extension/app/stores/toplevel/TransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TransactionsStore.js
@@ -558,7 +558,8 @@ export default class TransactionsStore extends Store<StoresMap, ActionsMap> {
           defaultTokenInfo,
         ),
         new RemoteTransactionIdsReducer(),
-        new TimestampsReducer()
+        new TimestampsReducer(),
+        new AssetIdsReducer(),
       ];
 
       for (;;) {
@@ -588,6 +589,7 @@ export default class TransactionsStore extends Store<StoresMap, ActionsMap> {
         unconfirmedAmount: reducers[2].result,
         remoteTransactionIds: reducers[3].result,
         timestamps: reducers[4].result,
+        assetIds: reducers[5].result,
       };
     };
   }
@@ -963,5 +965,27 @@ class TimestampsReducer {
   }
   get result(): Array<number> {
     return Array.from(this.timestamps);
+  }
+}
+
+// Collect all asset IDs that appear in the transaction list
+class AssetIdsReducer {
+  assetIds: Set<string> = new Set();
+  reduce(transactions: Array<WalletTransaction>): void {
+    for (const tx of transactions) {
+      for (const io of tx.addresses.from) {
+        for (const tokenEntry of io.value.values) {
+          this.assetIds.add(tokenEntry.identifier);
+        }
+      }
+      for (const io of tx.addresses.to) {
+        for (const tokenEntry of io.value.values) {
+          this.assetIds.add(tokenEntry.identifier);
+        }
+      }
+    }
+  }
+  get result(): Set<string> {
+    return this.assetIds;
   }
 }

--- a/packages/yoroi-extension/app/stores/toplevel/WalletStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/WalletStore.js
@@ -201,7 +201,7 @@ export default class WalletStore extends Store<StoresMap, ActionsMap> {
     const selectedPublicDeriverId = this.selected?.publicDeriverId;
     if (selectedPublicDeriverId != null) {
       const selectedCache: ?PublicKeyCache = this.publicKeyCache
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
         .find(c => c.publicDeriver.publicDeriverId === selectedPublicDeriverId);
       return selectedCache == null ? null : selectedCache.plate;
     }

--- a/packages/yoroi-extension/app/utils/formatters.js
+++ b/packages/yoroi-extension/app/utils/formatters.js
@@ -99,8 +99,7 @@ export function truncateAddress(addr: string): string {
  * Since the length is too small for some bech32 prefixes
  */
 export function truncateAddressShort(addr: string, by: ?number): string {
-  if (!by) by = 20
-  return truncateFormatter(addr, by);
+  return truncateFormatter(addr, by ?? 20);
 }
 
 /**

--- a/packages/yoroi-extension/stories/helpers/cardano/ByronMocks.js
+++ b/packages/yoroi-extension/stories/helpers/cardano/ByronMocks.js
@@ -112,6 +112,7 @@ function genMockByronBip44Cache(dummyWallet: PublicDeriver<>) {
     unconfirmedAmount: null,
     remoteTransactionIds: new Set(),
     timestamps: [],
+    assetIds: [],
   }));
   const getBalanceRequest = new CachedRequest(request => request.getBalance());
   const getAssetDepositRequest = new CachedRequest(request => request.getBalance());

--- a/packages/yoroi-extension/stories/helpers/cardano/ShelleyCip1852Mocks.js
+++ b/packages/yoroi-extension/stories/helpers/cardano/ShelleyCip1852Mocks.js
@@ -67,6 +67,7 @@ function genMockShelleyCip1852Cache(dummyWallet: PublicDeriver<>) {
     unconfirmedAmount: null,
     remoteTransactionIds: new Set(),
     timestamps: [],
+    assetIds: [],
   }));
   const getBalanceRequest = new CachedRequest(request => request.getBalance());
   const getAssetDepositRequest = new CachedRequest(request => request.getBalance());

--- a/packages/yoroi-extension/stories/helpers/ergo/ErgoMocks.js
+++ b/packages/yoroi-extension/stories/helpers/ergo/ErgoMocks.js
@@ -55,6 +55,7 @@ function genMockErgoCache(dummyWallet: PublicDeriver<>) {
     unconfirmedAmount: null,
     remoteTransactionIds: new Set(),
     timestamps: [],
+    assetIds: [],
   }));
   const getBalanceRequest = new CachedRequest(request => request.getBalance());
   const getAssetDepositRequest = new CachedRequest(request => request.getBalance());

--- a/packages/yoroi-extension/stories/helpers/jormungandr/JormungandrMocks.js
+++ b/packages/yoroi-extension/stories/helpers/jormungandr/JormungandrMocks.js
@@ -64,6 +64,7 @@ function genMockJormungandrCache(dummyWallet: PublicDeriver<>) {
     unconfirmedAmount: null,
     remoteTransactionIds: new Set(),
     timestamps: [],
+    assetIds: [],
   }));
   const getBalanceRequest = new CachedRequest(request => request.getBalance());
   const getAssetDepositRequest = new CachedRequest(request => request.getBalance());


### PR DESCRIPTION
Currently, when a wallet is selected, the tokens in its *outstanding balance* are checked: if there is no info for a token, then an endpoint is queried. The obtained token info is stored and never updated thereafter.

With this PR, when a wallet is selected, the tokens in its *transaction history* are checked: if there is no info for a token, or if the info is 1 hour stale, then the endpoint is queried for the token info and the storage is updated. A 404 return from the token info endpoint is treated as the token is not registered and its info in the storage is updated to the default value (decimal place being 0) even if the token was previously registered.

This PR is built on top of #2591 because it needs to get all token IDs from the transaction list.