### PR TITLE
connector resyncs before submitting tx

### DIFF
--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -1273,7 +1273,6 @@ function handleInjectorConnect(port) {
                   },
                   db,
                   localStorageApi,
-                  false,
                 )
               });
             } catch (e) {


### PR DESCRIPTION
This is a temporary measure but it is needed for the current implementation. I will refactor the whole submitted transaction stuff to eliminate the requirement for resyncing when submitting tx. 