### PR TITLE
query multiasset metadata using asset name in hex

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/types.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/types.js
@@ -379,7 +379,7 @@ export type MultiAssetMintMetadataRequest = {|
 |};
 
 export type MultiAssetMintMetadataRequestAsset = {|
-  name: string,
+  nameHex: string,
   policy: string
 |}
 

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1960,8 +1960,7 @@ export async function getTokenMintMetadata(
         nameHex: assetName,
         policy: policyId
       };
-    })
-    .filter(a => a.name !== '');
+    });
 
   if (!nativeAssets || nativeAssets.length === 0) return {};
 

--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -1957,7 +1957,7 @@ export async function getTokenMintMetadata(
       const assetName = parts[1];
       const policyId = parts[0];
       return {
-        name: Buffer.from(assetName, 'hex').toString(),
+        nameHex: assetName,
         policy: policyId
       };
     })


### PR DESCRIPTION
Correspond with the backend change: https://github.com/Emurgo/yoroi-graphql-migration-backend/pull/376