### PR TITLE
Updating experimental `createTx` api in the connector

### DIFF
--- a/packages/yoroi-ergo-connector/example-cardano/index.js
+++ b/packages/yoroi-ergo-connector/example-cardano/index.js
@@ -537,6 +537,7 @@ createTx.addEventListener('click', () => {
           amount: '42',
         }, {
           script: mintScriptHex,
+          storeScriptOnChain: true,
           assetName: nftAssetNameHex,
           metadata: {
             tag: 721,

--- a/packages/yoroi-extension/app/api/ada/index.js
+++ b/packages/yoroi-extension/app/api/ada/index.js
@@ -1292,7 +1292,7 @@ export default class AdaApi {
           // Set the new amount to the target assets
           targetAssets[assetId] = assetAmount;
           appendMintMetadata(metadata, policyId, assetName);
-          if (storeScriptOnChain) {
+          if (Boolean(storeScriptOnChain) === true) {
             nativeScripts.push(script);
           }
         }

--- a/packages/yoroi-extension/app/api/ada/index.js
+++ b/packages/yoroi-extension/app/api/ada/index.js
@@ -316,6 +316,7 @@ export type CardanoTxRequestMintMetadata = {|
 |};
 export type CardanoTxRequestMint = {|
   script: string, // the HEX of the policy script,
+  storeScriptOnChain?: boolean, // whether to include the script into auxiliary data
   assetName: string, // HEX
   amount?: string, // default to 1 for NFTs
   // This metadata will be wrapped into { tag: { [policyId]: { [assetName]: json } } }

--- a/packages/yoroi-extension/app/coreUtils.js
+++ b/packages/yoroi-extension/app/coreUtils.js
@@ -7,3 +7,7 @@ export function bytesToHex(bytes: *): string {
 export function hexToBytes(hex: string): Buffer {
   return Buffer.from(hex, 'hex');
 }
+
+export function hexToUtf(hex: string): string {
+  return hexToBytes(hex).toString('utf-8');
+}

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.11.200",
+  "version": "4.11.201",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.11.200",
+  "version": "4.11.201",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",


### PR DESCRIPTION
1. Fixed 721 v1 metadata - adding the version field `"1.0"` and specifting the asset name in utf-8
2. Added option to store the minting script in the auxiliary data using parameter: `storeScriptOnChain: true` in a mint request