### PR TITLE
remove max-width of wallet name box

### DIFF
--- a/packages/yoroi-extension/app/components/topbar/NavWalletDetailsRevamp.scss
+++ b/packages/yoroi-extension/app/components/topbar/NavWalletDetailsRevamp.scss
@@ -40,7 +40,6 @@
 }
 
 .walletInfo {
-  max-width: 100px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The hardcoded max-width causes undesirable line wrap:
![lb1](https://user-images.githubusercontent.com/1028789/172525199-0b35e29e-51c5-440d-8326-b6dfb76ee15f.jpg)
After removing:
![lb2](https://user-images.githubusercontent.com/1028789/172525225-279b7d22-8de5-4e4b-a954-7712ac753087.jpg)
