### PR TITLE
don't sync wallet for signHexPayload

### DIFF
--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -1327,6 +1327,7 @@ function handleInjectorConnect(port) {
                   },
                   db,
                   localStorageApi,
+                  false,
                 )
               });
             } catch (e) {


### PR DESCRIPTION
this disables wallet sync for signHexPayload calls and improves the performance