### PR TITLE
Bug fix: balance shown in "all wallets" dialog is always loading

### DIFF
--- a/packages/yoroi-extension/app/components/topbar/WalletListDialog.js
+++ b/packages/yoroi-extension/app/components/topbar/WalletListDialog.js
@@ -364,7 +364,7 @@ export default class WalletListDialog extends Component<Props, State> {
     for (let i = 1; i < wallets.length; i ++ ) {
       if (wallets[i].walletAmount) {
         sum.joinAddMutable(new MultiToken(
-          // treat TADA as ADA
+          // treat TADA as ADA or vice versa
           wallets[i].walletAmount.values.map(v => ({
             ...v,
             networkId: sum.getDefaults().defaultNetworkId,
@@ -376,7 +376,14 @@ export default class WalletListDialog extends Component<Props, State> {
       }
 
       if (wallets[i].rewards) {
-        sum.joinAddMutable(wallets[i].rewards);
+        sum.joinAddMutable(new MultiToken(
+          // treat TADA as ADA or vice versa
+          wallets[i].rewards.values.map(v => ({
+            ...v,
+            networkId: sum.getDefaults().defaultNetworkId,
+          })),
+          sum.getDefaults(),
+        ));
       }
     }
     if (!unitOfAccountSetting.enabled) {

--- a/packages/yoroi-extension/app/stores/toplevel/WalletStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/WalletStore.js
@@ -368,6 +368,7 @@ export default class WalletStore extends Store<StoresMap, ActionsMap> {
         );
       }
       stores.delegation.addObservedWallet(request.publicDeriver);
+      stores.delegation.refreshDelegation(request.publicDeriver);
     }
   };
 


### PR DESCRIPTION
The bug is because the balances of wallets shown on the "all wallets" dialog include rewards, but currently, rewards are not stored locally, nor refreshed until the wallet is open. The fix is to initiate a delegation data request at the start.

Also fixed a bug where there are both TADA and ADA wallets.