### PR TITLE
Connector injection priority

### DIFF
--- a/packages/yoroi-ergo-connector/src/inject.js
+++ b/packages/yoroi-ergo-connector/src/inject.js
@@ -1,6 +1,8 @@
 // sets up RPC communication with the connector + access check/request functions
 const WALLET_NAME = 'yoroi';
-const API_VERSION = '0.2.0';
+const API_VERSION = '0.3.0';
+const YOROI_TYPE = '$YOROI_BUILD_TYPE_ENV$';
+const INJECTED_TYPE_TAG_ID = '__yoroi_connector_api_injected_type'
 
 const initialInject = `
 (() => {
@@ -323,6 +325,19 @@ const ergo = Object.freeze(new ErgoAPI());
 const API_INTERNAL_ERROR = -2;
 const API_REFUSED = -3;
 
+function checkInjectionInDocument() {
+    const el = document.getElementById(INJECTED_TYPE_TAG_ID);
+    return el ? el.value : 'nothing';
+}
+
+function markInjectionInDocument(container) {
+    const inp = document.createElement('input');
+    inp.setAttribute('type', 'hidden');
+    inp.setAttribute('id', INJECTED_TYPE_TAG_ID);
+    inp.setAttribute('value', YOROI_TYPE);
+    container.appendChild(inp);
+}
+
 function injectIntoPage(code) {
     try {
         const container = document.head || document.documentElement;
@@ -331,11 +346,21 @@ function injectIntoPage(code) {
         scriptTag.textContent = code;
         container.insertBefore(scriptTag, container.children[0]);
         container.removeChild(scriptTag);
-        console.log("injection succeeded");
+        console.log(`[yoroi/${YOROI_TYPE}] dapp-connector is successfully injected into ${location.hostname}`);
+        markInjectionInDocument(container);
         return true;
     } catch (e) {
-        console.log("injection failed: " + e);
+        console.error(`[yoroi/${YOROI_TYPE}] injection failed!`, e);
         return false;
+    }
+}
+
+function buildTypePrecedence(buildType) {
+    switch (buildType) {
+        case 'dev': return 2;
+        case 'nightly': return 1;
+        case 'prod': return 0;
+        default: return -1;
     }
 }
 
@@ -344,7 +369,15 @@ function shouldInject() {
     const docElemCheck = documentElement ? documentElement.toLowerCase() === 'html' : true;
     const { docType } = window.document;
     const docTypeCheck = docType ? docType.name === 'html' : true;
-    return docElemCheck && docTypeCheck;
+    if (docElemCheck && docTypeCheck) {
+        console.debug(`[yoroi/${YOROI_TYPE}] checking if should inject dapp-connector api`);
+        const existingBuildType = checkInjectionInDocument();
+        if (buildTypePrecedence(YOROI_TYPE) >= buildTypePrecedence(existingBuildType)) {
+            console.debug(`[yoroi/${YOROI_TYPE}] injecting over '${existingBuildType}'`);
+            return true
+        }
+    }
+    return false;
 }
 
 /**
@@ -446,76 +479,74 @@ function createYoroiPort() {
 }
 
 if (shouldInject()) {
-    console.log(`content script injected into ${location.hostname}`);
-    injectIntoPage(initialInject);
-
-    // events from page (injected code)
-    window.addEventListener("message", function(event) {
-        const dataType = event.data.type;
-        if (dataType === "connector_rpc_request") {
-            console.debug("connector received from page: " + JSON.stringify(event.data) + " with source = " + event.source + " and origin = " + event.origin);
-            if (yoroiPort) {
-                try {
-                    yoroiPort.postMessage(event.data);
-                    return;
-                } catch (e) {
-                    console.error(`Could not send RPC to Yoroi: ${e}`);
+    if (injectIntoPage(initialInject)) {
+        // events from page (injected code)
+        window.addEventListener("message", function (event) {
+            const dataType = event.data.type;
+            if (dataType === "connector_rpc_request") {
+                console.debug("connector received from page: " + JSON.stringify(event.data) + " with source = " + event.source + " and origin = " + event.origin);
+                if (yoroiPort) {
+                    try {
+                        yoroiPort.postMessage(event.data);
+                        return;
+                    } catch (e) {
+                        console.error(`Could not send RPC to Yoroi: ${e}`);
+                        window.postMessage({
+                            type: "connector_rpc_response",
+                            uid: event.data.uid,
+                            return: {
+                                err: {
+                                    code: API_INTERNAL_ERROR,
+                                    info: `Could not send RPC to Yoroi: ${e}`
+                                }
+                            }
+                        }, location.origin);
+                    }
+                } else {
                     window.postMessage({
                         type: "connector_rpc_response",
                         uid: event.data.uid,
                         return: {
                             err: {
-                                code: API_INTERNAL_ERROR,
-                                info: `Could not send RPC to Yoroi: ${e}`
+                                code: API_REFUSED,
+                                info: 'Wallet disconnected'
                             }
                         }
                     }, location.origin);
                 }
-            } else {
-                window.postMessage({
-                    type: "connector_rpc_response",
-                    uid: event.data.uid,
-                    return: {
-                        err: {
-                            code: API_REFUSED,
-                            info: 'Wallet disconnected'
-                        }
+            } else if (dataType === "connector_connect_request/ergo" || dataType === 'connector_connect_request/cardano') {
+                const requestIdentification = event.data.requestIdentification;
+                if ((ergoApiInjected || (cardanoApiInjected && !requestIdentification)) && yoroiPort) {
+                    // we can skip communication - API injected + hasn't been disconnected
+                    window.postMessage({
+                        type: "connector_connected",
+                        success: true
+                    }, location.origin);
+                } else {
+                    if (yoroiPort == null) {
+                        createYoroiPort();
                     }
-                }, location.origin);
-            }
-        } else if (dataType === "connector_connect_request/ergo" || dataType === 'connector_connect_request/cardano') {
-            const requestIdentification = event.data.requestIdentification;
-            if ((ergoApiInjected || (cardanoApiInjected && !requestIdentification)) && yoroiPort) {
-                // we can skip communication - API injected + hasn't been disconnected
-                console.log('you are already connected')
-                window.postMessage({
-                    type: "connector_connected",
-                    success: true
-                }, location.origin);
-            } else {
-                if (yoroiPort == null) {
-                    createYoroiPort();
+                    // note: content scripts are subject to the same CORS policy as the website they are embedded in
+                    // but since we are querying the website this script is injected into, it should be fine
+                    const protocol = dataType.split('/')[1];
+                    convertImgToBase64(location.origin, getFavicons(location.origin))
+                      .then(imgBase64Url => {
+                          const message = {
+                              imgBase64Url,
+                              type: `yoroi_connect_request/${protocol}`,
+                              connectParameters: {
+                                  url: location.hostname,
+                                  requestIdentification,
+                                  onlySilent: event.data.onlySilent,
+                              },
+                              protocol,
+                          };
+                          yoroiPort.postMessage(message);
+                      });
                 }
-                // note: content scripts are subject to the same CORS policy as the website they are embedded in
-                // but since we are querying the website this script is injected into, it should be fine
-                const protocol = dataType.split('/')[1];
-                convertImgToBase64(location.origin, getFavicons(location.origin))
-                    .then(imgBase64Url => {
-                        const message = {
-                            imgBase64Url,
-                            type: `yoroi_connect_request/${protocol}`,
-                            connectParameters: {
-                                url: location.hostname,
-                                requestIdentification,
-                                onlySilent: event.data.onlySilent,
-                            },
-                            protocol,
-                        };
-                        yoroiPort.postMessage(message);
-                    });
             }
-        }
-    });
+        });
+    }
 }
 
 /**

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.506",
+  "version": "4.9.507",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.9.506",
+  "version": "4.9.507",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",


### PR DESCRIPTION
In case multiple different type copies of Yoroi are running (different builds) the code will be injected according to the priority rule:

```
unknown < prod < nightly < dev
```

So nightly and dev builds will be a higher priority than prod so that testers can use them over the installed prod version. Any nightly and dev versions must be removed or disabled in order for the prod version to inject.