### PR TITLE
paginate request to mint metadata

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/batchedFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/batchedFetcher.js
@@ -108,7 +108,7 @@ export class BatchedFetcher implements IFetcher {
       const { network, assets } = body;
       const assetChunks = chunk(assets, MINT_METADATA_REQUEST_PAGE_SIZE);
       const responses = await Promise.all(assetChunks.map(
-        chunk => this.baseFetcher.getMultiAssetMintMetadata({ network, assets: chunk })
+        assets => this.baseFetcher.getMultiAssetMintMetadata({ network, assets })
       ));
       const result = {};
       for (const response of responses) {

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/batchedFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/batchedFetcher.js
@@ -108,7 +108,7 @@ export class BatchedFetcher implements IFetcher {
       const { network, assets } = body;
       const assetChunks = chunk(assets, MINT_METADATA_REQUEST_PAGE_SIZE);
       const responses = await Promise.all(assetChunks.map(
-        assets => this.baseFetcher.getMultiAssetMintMetadata({ network, assets })
+        batch => this.baseFetcher.getMultiAssetMintMetadata({ network, assets: batch })
       ));
       const result = {};
       for (const response of responses) {

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/batchedFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/batchedFetcher.js
@@ -53,6 +53,8 @@ import config from '../../../../config';
 declare var CONFIG: ConfigType;
 const addressesLimit = CONFIG.app.addressRequestSize;
 
+const MINT_METADATA_REQUEST_PAGE_SIZE = 100;
+
 /**
  * Makes calls to Yoroi backend service
  * https://github.com/Emurgo/yoroi-graphql-migration-backend
@@ -100,10 +102,22 @@ export class BatchedFetcher implements IFetcher {
     this.baseFetcher.sendTx(body)
   )
 
-  getMultiAssetMintMetadata: MultiAssetMintMetadataRequest
-    => Promise<MultiAssetMintMetadataResponse> = (body) => (
-    this.baseFetcher.getMultiAssetMintMetadata(body)
-  )
+  getMultiAssetMintMetadata
+  : MultiAssetMintMetadataRequest => Promise<MultiAssetMintMetadataResponse>
+    = async (body) => {
+      const { network, assets } = body;
+      const assetChunks = chunk(assets, MINT_METADATA_REQUEST_PAGE_SIZE);
+      const responses = await Promise.all(assetChunks.map(
+        chunk => this.baseFetcher.getMultiAssetMintMetadata({ network, assets: chunk })
+      ));
+      const result = {};
+      for (const response of responses) {
+        for (const [key, value] of Object.entries(response)) {
+          result[key] = value;
+        }
+      }
+      return result;
+    }
 
   getAccountState: AccountStateRequest => Promise<AccountStateResponse> = (body) => (
     batchGetAccountState(this.baseFetcher.getAccountState)(body)


### PR DESCRIPTION
The backend has a request size limit:
https://github.com/Emurgo/yoroi-graphql-migration-backend/blob/master/src/services/multiAssetTxMint.ts#L62
So the front-end must paginate the request