### PR TITLE
Migration to `optional permission` for code injection for the `dapp-connector`

### DIFF
--- a/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
+++ b/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
@@ -39,11 +39,6 @@ export default class DappConnectorNavbar extends Component<Props> {
       ]
     }, (granted) => {
       this.setState({ hasPermission: granted })
-      if (granted) {
-        alert('you have the permissions')
-      } else {
-        alert('You don\'t')
-      }
     });
   }
 
@@ -55,11 +50,6 @@ export default class DappConnectorNavbar extends Component<Props> {
       ]
     }, (removed) => {
       this.setState({ hasPermission: !removed })
-      if (removed) {
-        alert('permissions removed')
-      } else {
-        alert('permissions is not removed!')
-      }
     });
   }
 

--- a/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
+++ b/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
@@ -3,6 +3,7 @@ import { Component } from 'react';
 import { observer } from 'mobx-react';
 import styles from './DappConnectorNavbar.scss'
 import type { Node } from 'react';
+import classnames from 'classnames';
 
 type Props = {|
 
@@ -16,13 +17,16 @@ export default class DappConnectorNavbar extends Component<Props> {
   }
 
   componentDidMount() {
+    this.checkAccess()
+  }
+
+  checkAccess() {
     chrome.permissions.contains({
       permissions: ['tabs', 'activeTab'],
       origins: [
         '*://*/*'
       ]
     }, (result) => {
-      console.log({result})
       this.setState({ hasPermission: result })
     });
   }
@@ -34,6 +38,7 @@ export default class DappConnectorNavbar extends Component<Props> {
         '*://*/*'
       ]
     }, (granted) => {
+      this.setState({ hasPermission: granted })
       if (granted) {
         alert('you have the permissions')
       } else {
@@ -49,6 +54,7 @@ export default class DappConnectorNavbar extends Component<Props> {
         '*://*/*'
       ]
     }, (removed) => {
+      this.setState({ hasPermission: removed })
       if (removed) {
         alert('permissions removed')
       } else {
@@ -62,14 +68,11 @@ export default class DappConnectorNavbar extends Component<Props> {
     return (
       <div className={styles.component}>
         <h1 className={styles.header}>Dapp connector</h1>
-        <p>{this.state.hasPermission? 'Has permission' : 'Has no permission'}</p>
-        <br />
-        <br />
-        <button onClick={this.getPermission} type='button'>Get Permission</button>
-        <br />
-        <br />
-        <br />
-        <button onClick={this.removePermission} type='button'>Remove Permission</button>
+        <div className={styles.permissionsContainer}>
+          <p className={styles.hasPermission}>{this.state.hasPermission? 'Has permission' : 'Has no permission'}</p>
+          <button className={classnames([styles.permission, styles.getPermission])} onClick={this.getPermission.bind(this)} type='button'>Get Permission</button>
+          <button className={classnames([styles.permission, styles.removePermission])} onClick={this.removePermission.bind(this)} type='button'>Remove Permission</button>
+        </div>
       </div>
     )
   }

--- a/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
+++ b/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
@@ -11,11 +11,30 @@ type Props = {|
 @observer
 export default class DappConnectorNavbar extends Component<Props> {
 
-    render(): Node {
-        return (
-          <div className={styles.component}>
-            <h1 className={styles.header}>Dapp connector</h1>
-          </div>
-        )
-    }
+  getPermission() {
+    chrome.permissions.request({
+      permissions: ['tabs', 'activeTab'],
+      // origins: [
+      //   'http://*/*',
+      //   'https://*/*',
+      // ]
+    }, (granted) => {
+      if (granted) {
+        alert('you have the permissions')
+      } else {
+        alert('You don\'t')
+      }
+    });
+  }
+
+  render(): Node {
+
+    
+    return (
+      <div className={styles.component}>
+        <h1 className={styles.header}>Dapp connector</h1>
+        <button onClick={this.getPermission} type='button'>Get Permission</button>
+      </div>
+    )
+  }
 }

--- a/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
+++ b/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
@@ -5,14 +5,15 @@ import styles from './DappConnectorNavbar.scss'
 import type { Node } from 'react';
 import classnames from 'classnames';
 
-type Props = {|
-
+type Props = {||}
+type State = {|
+  hasPermission: boolean,
 |}
 
 @observer
-export default class DappConnectorNavbar extends Component<Props> {
+export default class DappConnectorNavbar extends Component<Props, State> {
 
-  state = {
+  state: State = {
     hasPermission: false,
   }
 

--- a/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
+++ b/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
@@ -10,6 +10,9 @@ type State = {|
   hasPermission: boolean,
 |}
 
+/*::
+declare var chrome;
+*/
 @observer
 export default class DappConnectorNavbar extends Component<Props, State> {
 

--- a/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
+++ b/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
@@ -54,7 +54,7 @@ export default class DappConnectorNavbar extends Component<Props> {
         '*://*/*'
       ]
     }, (removed) => {
-      this.setState({ hasPermission: removed })
+      this.setState({ hasPermission: !removed })
       if (removed) {
         alert('permissions removed')
       } else {

--- a/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
+++ b/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.js
@@ -11,13 +11,28 @@ type Props = {|
 @observer
 export default class DappConnectorNavbar extends Component<Props> {
 
+  state = {
+    hasPermission: false,
+  }
+
+  componentDidMount() {
+    chrome.permissions.contains({
+      permissions: ['tabs', 'activeTab'],
+      origins: [
+        '*://*/*'
+      ]
+    }, (result) => {
+      console.log({result})
+      this.setState({ hasPermission: result })
+    });
+  }
+
   getPermission() {
     chrome.permissions.request({
       permissions: ['tabs', 'activeTab'],
-      // origins: [
-      //   'http://*/*',
-      //   'https://*/*',
-      // ]
+      origins: [
+        '*://*/*'
+      ]
     }, (granted) => {
       if (granted) {
         alert('you have the permissions')
@@ -27,13 +42,34 @@ export default class DappConnectorNavbar extends Component<Props> {
     });
   }
 
+  removePermission() {
+    chrome.permissions.remove({
+      permissions: ['tabs', 'activeTab'],
+      origins: [
+        '*://*/*'
+      ]
+    }, (removed) => {
+      if (removed) {
+        alert('permissions removed')
+      } else {
+        alert('permissions is not removed!')
+      }
+    });
+  }
+
   render(): Node {
 
-    
     return (
       <div className={styles.component}>
         <h1 className={styles.header}>Dapp connector</h1>
+        <p>{this.state.hasPermission? 'Has permission' : 'Has no permission'}</p>
+        <br />
+        <br />
         <button onClick={this.getPermission} type='button'>Get Permission</button>
+        <br />
+        <br />
+        <br />
+        <button onClick={this.removePermission} type='button'>Remove Permission</button>
       </div>
     )
   }

--- a/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.scss
+++ b/packages/yoroi-extension/app/components/dapp-connector/Layout/DappConnectorNavbar.scss
@@ -1,6 +1,9 @@
 .component {
     background-color: #FFFFFF;
     box-shadow: 0 2px 5px 3px rgba(0, 0, 0, 0.06);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
     .header {
         color: #38393D;
@@ -10,5 +13,38 @@
         letter-spacing: 0;
         line-height: 28px;
         padding: 32px 40px;
+    }
+
+    .permissionsContainer {
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+        padding-right: 40px;
+
+        .hasPermission {
+            padding: 8px 16px;
+            font-size: 12px;
+            background-color: var(--yoroi-palette-gray-400);
+            color: var(--yoroi-palette-gray-800);
+            border-radius: 8px;
+            margin-right: 10px;
+        }
+
+        .permission {
+            margin-right: 10px;
+            padding: 8px 16px;
+            font-size: 12px;
+            border-radius: 8px;
+        }
+
+        .getPermission {
+            background-color: var(--yoroi-palette-secondary-300);
+            color: #fff;
+        }
+
+        .removePermission {
+            background-color: var(--yoroi-palette-error-200);
+            color: #fff;
+        }
     }
 }

--- a/packages/yoroi-extension/app/stores/toplevel/WalletSettingsStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/WalletSettingsStore.js
@@ -49,6 +49,9 @@ export type WarningList = {|
   dialogs: Array<void => Node>,
 |};
 
+/*::
+declare var chrome;
+*/
 export default class WalletSettingsStore extends Store<StoresMap, ActionsMap> {
 
   @observable renameModelRequest: Request<RenameModelFunc>
@@ -99,7 +102,7 @@ export default class WalletSettingsStore extends Store<StoresMap, ActionsMap> {
     throw new Error(`${nameof(WalletSettingsStore)}::${nameof(this.getWalletWarnings)} no warning list found`);
   }
 
-  @observable isConnectorHasPermission: boolen = false;
+  @observable isConnectorHasPermission: boolean = false;
 
   setup(): void {
     super.setup();

--- a/packages/yoroi-extension/app/stores/toplevel/WalletSettingsStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/WalletSettingsStore.js
@@ -102,7 +102,7 @@ export default class WalletSettingsStore extends Store<StoresMap, ActionsMap> {
     throw new Error(`${nameof(WalletSettingsStore)}::${nameof(this.getWalletWarnings)} no warning list found`);
   }
 
-  @observable isConnectorHasPermission: boolean = false;
+  @observable isDappEnabled: boolean = false;
 
   setup(): void {
     super.setup();
@@ -127,7 +127,7 @@ export default class WalletSettingsStore extends Store<StoresMap, ActionsMap> {
       ]
     }, (result) => {
       runInAction(() => {
-        this.isConnectorHasPermission = Boolean(result)
+        this.isDappEnabled = Boolean(result)
       })
     });
   }
@@ -140,7 +140,7 @@ export default class WalletSettingsStore extends Store<StoresMap, ActionsMap> {
       ]
     }, (granted) => {
       runInAction(() => {
-        this.isConnectorHasPermission = Boolean(granted)
+        this.isDappEnabled = Boolean(granted)
       })
     });
   }
@@ -153,7 +153,7 @@ export default class WalletSettingsStore extends Store<StoresMap, ActionsMap> {
       ]
     }, (removed) => {
       runInAction(() => {
-        this.isConnectorHasPermission = Boolean(!removed)
+        this.isDappEnabled = Boolean(!removed)
       })
     });
   }

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -85,6 +85,13 @@ const onYoroiIconClicked = () => {
 
 chrome.browserAction.onClicked.addListener(debounce(onYoroiIconClicked, 500, { leading: true }));
 
+// Inject dapp-connector api code
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  chrome.tabs.executeScript({
+    file: 'js/inject.js',
+    allFrames: true,
+  })
+});
 /**
  * we store the ID instead of an index
  * because the user could delete a wallet (causing indices to shift)

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -87,7 +87,10 @@ chrome.browserAction.onClicked.addListener(debounce(onYoroiIconClicked, 500, { l
 
 // Inject dapp-connector api code
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  chrome.tabs.executeScript({
+  console.log({
+    tabId, changeInfo, tab
+  })
+  chrome.tabs.executeScript(tabId, {
     file: 'js/inject.js',
     allFrames: true,
   })

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -86,10 +86,7 @@ const onYoroiIconClicked = () => {
 chrome.browserAction.onClicked.addListener(debounce(onYoroiIconClicked, 500, { leading: true }));
 
 // Inject dapp-connector api code
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  console.log({
-    tabId, changeInfo, tab
-  })
+chrome.tabs.onUpdated.addListener((tabId) => {
   chrome.tabs.executeScript(tabId, {
     file: 'js/inject.js',
     allFrames: true,

--- a/packages/yoroi-extension/chrome/manifest.template.js
+++ b/packages/yoroi-extension/chrome/manifest.template.js
@@ -93,20 +93,7 @@ export default ({
   };
 
   if (shouldInjectConnector) {
-    base.content_scripts.push(
-      {
-        matches: [
-          'file://*/*',
-          'http://*/*',
-          'https://*/*',
-        ],
-        js: [
-          'js/inject.js',
-        ],
-        run_at: 'document_start',
-        all_frames: true,
-      }
-    );
+    base.optional_permissions = ['tabs', 'activeTab', '*://*/*']
   }
 
   const verName /*: {| version_name?: string |} */ = versionName != null

--- a/packages/yoroi-extension/chrome/manifest.template.js
+++ b/packages/yoroi-extension/chrome/manifest.template.js
@@ -90,11 +90,8 @@ export default ({
           uriTemplate: 'main_window.html#/send-from-uri?q=%s',
         },
       ],
+    optional_permissions: shouldInjectConnector ? ['tabs', 'activeTab', '*://*/*'] : []
   };
-
-  if (shouldInjectConnector) {
-    base.optional_permissions = ['tabs', 'activeTab', '*://*/*']
-  }
 
   const verName /*: {| version_name?: string |} */ = versionName != null
     ? { version_name: versionName }


### PR DESCRIPTION
### Before having the permission. Yoroi will be under `no access` category
<img width="318" alt="Screen Shot 2022-01-26 at 2 30 51 PM" src="https://user-images.githubusercontent.com/72753578/151163330-f5e8b7ab-ebbe-469c-9cf9-8df2639d9be8.png">

### After having the permission. Yoroi will be under `full access` category
<img width="319" alt="Screen Shot 2022-01-26 at 2 35 33 PM" src="https://user-images.githubusercontent.com/72753578/151163963-d3b3b343-ee48-4a5d-885f-ae43cbc4356c.png">

### When asking for permission. user will see this popup.
<img width="521" alt="Screen Shot 2022-01-26 at 2 34 02 PM" src="https://user-images.githubusercontent.com/72753578/151163744-45feaa7f-f80b-4c58-ba60-703bb57ecb5c.png">

## Simple buttons for testing 
To interact with the `chrome.permissions` API. will be removed in the final design

<img width="1373" alt="Screen Shot 2022-01-26 at 2 25 37 PM" src="https://user-images.githubusercontent.com/72753578/151162614-1c3a0ca9-51cd-4e43-8523-efa6ae93f1c3.png">

## Reference 

- [chrome.permissions](https://developer.chrome.com/docs/extensions/reference/permissions/)
- [Content Scripts for Manifest V2 (**Inject programmatically**)](https://developer.chrome.com/docs/extensions/mv2/content_scripts/#programmatic)

## Extensions 
- [x] Move the code that is responsible for requesting/removing/checking the access to the `profile` or `setting` stores so it can be accessed anywhere. 