### PR TITLE
optimize connector list NFT API

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
@@ -474,13 +474,12 @@ export type CardanoAssetMintMetadata = {|
   // transaction_metadatum_label: 721 for NFTs
   // See CIP 721
   // https://github.com/cardano-foundation/CIPs/blob/8b1f2f0900d81d6233e9805442c2b42aa1779d2d/CIP-NFTMetadataStandard.md
-  ...{[key: string]: {|
-    // policy ID
-    ...{[key: string]: {|
-      // asset name
-      ...{[key: string]: any}
-    |}}
-  |}}
+  [key: string]: {|
+    version?: ?string,
+    [policyID: string]: {|
+      [assetNameHex: string]: any
+    |}
+  |}
 |}
 
 export type CommonMetadata = {|

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/api.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/api.js
@@ -83,6 +83,12 @@ import { derivePrivateByAddressing } from '../../../app/api/ada/lib/cardanoCrypt
 import { cip8Sign } from '../../../app/ergo-connector/api';
 import type { PersistedSubmittedTransaction } from '../../../app/api/localStorage';
 import type { ForeignUtxoFetcher } from '../../../app/ergo-connector/stores/ConnectorStore';
+import { GetToken } from '../../../app/api/ada/lib/storage/database/primitives/api/read';
+import {
+  getAllSchemaTables,
+  raii,
+} from '../../../app/api/ada/lib/storage/database/utils';
+import type { TokenRow } from '../../../app/api/ada/lib/storage/database/primitives/tables';
 
 function paginateResults<T>(results: T[], paginate: ?Paginate): T[] {
   if (paginate != null) {
@@ -1469,4 +1475,22 @@ export async function connectorSignData(
     signature: Buffer.from(coseSign1.to_bytes()).toString('hex'),
     key: Buffer.from(key.to_bytes()).toString('hex'),
   };
+}
+
+export function getTokenMetadataFromIds(
+  tokenIds: Array<string>,
+  publicDeriver: PublicDeriver<>,
+): Promise<$ReadOnlyArray<$ReadOnly<TokenRow>>> {
+  const networkId = publicDeriver.getParent().getNetworkInfo().NetworkId;
+  const db = publicDeriver.getDb();
+  return raii(
+    db,
+    getAllSchemaTables(db, GetToken),
+    async (dbTx) => {
+      return (await GetToken.fromIdentifier(
+        db, dbTx,
+        tokenIds
+      )).filter(row => row.NetworkId === networkId);
+    }
+  );
 }


### PR DESCRIPTION
Original implementation queries the NFT metadata from the backend, but actually, this info should've already been queried and stored locally.