### PR TITLE
remove fiat conversion on pending tx amount

### DIFF
--- a/packages/yoroi-extension/app/components/wallet/summary/WalletSummary.js
+++ b/packages/yoroi-extension/app/components/wallet/summary/WalletSummary.js
@@ -118,7 +118,7 @@ export default class WalletSummary extends Component<Props> {
     } = this.props;
 
     let pendingAmount = null;
-    if (unitOfAccountSetting.enabled) {
+    if (false /* temporarily disabled */ && unitOfAccountSetting.enabled) {
       const { currency } = unitOfAccountSetting;
       if (!currency) {
         throw new Error(`unexpected unit of account ${String(currency)}`);

--- a/packages/yoroi-extension/app/ergo-connector/components/signin/CardanoSignTxPage.js
+++ b/packages/yoroi-extension/app/ergo-connector/components/signin/CardanoSignTxPage.js
@@ -212,7 +212,7 @@ class SignTxPage extends Component<Props, State> {
 
     let fiatAmountDisplay = null;
 
-    if (this.props.unitOfAccountSetting.enabled === true) {
+    if (false && this.props.unitOfAccountSetting.enabled === true) {
       const { currency } = this.props.unitOfAccountSetting;
       const price = this.props.getCurrentPrice(
         getTokenName(tokenInfo),

--- a/packages/yoroi-extension/app/ergo-connector/components/signin/CardanoUtxoDetails.js
+++ b/packages/yoroi-extension/app/ergo-connector/components/signin/CardanoUtxoDetails.js
@@ -93,7 +93,7 @@ class CardanoUtxoDetails extends Component<Props> {
 
     let fiatAmountDisplay = null;
 
-    if (this.props.unitOfAccountSetting.enabled === true) {
+    if (false && this.props.unitOfAccountSetting.enabled === true) {
       const { currency } = this.props.unitOfAccountSetting;
       const price = this.props.getCurrentPrice(
         tokenInfo ? getTokenName(tokenInfo) : nameFromIdentifier,

--- a/packages/yoroi-extension/app/ergo-connector/components/signin/SignTxPage.js
+++ b/packages/yoroi-extension/app/ergo-connector/components/signin/SignTxPage.js
@@ -219,7 +219,7 @@ class SignTxPage extends Component<Props, State> {
     if (tokenInfo == null) return this.displayUnAvailableToken(request.entry);
     const shiftedAmount = request.entry.amount.shiftedBy(-tokenInfo.Metadata.numberOfDecimals);
 
-    if (this.props.unitOfAccountSetting.enabled === true) {
+    if (false && this.props.unitOfAccountSetting.enabled === true) {
       const { currency } = this.props.unitOfAccountSetting;
       const price = this.props.getCurrentPrice(request.entry.identifier, currency);
       if (price != null) {

--- a/packages/yoroi-extension/app/ergo-connector/components/signin/UtxoDetails.js
+++ b/packages/yoroi-extension/app/ergo-connector/components/signin/UtxoDetails.js
@@ -98,7 +98,7 @@ class UtxoDetails extends Component<Props> {
     if (tokenInfo == null) return this.displayUnAvailableToken(request.entry);
     const shiftedAmount = request.entry.amount.shiftedBy(-tokenInfo.Metadata.numberOfDecimals);
 
-    if (this.props.unitOfAccountSetting.enabled === true) {
+    if (false && this.props.unitOfAccountSetting.enabled === true) {
       const { currency } = this.props.unitOfAccountSetting;
       const price = this.props.getCurrentPrice(request.entry.identifier, currency);
       if (price != null) {


### PR DESCRIPTION
Should've been part of https://github.com/Emurgo/yoroi-frontend/pull/2877 but I overlooked it. I guess we don't need to release a new update just for this because the pending tx amounts appear relatively rarely.