### PR TITLE
use stake key path instead of key hash for trezor signing

### DIFF
--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/trezorTx.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/trezorTx.js
@@ -54,10 +54,10 @@ export async function createTrezorSignTxPayload(
     if (firstUtxo.addressing.startLevel !== Bip44DerivationLevels.PURPOSE.level) {
       throw new Error(`${nameof(createTrezorSignTxPayload)} unexpected addressing start level`);
     }
-    const stakingKeyPath = [...firstUtxo.addressing.path];
-    stakingKeyPath[Bip44DerivationLevels.CHAIN.level - 1] = ChainDerivations.CHIMERIC_ACCOUNT;
-    stakingKeyPath[Bip44DerivationLevels.ADDRESS.level - 1] = 0;
-    return stakingKeyPath;
+    const result = [...firstUtxo.addressing.path];
+    result[Bip44DerivationLevels.CHAIN.level - 1] = ChainDerivations.CHIMERIC_ACCOUNT;
+    result[Bip44DerivationLevels.ADDRESS.level - 1] = 0;
+    return result;
   })();
 
   const txBody = signRequest.unsignedTx.build();

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/trezorTx.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/trezorTx.js
@@ -43,33 +43,7 @@ export async function createTrezorSignTxPayload(
   byronNetworkMagic: number,
   networkId: number,
 ): Promise<$Exact<CardanoSignTransaction>> {
-  const txBody = signRequest.unsignedTx.build();
-
-  // Inputs
-  const trezorInputs = _transformToTrezorInputs(
-    signRequest.senderUtxos
-  );
-
-  // Output
-  const trezorOutputs = _generateTrezorOutputs(
-    txBody.outputs(),
-    signRequest.changeAddr
-  );
-
-  let request = {
-    signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
-    inputs: trezorInputs,
-    outputs: trezorOutputs,
-    fee: txBody.fee().to_str(),
-    ttl: txBody.ttl()?.toString(),
-    protocolMagic: byronNetworkMagic,
-    networkId,
-  };
-
-  // withdrawals
-  const withdrawals = txBody.withdrawals();
-
-  const getStakingKeyPath = () => {
+  const stakingKeyPath = (() => {
     // TODO: this entire block is super hacky
     // need to instead pass in a mapping from wallet addresses to addressing
     // or add something similar to the sign request
@@ -84,14 +58,41 @@ export async function createTrezorSignTxPayload(
     stakingKeyPath[Bip44DerivationLevels.CHAIN.level - 1] = ChainDerivations.CHIMERIC_ACCOUNT;
     stakingKeyPath[Bip44DerivationLevels.ADDRESS.level - 1] = 0;
     return stakingKeyPath;
+  })();
+
+  const txBody = signRequest.unsignedTx.build();
+
+  // Inputs
+  const trezorInputs = _transformToTrezorInputs(
+    signRequest.senderUtxos
+  );
+
+  // Output
+  const trezorOutputs = _generateTrezorOutputs(
+    txBody.outputs(),
+    signRequest.changeAddr,
+    stakingKeyPath,
+  );
+
+  let request = {
+    signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
+    inputs: trezorInputs,
+    outputs: trezorOutputs,
+    fee: txBody.fee().to_str(),
+    ttl: txBody.ttl()?.toString(),
+    protocolMagic: byronNetworkMagic,
+    networkId,
   };
+
+  // withdrawals
+  const withdrawals = txBody.withdrawals();
   request = withdrawals == null
     ? request
     : {
       ...request,
       withdrawals: formatTrezorWithdrawals(
         withdrawals,
-        [getStakingKeyPath()],
+        [stakingKeyPath],
       )
     };
 
@@ -103,7 +104,7 @@ export async function createTrezorSignTxPayload(
       ...request,
       certificates: formatTrezorCertificates(
         certificates,
-        range(0, certificates.len()).map(_i => getStakingKeyPath()),
+        range(0, certificates.len()).map(_i => stakingKeyPath),
       )
     };
 
@@ -114,10 +115,10 @@ export async function createTrezorSignTxPayload(
       auxiliaryData: {
         catalystRegistrationParameters: {
           votingPublicKey: votingPublicKey.replace(/^0x/, ''),
-          stakingPath: getStakingKeyPath(),
+          stakingPath: stakingKeyPath,
           rewardAddressParameters: {
             addressType: ADDRESS_TYPE.Reward,
-            path: getStakingKeyPath(),
+            path: stakingKeyPath,
           },
           nonce: String(nonce),
         },
@@ -238,6 +239,7 @@ function toTrezorTokenBundle(
 function _generateTrezorOutputs(
   txOutputs: RustModule.WalletV4.TransactionOutputs,
   changeAddrs: Array<{| ...Address, ...Value, ...Addressing |}>,
+  stakingKeyPath: Array<number>,
 ): Array<CardanoOutput> {
   const result = [];
   for (let i = 0; i < txOutputs.len(); i++) {
@@ -250,11 +252,15 @@ function _generateTrezorOutputs(
     const changeAddr = changeAddrs.find(change => jsAddr === change.address);
     if (changeAddr != null) {
       verifyFromBip44Root(changeAddr.addressing);
+      if (!RustModule.WalletV4.BaseAddress.from_address(address)) {
+        throw new Error('expect change address to be a base address');
+      }
       result.push({
-        addressParameters: toTrezorAddressParameters(
-          address,
-          changeAddr.addressing.path
-        ),
+        addressParameters: {
+          addressType: ADDRESS_TYPE.Base,
+          path: changeAddr.addressing.path,
+          stakingPath: stakingKeyPath,
+        },
         amount: output.amount().coin().to_str(),
         ...tokenBundle
       });


### PR DESCRIPTION
This PR is to fix https://github.com/Emurgo/yoroi-frontend/issues/2575 .

For the change address, Trezor can accept either the stake key path or the stake key hash. But after a recent FW update, if we pass the change key path and the stake key _hash_, as the issue reports, Trezor shows "Change address payment credential is a path" and asks the user to confirm every asset in the change, making a bad UX. This PR let Yoroi pass the change key path and the stake key _path_.

Currently, when sending a tx, the steps that the user goes through on the device are (as an example):
1. Confirming sending x ADA to addr_xxx
2. The following transaction output contains tokens. Continue?
3. Change address payment credential is a path: m/1852'/1815'/0'/1/x
4. Change address stake credential is a key hash: xxx
5. Change amount: x ADA to addr_xxx
6. Asset fingerprint: xxx
7. Asset fingerprint: xxx
8. Transaction fee: ... Hold to confirm

After applying the PR, the steps are:
1. Confirm sending x ADA to addr_xxx
2. Transaction fee: ... Hold to confirm
which is "expected".