### PR TITLE
Connector api CIP30 update

### DIFF
--- a/packages/yoroi-ergo-connector/README.md
+++ b/packages/yoroi-ergo-connector/README.md
@@ -1,4 +1,4 @@
-# Yoroi-Ergo dApp Connector
+# Yoroi dApp Connector
 
 This experimental extension is the first in a modular design to interface the [Yoroi frontend extension](https://github.com/Emurgo/yoroi-frontend) with dApps. It targets the [Ergo](https://ergoplatform.org/en/) cryptocurrency.
 

--- a/packages/yoroi-ergo-connector/build.js
+++ b/packages/yoroi-ergo-connector/build.js
@@ -43,8 +43,8 @@ Object.values(icons).forEach(path => fse.copyFileSync(`./${path}`, `./build/${pa
 
 const manifest = genManifest({
   displayName: isNightly
-    ? 'Yoroi-Ergo dApp Connector Nightly'
-    : 'Yoroi-Ergo dApp Connector',
+    ? 'Yoroi dApp Connector Nightly'
+    : 'Yoroi dApp Connector',
   version: package.version,
   icons: isNightly
     ? {

--- a/packages/yoroi-ergo-connector/example-cardano/index.html
+++ b/packages/yoroi-ergo-connector/example-cardano/index.html
@@ -37,6 +37,9 @@
           <button id="get-change-address" class="btn btn-light w-100" >Get Change Address</button>
         </div>
         <div class="col-6 mb-4">
+          <button id="get-reward-addresses" class="btn btn-light w-100" >Get Reward Addresses</button>
+        </div>
+        <div class="col-6 mb-4">
           <button id="get-utxos" class="btn btn-light w-100" >Get Utxos</button>
         </div>
         <div class="col-6 mb-4">

--- a/packages/yoroi-ergo-connector/example-cardano/index.js
+++ b/packages/yoroi-ergo-connector/example-cardano/index.js
@@ -12,6 +12,7 @@ const walletIconSpan = document.querySelector('#wallet-icon')
 const getUnUsedAddresses = document.querySelector('#get-unused-addresses')
 const getUsedAddresses = document.querySelector('#get-used-addresses')
 const getChangeAddress = document.querySelector('#get-change-address')
+const getRewardAddresses = document.querySelector('#get-reward-addresses')
 const getAccountBalance = document.querySelector('#get-balance')
 const getUtxos = document.querySelector('#get-utxos')
 const submitTx = document.querySelector('#submit-tx')
@@ -22,9 +23,14 @@ const spinner = document.querySelector('#spinner')
 
 let accessGranted = false
 let cardanoApi
+let returnType = 'cbor'
 let utxos
 let changeAddress
 let transactionHex
+
+function isCBOR() {
+  return returnType === 'cbor';
+}
 
 const mkcolor = (primary, secondary, spots) => ({ primary, secondary, spots });
 const COLORS = [
@@ -54,6 +60,8 @@ function onApiConnectied(api) {
   toggleSpinner('hide');
   let walletDisplay = 'an anonymous Yoroi Wallet';
 
+  api.setReturnType(returnType);
+
   const auth = api.auth && api.auth();
   const authEnabled = auth && auth.isEnabled();
 
@@ -71,7 +79,7 @@ function onApiConnectied(api) {
   walletPlateSpan.innerHTML = walletDisplay;
   toggleConnectionUI('status');
   accessGranted = true;
-  cardanoApi = api;
+  window.cardanoApi = cardanoApi = api;
 
   api.onDisconnect(() => {
     alertWarrning(`Disconnected from ${walletDisplay}`);
@@ -125,26 +133,44 @@ getAccountBalance.addEventListener('click', () => {
     } else {
         toggleSpinner('show')
         cardanoApi.getBalance().then(function(balance) {
-            toggleSpinner('hide')
-            alertSuccess(`Account Balance: ${balance}`)
+          toggleSpinner('hide')
+          let mainBalance;
+          let numAssets;
+          if (isCBOR()) {
+            const value = CardanoWasm.Value.from_bytes(Buffer.from(balance, 'hex'));
+            mainBalance = value.coin().to_str();
+            const ma = value.multiasset()
+            numAssets = ma ? ma.len() : 0;
+          } else {
+            mainBalance = balance.default;
+            numAssets = (balance.assets||[]).length;
+          }
+          alertSuccess(`Account Balance: ${mainBalance} (assets: ${numAssets})`)
         });
     }
 })
+
+function addressesFromCborIfNeeded(addresses) {
+  return isCBOR() ? addresses.map(a => CardanoWasm.Address.from_bytes(
+    Buffer.from(a, 'hex'),
+  ).to_bech32()) : addresses;
+}
 
 getUnUsedAddresses.addEventListener('click', () => {
     if(!accessGranted) {
        alertError('Should request access first')
     } else {
-        toggleSpinner('show')
-        cardanoApi.getUnusedAddresses().then(function(addresses) {
-            toggleSpinner('hide')
-            if(addresses.length === 0){
-                alertWarrning('No unused addresses')
-            } else {
-                alertSuccess(`Address: `)
-                alertEl.innerHTML = '<pre>' + JSON.stringify(addresses, undefined, 2) + '</pre>'
-            }
-        });
+      toggleSpinner('show')
+      cardanoApi.getUnusedAddresses().then(function(addresses) {
+        toggleSpinner('hide')
+        if (addresses.length === 0) {
+          alertWarrning('No unused addresses')
+          return;
+        }
+        addresses = addressesFromCborIfNeeded(addresses)
+        alertSuccess(`Address: `)
+        alertEl.innerHTML = '<h2>Unused addresses:</h2><pre>' + JSON.stringify(addresses, undefined, 2) + '</pre>'
+      });
     }
 })
 
@@ -152,16 +178,17 @@ getUsedAddresses.addEventListener('click', () => {
     if(!accessGranted) {
        alertError('Should request access first')
     } else {
-        toggleSpinner('show')
-        cardanoApi.getUsedAddresses().then(function(addresses) {
-            toggleSpinner('hide')
-           if(addresses.length === 0){
-               alertWarrning('No used addresses')
-           } else {
-               alertSuccess(`Address: ${addresses.concat(',')}`)
-               alertEl.innerHTML = '<pre>' + JSON.stringify(addresses, undefined, 2) + '</pre>'
-           }
-        });
+      toggleSpinner('show')
+      cardanoApi.getUsedAddresses({ page: 0, limit: 5 }).then(function(addresses) {
+        toggleSpinner('hide')
+        if (addresses.length === 0) {
+          alertWarrning('No used addresses')
+          return;
+        }
+        addresses = addressesFromCborIfNeeded(addresses)
+        alertSuccess(`Address: ${addresses.concat(',')}`)
+        alertEl.innerHTML = '<h2>Used addresses:</h2><pre>' + JSON.stringify(addresses, undefined, 2) + '</pre>'
+      });
     }
 })
 
@@ -169,17 +196,35 @@ getChangeAddress.addEventListener('click', () => {
     if(!accessGranted) {
         alertError('Should request access first')
     } else {
-        toggleSpinner('show')
-        cardanoApi.getChangeAddress().then(function(address) {
-            toggleSpinner('hide')
-            if(address.length === 0){
-                alertWarrning('No change addresses')
-            } else {
-                changeAddress = address
-                alertSuccess(`Address: `)
-                alertEl.innerHTML = '<pre>' + JSON.stringify(address, undefined, 2) + '</pre>'
-            }
-        });
+      toggleSpinner('show')
+      cardanoApi.getChangeAddress().then(function(address) {
+        toggleSpinner('hide')
+        if (address.length === 0) {
+          alertWarrning('No change addresses')
+          return;
+        }
+        changeAddress = addressesFromCborIfNeeded([address])[0]
+        alertSuccess(`Address: `)
+        alertEl.innerHTML = '<h2>Change address:</h2><pre>' + JSON.stringify(address, undefined, 2) + '</pre>'
+      });
+    }
+})
+
+getRewardAddresses.addEventListener('click', () => {
+    if(!accessGranted) {
+        alertError('Should request access first')
+    } else {
+      toggleSpinner('show')
+      cardanoApi.getRewardAddresses().then(function(addresses) {
+        toggleSpinner('hide')
+        if (addresses.length === 0) {
+          alertWarrning('No change addresses')
+          return;
+        }
+        addresses = addressesFromCborIfNeeded(addresses)
+        alertSuccess(`Address: ${addresses.concat(',')}`)
+        alertEl.innerHTML = '<h2>Reward addresses:</h2><pre>' + JSON.stringify(addresses, undefined, 2) + '</pre>'
+      });
     }
 })
 
@@ -190,14 +235,59 @@ getUtxos.addEventListener('click', () => {
     }
     toggleSpinner('show')
     cardanoApi.getUtxos().then(utxosResponse => {
-        toggleSpinner('hide')
-        if(utxosResponse.length === 0){
-            alertWarrning('NO UTXOS')
+      toggleSpinner('hide')
+      if(utxosResponse.length === 0){
+        alertWarrning('NO UTXOS')
+      } else {
+        if (isCBOR()) {
+          utxos = utxosResponse.map(hex => {
+            const u = CardanoWasm.TransactionUnspentOutput.from_bytes(Buffer.from(hex, 'hex'))
+            const input = u.input();
+            const output = u.output();
+            const txHash = Buffer.from(input.transaction_id().to_bytes()).toString('hex');
+            const txIndex = input.index();
+            const value = output.amount();
+            const multiasset = value.multiasset();
+            function parseMultiasset() {
+              if (!multiasset) {
+                return [];
+              }
+              const result = [];
+              const policyIds = multiasset.keys();
+              for (let i = 0; i < policyIds.len(); i++) {
+                const policyId = policyIds.get(i);
+                const assets = multiasset.get(policyId);
+                const assetNames = assets.keys();
+                for (let j = 0; j < assetNames.len(); j++) {
+                  const name = assetNames.get(j);
+                  const amount = assets.get(name);
+                  const policyIdHex = Buffer.from(policyId.to_bytes()).toString('hex');
+                  const encodedName = Buffer.from(name.to_bytes()).toString('hex');
+                  result.push({
+                    policyId: policyIdHex,
+                    name: encodedName,
+                    amount: amount.to_str(),
+                    assetId: `${policyIdHex}.${encodedName}`,
+                  });
+                }
+              }
+              return result;
+            }
+            return {
+              utxo_id: `${txHash}${txIndex}`,
+              tx_hash: txHash,
+              tx_index: txIndex,
+              receiver: output.address().to_bech32(),
+              amount: value.coin().to_str(),
+              assets: parseMultiasset(),
+            }
+          })
         } else {
-            utxos = utxosResponse
-            alertSuccess(`Check the console`)
-            alertEl.innerHTML = '<pre>' + JSON.stringify(utxosResponse, undefined, 2) + '</pre>'
+          utxos = utxosResponse
         }
+        alertSuccess(`Check the console`)
+        alertEl.innerHTML = '<h2>UTxO:</h2><pre>' + JSON.stringify(utxos, undefined, 2) + '</pre>'
+      }
     })
 })
 
@@ -277,10 +367,7 @@ signTx.addEventListener('click', () => {
   )  
 
   const shelleyOutputAddress = CardanoWasm.Address.from_bech32(SEND_TO_ADDRESS)
-
-  const shelleyChangeAddress = CardanoWasm.Address.from_bytes(
-    Buffer.from(changeAddress, 'hex')
-  )
+  const shelleyChangeAddress = CardanoWasm.Address.from_bech32(changeAddress)
 
   // add output to the tx
   txBuilder.add_output(
@@ -297,7 +384,14 @@ signTx.addEventListener('click', () => {
   txBuilder.add_change_if_needed(shelleyChangeAddress)
 
   const txBody = txBuilder.build()
-  const txHex = Buffer.from(txBody.to_bytes()).toString('hex')
+
+  const tx = CardanoWasm.Transaction.new(
+    txBody,
+    CardanoWasm.TransactionWitnessSet.new(),
+    undefined,
+  )
+
+  const txHex = Buffer.from(tx.to_bytes()).toString('hex')
 
   cardanoApi.signTx(txHex, true).then(witnessSetHex => {
     toggleSpinner('hide')

--- a/packages/yoroi-ergo-connector/example-cardano/index.js
+++ b/packages/yoroi-ergo-connector/example-cardano/index.js
@@ -131,22 +131,27 @@ getAccountBalance.addEventListener('click', () => {
     if(!accessGranted) {
         alertError('Should request access first')
     } else {
-        toggleSpinner('show')
-        cardanoApi.getBalance().then(function(balance) {
-          toggleSpinner('hide')
-          let mainBalance;
-          let numAssets;
-          if (isCBOR()) {
-            const value = CardanoWasm.Value.from_bytes(Buffer.from(balance, 'hex'));
-            mainBalance = value.coin().to_str();
-            const ma = value.multiasset()
-            numAssets = ma ? ma.len() : 0;
-          } else {
-            mainBalance = balance.default;
-            numAssets = (balance.assets||[]).length;
+      toggleSpinner('show')
+      const tokenId = '*';
+      cardanoApi.getBalance(tokenId).then(function(balance) {
+        toggleSpinner('hide')
+        let mainBalance;
+        let numAssets;
+        if (isCBOR()) {
+          if (tokenId !== '*') {
+            alertSuccess(`Asset Balance: ${balance} (asset: ${tokenId})`)
+            return;
           }
-          alertSuccess(`Account Balance: ${mainBalance} (assets: ${numAssets})`)
-        });
+          const value = CardanoWasm.Value.from_bytes(Buffer.from(balance, 'hex'));
+          mainBalance = value.coin().to_str();
+          const ma = value.multiasset()
+          numAssets = ma ? ma.len() : 0;
+        } else {
+          mainBalance = balance.default;
+          numAssets = (balance.assets||[]).length;
+        }
+        alertSuccess(`Account Balance: ${mainBalance} (assets: ${numAssets})`)
+      });
     }
 })
 
@@ -262,7 +267,7 @@ getUtxos.addEventListener('click', () => {
                   const name = assetNames.get(j);
                   const amount = assets.get(name);
                   const policyIdHex = Buffer.from(policyId.to_bytes()).toString('hex');
-                  const encodedName = Buffer.from(name.to_bytes()).toString('hex');
+                  const encodedName = Buffer.from(name.name()).toString('hex');
                   result.push({
                     policyId: policyIdHex,
                     name: encodedName,

--- a/packages/yoroi-ergo-connector/example-cardano/package.json
+++ b/packages/yoroi-ergo-connector/example-cardano/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-ergo-dapp",
   "version": "0.1.0",
-  "description": "test dApp to interact with the Yoroi Ergo dApp Connector",
+  "description": "test dApp to interact with the Yoroi dApp Connector",
   "main": "index.js",
   "bin": {
     "test-ergo-dapp": ".bin/test-ergo-dapp.js"

--- a/packages/yoroi-ergo-connector/example-ergo/package.json
+++ b/packages/yoroi-ergo-connector/example-ergo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-ergo-dapp",
   "version": "0.1.0",
-  "description": "test dApp to interact with the Yoroi Ergo dApp Connector",
+  "description": "test Ergo dApp to interact with the Yoroi dApp Connector",
   "main": "index.js",
   "bin": {
     "test-ergo-dapp": ".bin/test-ergo-dapp.js"

--- a/packages/yoroi-extension/app/api/ada/index.js
+++ b/packages/yoroi-extension/app/api/ada/index.js
@@ -1175,7 +1175,7 @@ export default class AdaApi {
       if (noInputs) {
         throw new Error('Invalid tx-build request, must specify inputs, outputs, or targets');
       }
-      if (!onlyInputsIntended) {
+      if (Boolean(onlyInputsIntended) === false) {
         throw new Error('No outputs is specified and intended inputs flag is false');
       }
     }

--- a/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
@@ -442,9 +442,20 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
       network.NetworkId
     );
 
-    const txBody = RustModule.WalletV4.TransactionBody.from_bytes(
-      Buffer.from(tx, 'hex')
-    );
+
+    let txBody;
+    const bytes = Buffer.from(tx, 'hex');
+    try {
+      // <TODO:USE_METADATA_AND_WITNESSES>
+      txBody = RustModule.WalletV4.Transaction.from_bytes(bytes).body();
+    } catch (originalErr) {
+      try {
+        // Try parsing as body for backward compatibility
+        txBody = RustModule.WalletV4.TransactionBody.from_bytes(bytes);
+      } catch (_e) {
+        throw originalErr;
+      }
+    }
 
     const inputs = [];
     for (let i = 0; i < txBody.inputs().len(); i++) {

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -945,32 +945,25 @@ function handleInjectorConnect(port) {
                   async (wallet) => {
                     const balance =
                       await connectorGetBalance(wallet, pendingTxs, tokenId, connectionProtocol);
-                    if (isCBOR) {
+                    if (isCBOR && tokenId === '*') {
                       await RustModule.load();
                       const W4 = RustModule.WalletV4;
-                      if (tokenId === '*') {
-                        const value = W4.Value.new(
-                          W4.BigNum.from_str(balance.default),
-                        );
-                        if (balance.assets.length > 0) {
-                          const mappedAssets = balance.assets.map(a => {
-                            const [policyId, name] = a.identifier.split('.');
-                            return {
-                              amount: a.amount,
-                              assetId: a.identifier,
-                              policyId,
-                              name,
-                            };
-                          })
-                          value.set_multiasset(assetToRustMultiasset(mappedAssets));
-                        }
-                        rpcResponse({ ok: Buffer.from(value.to_bytes()).toString('hex') });
-                      } else {
-                        const value = W4.Value.new(
-                          W4.BigNum.from_str(balance),
-                        );
-                        rpcResponse({ ok: value });
+                      const value = W4.Value.new(
+                        W4.BigNum.from_str(balance.default),
+                      );
+                      if (balance.assets.length > 0) {
+                        const mappedAssets = balance.assets.map(a => {
+                          const [policyId, name] = a.identifier.split('.');
+                          return {
+                            amount: a.amount,
+                            assetId: a.identifier,
+                            policyId,
+                            name,
+                          };
+                        })
+                        value.set_multiasset(assetToRustMultiasset(mappedAssets));
                       }
+                      rpcResponse({ ok: Buffer.from(value.to_bytes()).toString('hex') });
                     } else {
                       rpcResponse({ ok: balance });
                     }

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -1120,7 +1120,7 @@ function handleInjectorConnect(port) {
                     if (!isCardano || isCBOR) {
                       rpcResponse({ ok: address });
                     } else {
-                      rpcResponse({ ok: await addressesToBech([address])[0] });
+                      rpcResponse({ ok: (await addressesToBech([address]))[0] });
                     }
                   },
                   db,

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -786,7 +786,7 @@ function handleInjectorConnect(port) {
         }, {})
         const W4 = RustModule.WalletV4;
         const multiasset = W4.MultiAsset.new();
-        for (const policyHex in groupedAssets) {
+        for (const policyHex of Object.keys(groupedAssets)) {
           const assetGroup = groupedAssets[policyHex];
           const policyId = W4.ScriptHash.from_bytes(Buffer.from(policyHex, 'hex'));
           const assets = RustModule.WalletV4.Assets.new();

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -665,7 +665,7 @@ async function confirmConnect(
         });
         return;
       }
-      if (onlySilent) {
+      if (Boolean(onlySilent) === true) {
         reject(new Error('[onlySilent:fail] No active connection'));
         return;
       }

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/api.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/api.js
@@ -303,7 +303,9 @@ export async function connectorGetUnusedAddresses(wallet: PublicDeriver<>): Prom
   return getAllAddresses(wallet, false);
 }
 
-export async function connectorGetCardanoRewardAddresses(wallet: PublicDeriver<>): Promise<Address[]> {
+export async function connectorGetCardanoRewardAddresses(
+  wallet: PublicDeriver<>,
+): Promise<Address[]> {
   return getCardanoRewardAddresses(wallet)
     .then(arr => arr.map(a => a.base58));
 }

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/api.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/api.js
@@ -531,9 +531,18 @@ export async function connectorSignCardanoTx(
   // eslint-disable-next-line no-unused-vars
   const { tx: txHex, partialSign } = tx;
 
-  const txBody = RustModule.WalletV4.TransactionBody.from_bytes(
-    Buffer.from(txHex, 'hex')
-  );
+  let txBody;
+  const bytes = Buffer.from(txHex, 'hex');
+  try {
+    txBody = RustModule.WalletV4.Transaction.from_bytes(bytes).body();
+  } catch (originalErr) {
+    try {
+      // Try parsing as body for backward compatibility
+      txBody = RustModule.WalletV4.TransactionBody.from_bytes(bytes);
+    } catch (_e) {
+      throw originalErr;
+    }
+  }
 
   const withUtxos = asGetAllUtxos(publicDeriver);
   if (withUtxos == null) {
@@ -564,10 +573,8 @@ export async function connectorSignCardanoTx(
   const utxoIdSet: Set<string> = new Set();
   for (let i = 0; i < txBody.inputs().len(); i++) {
     const input = txBody.inputs().get(i);
-    utxoIdSet.add(
-      Buffer.from(input.transaction_id().to_bytes()).toString('hex') +
-      String(input.index())
-    );
+    const txHash = Buffer.from(input.transaction_id().to_bytes()).toString('hex');
+    utxoIdSet.add(`${txHash}${String(input.index())}`);
   }
   const usedUtxos = addressedUtxos.filter(utxo =>
     utxoIdSet.has(utxo.utxo_id)

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/api.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/api.js
@@ -9,7 +9,7 @@ import type {
   TxId,
   SignedTx,
   Value,
-  CardanoTx,
+  CardanoTx, AccountBalance,
 } from './types';
 import { ConnectorError } from './types';
 import { RustModule } from '../../../app/api/ada/lib/cardanoCrypto/rustLoader';
@@ -86,7 +86,7 @@ export async function connectorGetBalance(
   pendingTxs: PendingTransaction[],
   tokenId: TokenId,
   protocol: 'cardano' | 'ergo',
-): Promise<Value> {
+): Promise<AccountBalance | Value> {
   if (tokenId === 'ERG' || tokenId === 'ADA' || tokenId === 'TADA') {
     if (pendingTxs.length === 0) {
       // can directly query for balance

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/types.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/types.js
@@ -328,6 +328,16 @@ export function asTxId(input: any): TxId {
 
 export type Value = string;
 
+export type AccountBalance = {|
+  default: string,
+  networkId: number,
+  assets: Array<{|
+    identifier: string,
+    networkId: number,
+    amount: string,
+  |}>
+|};
+
 export function asValue(input: any): Value {
   if (typeof input === 'string') {
     return input;

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.501",
+  "version": "4.9.502",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.502",
+  "version": "4.9.503",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.500",
+  "version": "4.9.501",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.503",
+  "version": "4.9.504",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.500",
+  "version": "4.9.501",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.502",
+  "version": "4.9.503",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.501",
+  "version": "4.9.502",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.503",
+  "version": "4.9.504",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",

--- a/packages/yoroi-extension/webpack/commonConfig.js
+++ b/packages/yoroi-extension/webpack/commonConfig.js
@@ -36,7 +36,7 @@ const plugins = (folder /*: string */, _networkName /*: string */) /*: * */ => {
       template: path.join(__dirname, '../chrome/views/ergo-connector/main_window.html'),
       chunks: ['ergo'],
       alwaysWriteToDisk: true,
-      title: 'Yoroi-Ergo Dapp Connector',
+      title: 'Yoroi dApp Connector',
     }),
     new HtmlWebpackPlugin({
       filename: path.join(__dirname, `../${folder}/background.html`),


### PR DESCRIPTION
## Changes in the connector API (Cardano only)

1. `getRewardAddresses()` is supported now
2. Return type is now CBOR, by default, to match the [CIP30](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0030) spec, but optionally can be changed to JSON using `api.setReturnType('json')`, this will switch the return types back to the same JSON format as it was before, but the addresses are changed to be returned in `bech32` instead of hex, so they will match what users see in the wallet.
3. `getBalance()` function is reworked to accept a new token id placeholder `"*"` - this is also changed to be the default value, instead of ADA. When this placeholder is used the API will return the total balance value, including the main coin and the assets, and it can be returned either as a JSON object or as the Rust type `Value` in case CBOR return type is selected. If any other token id is specified as a parameter (e.g. `getBalance("ADA")`) the return value will be a single string with the number value of the balance.
4. Balance requests for different tokens are fixed
5. `signTx(tx)` now accepts the full Rust `Transaction` type