### PR TITLE
improve typing for NFT metadata

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/database/primitives/tables.js
@@ -470,6 +470,18 @@ export const AddressMappingSchema: {|
   }
 };
 
+export type NFTMetadata = {|
+  name: string,
+  image: string | Array<string>,
+  mediaType?: ?string,
+  description: ?(string | Array<string>),
+  files?: ?Array<{|
+    name?: ?string,
+    mediaType?: ?string,
+    src?: ?(string | Array<string>),
+  |}>
+|};
+
 export type CardanoAssetMintMetadata = {|
   // transaction_metadatum_label: 721 for NFTs
   // See CIP 721
@@ -477,7 +489,7 @@ export type CardanoAssetMintMetadata = {|
   [key: string]: {|
     version?: ?string,
     [policyID: string]: {|
-      [assetNameHex: string]: any
+      [assetNameHex: string]: NFTMetadata
     |}
   |}
 |}
@@ -512,7 +524,7 @@ export type TokenMetadata = {|
   // empty string for ADA
   +assetName: string,
   ...CommonMetadata,
-  +assetMintMetadata?: ?Array<CardanoAssetMintMetadata | any> | any
+  +assetMintMetadata?: Array<CardanoAssetMintMetadata>
 |};
 
 export type TokenInsert = {|

--- a/packages/yoroi-extension/app/components/wallet/assets/NFTDetails.js
+++ b/packages/yoroi-extension/app/components/wallet/assets/NFTDetails.js
@@ -12,6 +12,7 @@ import { ROUTES } from '../../../routes-config';
 import CopyToClipboardText from '../../widgets/CopyToClipboardLabel';
 import { getNetworkUrl, tokenMessages } from './TokenDetails';
 import type { NetworkRow } from '../../../api/ada/lib/storage/database/primitives/tables';
+import { ReactComponent as DefaultNFT } from '../../../assets/images/nft-no.inline.svg';
 
 type Props = {|
   nftInfo: void | {|
@@ -22,7 +23,7 @@ type Props = {|
     name: string | void,
     id: string,
     amount: string,
-    image?: string,
+    image: string | null,
     description: ?string
   |},
   network: $ReadOnly<NetworkRow>,
@@ -35,8 +36,14 @@ type Intl = {|
 
 function NFTDetails({ nftInfo, nftsCount, network, intl }: Props & Intl): Node {
   if (nftInfo == null) return null;
-  const ipfsHash = nftInfo.image != null ? nftInfo.image.replace('ipfs://', '') : '';
   const networkUrl = getNetworkUrl(network);
+  let nftImage;
+  if (nftInfo.image != null) {
+    const ipfsHash = nftInfo.image.replace('ipfs://', '');
+    nftImage = (<img src={`https://ipfs.io/ipfs/${ipfsHash}`} alt={nftInfo.name} loading="lazy" />);
+  } else {
+    nftImage = <DefaultNFT />;
+  }
 
   return (
     <Box>
@@ -71,7 +78,7 @@ function NFTDetails({ nftInfo, nftsCount, network, intl }: Props & Intl): Node {
         }}
       >
         <ImageItem flex="1">
-          <img src={`https://ipfs.io/ipfs/${ipfsHash}`} alt={nftInfo.name} loading="lazy" />
+          {nftImage}
         </ImageItem>
         <Box flex="1" backgroundColor="var(--yoroi-palette-common-white)" borderRadius="8px">
           <Box borderBottom="1px solid var(--yoroi-palette-gray-50)" px="24px" py="22px">

--- a/packages/yoroi-extension/app/components/wallet/assets/NFTDetails.js
+++ b/packages/yoroi-extension/app/components/wallet/assets/NFTDetails.js
@@ -23,7 +23,7 @@ type Props = {|
     id: string,
     amount: string,
     image?: string,
-    description?: string
+    description: ?string
   |},
   network: $ReadOnly<NetworkRow>,
   nftsCount: number

--- a/packages/yoroi-extension/app/components/wallet/assets/NFTsList.js
+++ b/packages/yoroi-extension/app/components/wallet/assets/NFTsList.js
@@ -18,9 +18,10 @@ import { Link } from 'react-router-dom';
 import { ROUTES } from '../../../routes-config';
 import { useState } from 'react';
 import { ListEmpty } from './ListEmpty';
+import { ReactComponent as DefaultNFT } from '../../../assets/images/nft-no.inline.svg';
 
 type Props = {|
-  list: Array<{| name: string, image: string | void |}> | void,
+  list: Array<{| name: string, image: string | null |}> | void,
 |};
 type Intl = {|
   intl: $npm$ReactIntl$IntlShape,
@@ -96,7 +97,7 @@ function NfTsList({ list, intl }: Props & Intl): Node {
           {nftList.map(nft => {
             return (
               <SLink key={nft.name} to={ROUTES.ASSETS.NFT_DETAILS.replace(':nftId', nft.name)}>
-                <NftCardImage ipfsUrl={nft.image} name={nft.name} />
+                <NftCardImage image={nft.image} name={nft.name} />
               </SLink>
             );
           })}
@@ -108,12 +109,18 @@ function NfTsList({ list, intl }: Props & Intl): Node {
 
 export default (injectIntl(NfTsList): ComponentType<Props>);
 
-function NftCardImage({ ipfsUrl, name }) {
-  const ipfsHash = ipfsUrl != null ? ipfsUrl.replace('ipfs://', '') : '';
+function NftCardImage({ image, name }) {
+  let nftImage
+  if (image != null) {
+    const ipfsHash = image.replace('ipfs://', '');
+    nftImage = (<img src={`https://ipfs.io/ipfs/${ipfsHash}`} alt={name} loading="lazy" />);
+  } else {
+    nftImage = (<DefaultNFT />);
+  }
 
   return (
     <ImageItem sx={{ height: '100%' }}>
-      <img src={`https://ipfs.io/ipfs/${ipfsHash}`} alt={name} loading="lazy" />
+      {nftImage}
       <Typography mt="16px" minHeight="48px" color="var(--yoroi-palette-gray-900)">
         {name}
       </Typography>

--- a/packages/yoroi-extension/app/components/wallet/send/WalletSendFormRevamp.js
+++ b/packages/yoroi-extension/app/components/wallet/send/WalletSendFormRevamp.js
@@ -48,6 +48,7 @@ import QRScannerDialog from './WalletSendFormSteps/QRScannerDialog';
 import type { UnitOfAccountSettingType } from '../../../types/unitOfAccountType';
 import { calculateAndFormatValue } from '../../../utils/unit-of-account';
 import { CannotSendBelowMinimumValueError } from '../../../api/common/errors';
+import { getImageFromTokenMetadata } from '../../../utils/nftMetadata';
 
 const messages = defineMessages({
   receiverLabel: {
@@ -349,10 +350,9 @@ export default class WalletSendForm extends Component<Props, State> {
       const policyId = token.Identifier.split('.')[0];
       const name = truncateToken(getTokenStrictName(token) ?? '-');
       return {
-          name,
-          // $FlowFixMe[prop-missing]
-          image: token.Metadata.assetMintMetadata?.[0]?.['721']?.[policyId]?.[name]?.image,
-          info: token,
+        name,
+        image: getImageFromTokenMetadata(policyId, name, token.Metadata),
+        info: token,
       };
     });
 

--- a/packages/yoroi-extension/app/containers/wallet/NFTDetailPageRevamp.js
+++ b/packages/yoroi-extension/app/containers/wallet/NFTDetailPageRevamp.js
@@ -20,6 +20,10 @@ import type { Match } from 'react-router-dom';
 import { withRouter } from 'react-router-dom';
 import { Box } from '@mui/system';
 import NFTDetails from '../../components/wallet/assets/NFTDetails';
+import {
+  getDescriptionFromTokenMetadata,
+  getImageFromTokenMetadata,
+} from '../../utils/nftMetadata';
 
 export type GeneratedData = typeof NFTDetailPageRevamp.prototype.generated;
 type Props = {|
@@ -63,26 +67,14 @@ class NFTDetailPageRevamp extends Component<AllProps> {
                 assetName: token.entry.identifier.split('.')[1] ?? '',
                 id: getTokenIdentifierIfExists(token.info) ?? '-',
                 amount: genFormatTokenAmount(getTokenInfo)(token.entry),
-                nftMetadata: token.info.Metadata.assetMintMetadata
-                  && token.info.Metadata.assetMintMetadata.length > 0
-                  && token.info.Metadata.assetMintMetadata[0]['721']
-                  && token.info.Metadata.assetMintMetadata[0]['721'][policyId]
-                  && token.info.Metadata.assetMintMetadata[0]['721'][policyId][name]
-                  ? token.info.Metadata.assetMintMetadata[0]['721'][policyId][name]
-                  : undefined,
+                image: getImageFromTokenMetadata(policyId, name, token.info.Metadata),
+                description: getDescriptionFromTokenMetadata(
+                  policyId,
+                  name,
+                  token.info.Metadata
+                ),
               };
-            })
-            .map(item => ({
-              policyId: item.policyId,
-              lastUpdatedAt: item.lastUpdatedAt,
-              ticker: item.ticker,
-              assetName: item.assetName,
-              id: item.id,
-              amount: item.amount,
-              name: item.name,
-              image: item.nftMetadata?.image ?? '',
-              description: item.nftMetadata?.description ?? '',
-            }));
+            });
 
     const { nftId } = this.props.match.params;
     const nftInfo = nftsList.find(nft => nft.name === nftId);

--- a/packages/yoroi-extension/app/containers/wallet/NFTsPageRevamp.js
+++ b/packages/yoroi-extension/app/containers/wallet/NFTsPageRevamp.js
@@ -17,6 +17,7 @@ import { MultiToken } from '../../api/common/lib/MultiToken';
 import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver';
 import type { TxRequests } from '../../stores/toplevel/TransactionsStore';
 import NfTsList from '../../components/wallet/assets/NFTsList';
+import { getImageFromTokenMetadata } from '../../utils/nftMetadata';
 
 export type GeneratedData = typeof NFTsPageRevamp.prototype.generated;
 
@@ -42,17 +43,13 @@ export default class NFTsPageRevamp extends Component<InjectedOrGenerated<Genera
           const name = truncateToken(getTokenStrictName(token.info) ?? '-');
           return {
             name,
-            id: getTokenIdentifierIfExists(token.info) ?? '-',
-            amount: genFormatTokenAmount(getTokenInfo)(token.entry),
-            policyId,
-            // $FlowFixMe[prop-missing]
-            nftMetadata: token.info.Metadata.assetMintMetadata?.[0]['721'][policyId][name],
+            image: getImageFromTokenMetadata(
+              policyId,
+              name,
+              token.info.Metadata,
+            ),
           };
-        })
-        .map(item => ({
-          name: item.name,
-          image: item.nftMetadata?.image,
-        }));
+        });
     })();
 
     return <NfTsList list={nftsList} />;

--- a/packages/yoroi-extension/app/containers/wallet/NFTsPageRevamp.js
+++ b/packages/yoroi-extension/app/containers/wallet/NFTsPageRevamp.js
@@ -4,9 +4,7 @@ import { Component } from 'react';
 import type { InjectedOrGenerated } from '../../types/injectedPropsType';
 import type { Node } from 'react';
 import {
-  genFormatTokenAmount,
   genLookupOrFail,
-  getTokenIdentifierIfExists,
   getTokenStrictName,
 } from '../../stores/stateless/tokenHelpers';
 import { truncateToken } from '../../utils/formatters';

--- a/packages/yoroi-extension/app/utils/nftMetadata.js
+++ b/packages/yoroi-extension/app/utils/nftMetadata.js
@@ -1,0 +1,130 @@
+//@flow
+import { isArray } from 'util';
+
+import type {
+  CardanoAssetMintMetadata,
+  NFTMetadata,
+  TokenMetadata,
+} from '../api/ada/lib/storage/database/primitives/tables';
+
+export function find721metadata(
+  policyId: string,
+  assetNameHex: string,
+  assetMintMetadata: ?Array<CardanoAssetMintMetadata>,
+): NFTMetadata | null {
+  if (!assetMintMetadata) {
+    return null;
+  }
+  const metadataWrapper = assetMintMetadata.find(m => m['721'] != null);
+  if (metadataWrapper === undefined) {
+    return null;
+  }
+  const metadata = metadataWrapper['721'];
+  if (metadata.version && metadata.version !== '1.0') {
+    return null;
+  }
+
+  const assetName = Array.from(Buffer.from(assetNameHex, 'hex')).map(
+    c => String.fromCharCode(c)
+  ).join('');
+  const asset: any = metadata[policyId]?.[assetName] || metadata[policyId]?.[assetNameHex];
+  if (!asset) {
+    return null;
+  }
+
+  // Note that `asset` is from the backend via asset metadata query, which in turn
+  // gets the data from the blockchain, but none of the step actually verifies that
+  // it conforms to the structure defined by CIP 25 - NFT Metadata Standard. In order
+  // to avoid causing error in the user of this data, we normalize the data to
+  // guarentee that the return value conforms to the `NFTMetadata` type.
+  const ret: any = {};
+  if (typeof asset.name === 'string') {
+    ret.name = asset.name;
+  } else {
+    ret.name = '';
+  }
+  if (
+    typeof asset.image === 'string' || (
+      isArray(asset.image) &&  asset.image.every(i => typeof i === 'string')
+    )
+  ) {
+    ret.image = asset.image;
+  }
+  if (typeof asset.mediaType === 'string') {
+    ret.mediaType = asset.mediaType;
+  }
+  if (
+    typeof asset.description === 'string' || (
+      isArray(asset.description) && asset.description.every(i => typeof i === 'string')
+    )
+  ) {
+    ret.description = asset.description;
+  }
+  if (
+    isArray(asset.files) &&
+      asset.files.every(({name, mediaType, src }) => (
+        typeof name === 'string' &&
+          typeof mediaType === 'string' &&
+          (
+            typeof src === 'string' ||
+              (isArray(src) && src.every(s => typeof s === 'string'))
+          )
+      ))
+  ) {
+    ret.files = asset.files;
+  }
+  return ret;
+}
+
+export function getImageFromTokenMetadata(
+  policyId: string,
+  name: string,
+  tokenMetadata: TokenMetadata,
+): string {
+  if (tokenMetadata.type !== 'Cardano') {
+    return '';
+  }
+  const nftMetadata = find721metadata(
+    policyId,
+    name,
+    tokenMetadata.assetMintMetadata,
+  );
+
+  if (!nftMetadata) {
+    return '';
+  }
+  if (typeof nftMetadata.image === 'string') {
+    return nftMetadata.image;
+  }
+  if (typeof nftMetadata.image?.[0] === 'string') {
+    return nftMetadata.image[0];
+  }
+  return '';
+}
+
+
+export function getDescriptionFromTokenMetadata(
+  policyId: string,
+  name: string,
+  tokenMetadata: TokenMetadata,
+): string | null {
+  if (tokenMetadata.type !== 'Cardano') {
+    return null;
+  }
+  const nftMetadata = find721metadata(
+    policyId,
+    name,
+    tokenMetadata.assetMintMetadata,
+  );
+
+  if (!nftMetadata) {
+    return null;
+  }
+  if (typeof nftMetadata.description === 'string') {
+    return nftMetadata.description;
+  }
+  if (typeof nftMetadata.description?.[0] === 'string') {
+    return nftMetadata.description[0];
+  }
+  return null;
+}

--- a/packages/yoroi-extension/app/utils/nftMetadata.js
+++ b/packages/yoroi-extension/app/utils/nftMetadata.js
@@ -80,9 +80,9 @@ export function getImageFromTokenMetadata(
   policyId: string,
   name: string,
   tokenMetadata: TokenMetadata,
-): string {
+): string | null {
   if (tokenMetadata.type !== 'Cardano') {
-    return '';
+    return null;
   }
   const nftMetadata = find721metadata(
     policyId,
@@ -91,7 +91,7 @@ export function getImageFromTokenMetadata(
   );
 
   if (!nftMetadata) {
-    return '';
+    return null;
   }
   if (typeof nftMetadata.image === 'string') {
     return nftMetadata.image;
@@ -99,7 +99,7 @@ export function getImageFromTokenMetadata(
   if (typeof nftMetadata.image?.[0] === 'string') {
     return nftMetadata.image[0];
   }
-  return '';
+  return null;
 }
 
 

--- a/packages/yoroi-extension/app/utils/wallet.js
+++ b/packages/yoroi-extension/app/utils/wallet.js
@@ -18,7 +18,7 @@ export type FormattedTokenDisplay = {|
 
 export type FormattedNFTDisplay = {|
     id?: string,
-    image?: string,
+    image: string | null,
     name: string,
     info: $ReadOnly<TokenRow>,
 |}

--- a/packages/yoroi-extension/app/utils/wallet.js
+++ b/packages/yoroi-extension/app/utils/wallet.js
@@ -6,6 +6,7 @@ import type {
     TokenLookupKey,
     MultiToken
 } from '../api/common/lib/MultiToken';
+import { getImageFromTokenMetadata } from './nftMetadata';
 
 export type FormattedTokenDisplay = {|
     value?: number,
@@ -66,19 +67,10 @@ export const getNFTs: GetNFTFunc = (spendableBalance, getTokenInfo) => {
         return {
             name,
             id: getTokenIdentifierIfExists(token.info) ?? '-',
-            amount: genFormatTokenAmount(getTokenInfo)(token.entry),
-            policyId,
-            // $FlowFixMe[prop-missing]
-            nftMetadata: token.info.Metadata.assetMintMetadata?.[0]?.['721']?.[policyId][name],
+            image: getImageFromTokenMetadata(policyId, name, token.info.Metadata),
             info: token.info,
         };
-    })
-    .map(item => ({
-        name: item.name,
-        image: item.nftMetadata?.image,
-        id: item.id,
-        info: item.info,
-    }));
+    });
 }
 
 export function checkNFTImage(imageSrc: string, onload: void => void, onerror: void => void): void {

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -88,7 +88,7 @@ import { NotEnoughMoneyToSendError, } from '../../app/api/common/errors';
 import { asAddressedUtxo as asAddressedUtxoCardano, } from '../../app/api/ada/transactions/utils';
 import ConnectorStore from '../../app/ergo-connector/stores/ConnectorStore';
 import type { ForeignUtxoFetcher } from '../../app/ergo-connector/stores/ConnectorStore';
-import type { CardanoAssetMintMetadata } from '../../app/api/ada/lib/storage/database/primitives/tables';
+import { find721metadata } from '../../app/utils/nftMetadata';
 
 /*::
 declare var chrome;
@@ -1654,34 +1654,6 @@ function handleInjectorConnect(port) {
       }
     }
   });
-}
-
-function find721metadata(
-  policyId: string,
-  assetNameHex: string,
-  assetMintMetadata: ?Array<CardanoAssetMintMetadata>,
-): any {
-  if (!assetMintMetadata) {
-    return null;
-  }
-  const metadataWrapper = assetMintMetadata.find(m => m['721'] != null);
-  if (metadataWrapper === undefined) {
-    return null;
-  }
-  const metadata = metadataWrapper['721'];
-  if (metadata.version && metadata.version !== '1.0') {
-    return null;
-  }
-
-  const assetName = Array.from(Buffer.from(assetNameHex, 'hex')).map(
-    c => String.fromCharCode(c)
-  ).join('');
-  const asset = metadata[policyId]?.[assetName] || metadata[policyId]?.[assetNameHex];
-  if (!asset) {
-    return null;
-  }
-
-  return asset;
 }
 
 function assetToRustMultiasset(jsonAssets): RustModule.WalletV4.MultiAsset {


### PR DESCRIPTION
NFT metadata is defined by https://cips.cardano.org/cips/cip25/ . The lifecycle of the metadata is:

minting tx -> blockchain -> db-sync -> Yoroi backend db -> /multiAsset/metadata endpoint -> Yoroi extension storage -> Yoroi extension UI 

Currently, there are some problems with the handling of NFT metadata:
1. The type definition in Yoroi-frontend is not strong enough, `any` types are used.
2. The `image` and `description` fields are assumed to be strings, but according to the spec they can be arrays of strings.
3. Most importantly, the values of the metadata are not checked. They are just cast from `any` to `CardanoAssetMintMetadata`, which flow is happy to accept but without guaranteeing the actual value conforms to the type.

This PR addresses these problems but correctly strong-typing the NFT metadata and adding run-time checks.