### PR TITLE
Make backend error messages visible in the logs

### DIFF
--- a/packages/yoroi-extension/app/api/ada/index.js
+++ b/packages/yoroi-extension/app/api/ada/index.js
@@ -2,7 +2,7 @@
 import moment from 'moment';
 import BigNumber from 'bignumber.js';
 import type { lf$Database } from 'lovefield';
-import { Logger, stringifyData, stringifyError } from '../../utils/logging';
+import { fullErrStr, Logger, stringifyData, stringifyError } from '../../utils/logging';
 import CardanoByronTransaction from '../../domain/CardanoByronTransaction';
 import CardanoShelleyTransaction from '../../domain/CardanoShelleyTransaction';
 import {
@@ -862,13 +862,14 @@ export default class AdaApi {
         request.signRequest.metadata,
       );
 
-      const response = request.sendTx({
+      const response = await request.sendTx({
         network: request.publicDeriver.getParent().getNetworkInfo(),
         id: Buffer.from(
           RustModule.WalletV4.hash_transaction(signedTx.body()).to_bytes()
         ).toString('hex'),
         encodedTx: signedTx.to_bytes(),
       });
+
       Logger.debug(
         `${nameof(AdaApi)}::${nameof(this.signAndBroadcast)} success: ` + stringifyData(response)
       );
@@ -877,7 +878,8 @@ export default class AdaApi {
       if (error instanceof WrongPassphraseError) {
         throw new IncorrectWalletPasswordError();
       }
-      Logger.error(`${nameof(AdaApi)}::${nameof(this.signAndBroadcast)} error: ` + stringifyError(error));
+
+      Logger.error(`${nameof(AdaApi)}::${nameof(this.signAndBroadcast)} error: ${fullErrStr(error)}` );
       if (error instanceof InvalidWitnessError) {
         throw new InvalidWitnessError();
       }

--- a/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
+++ b/packages/yoroi-extension/app/api/ada/lib/state-fetch/remoteFetcher.js
@@ -300,7 +300,12 @@ export class RemoteFetcher implements IFetcher {
       txId: body.id
     }))
       .catch((error) => {
-        Logger.error(`${nameof(RemoteFetcher)}::${nameof(this.sendTx)} error: ` + stringifyError(error));
+        const err = {
+          msg: error.message,
+          res: error.response?.data || null,
+        }
+
+        Logger.error(`${nameof(RemoteFetcher)}::${nameof(this.sendTx)} error: ${stringifyError(err)}`);
         if (error.request.response.includes('Invalid witness')) {
           throw new InvalidWitnessError();
         }

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/transactions.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/transactions.js
@@ -614,7 +614,8 @@ function _newAdaUnsignedTxFromUtxo(
     );
     txBuilder.set_withdrawals(withdrawalWasm);
   }
-  txBuilder.set_ttl(absSlotNumber.plus(defaultTtlOffset).toNumber());
+  // txBuilder.set_ttl(absSlotNumber.plus(defaultTtlOffset).toNumber());
+  txBuilder.set_ttl(100);
 
   function addOutput(output: TxOutput): void {
     const wasmReceiver = normalizeToAddress(output.address);

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/transactions.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/transactions.js
@@ -614,8 +614,7 @@ function _newAdaUnsignedTxFromUtxo(
     );
     txBuilder.set_withdrawals(withdrawalWasm);
   }
-  // txBuilder.set_ttl(absSlotNumber.plus(defaultTtlOffset).toNumber());
-  txBuilder.set_ttl(100);
+  txBuilder.set_ttl(absSlotNumber.plus(defaultTtlOffset).toNumber());
 
   function addOutput(output: TxOutput): void {
     const wasmReceiver = normalizeToAddress(output.address);

--- a/packages/yoroi-extension/app/stores/ada/send/AdaMnemonicSendStore.js
+++ b/packages/yoroi-extension/app/stores/ada/send/AdaMnemonicSendStore.js
@@ -3,8 +3,8 @@
 import Store from '../../base/Store';
 import { HaskellShelleyTxSignRequest } from '../../../api/ada/transactions/shelley/HaskellShelleyTxSignRequest';
 import {
+  fullErrStr,
   Logger,
-  stringifyError,
 } from '../../../utils/logging';
 import { PublicDeriver } from '../../../api/ada/lib/storage/models/PublicDeriver/index';
 import {
@@ -124,7 +124,7 @@ export default class AdaMnemonicSendStore extends Store<StoresMap, ActionsMap> {
       );
       return { txId };
     } catch (error) {
-      Logger.error(`${nameof(AdaMnemonicSendStore)}::${nameof(this.signAndBroadcast)} error: ` + stringifyError(error));
+      Logger.error(`${nameof(AdaMnemonicSendStore)}::${nameof(this.signAndBroadcast)} error: ${fullErrStr(error)}` );
       throw error;
     }
   }

--- a/packages/yoroi-extension/app/utils/logging.js
+++ b/packages/yoroi-extension/app/utils/logging.js
@@ -77,3 +77,9 @@ export const stringifyData = (data : any): string => inspect(data);
 export const stringifyError = (error : any): string => (
   JSON.stringify(error, Object.getOwnPropertyNames(error), 2)
 );
+
+// It should convert all error object into json
+// Unlinke `stringifyError` which use a `replacer` to select some fields
+export const fullErrStr = (err: any): string  => (
+  JSON.stringify(err, null, 2)
+)

--- a/packages/yoroi-extension/app/utils/logging.js
+++ b/packages/yoroi-extension/app/utils/logging.js
@@ -78,8 +78,8 @@ export const stringifyError = (error : any): string => (
   JSON.stringify(error, Object.getOwnPropertyNames(error), 2)
 );
 
-// It should convert all error object into json
-// Unlinke `stringifyError` which use a `replacer` to select some fields
+// It should convert the whole error object into json
+// Unlike `stringifyError` which use a `replacer` to select some fields
 export const fullErrStr = (err: any): string  => (
   JSON.stringify(err, null, 2)
 )


### PR DESCRIPTION
Original description [YOEXT-417](https://emurgo.atlassian.net/browse/YOEXT-417) 

### Note
To prevent unnecessary duplication of the error message. The error message is logged at the source which is the catch block for the failed endpoint. 

The error stack should look like this 
```
 RemoteFetcher::sendTx error <Main Message>
AdaApi::signAndBroadcast ...
AdaMnemonicSendStore::signAndBroadcast...

```
<details>
<summary>Logs example</summary>

```
[INFO] Yoroi v.4.16.200
[INFO] Commit: 83e248487c15959fa08b05db2f5809904eae6b85
[INFO] Network: mainnet
[INFO] User Agent: { ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
  browser: { name: 'Chrome', version: '104.0.0.0', major: '104' },
  engine: { name: 'Blink', version: '104.0.0.0' },
  os: { name: 'Mac OS', version: '10.15.7' },
  device: { vendor: undefined, model: undefined, type: undefined },
  cpu: { architecture: undefined } }
----
[2022-08-24T14:05:57+02:00] RemoteFetcher::sendTx error: {
  "msg": "Request failed with status code 400",
  "res": "transaction submit error ShelleyTxValidationError
 ShelleyBasedEraBabbage (ApplyTxError [UtxowFailure (UtxoFailure (FromAlonzoUtxoFail (OutsideValidityIntervalUTxO (ValidityInterval {invalidBefore = SNothing, 
invalidHereafter = SJust (SlotNo 100)}) (SlotNo 66973479))))])"
}
[2022-08-24T14:05:57+02:00] AdaApi::signAndBroadcast error: {
  "id": "api.errors.sendTransactionApiError",
  "defaultMessage": "!!!Error received from server while sending tx.",
  "values": {}
}
[2022-08-24T14:05:57+02:00] AdaMnemonicSendStore::signAndBroadcast error: {
  "id": "api.errors.sendTransactionApiError",
  "defaultMessage": "!!!Error received from server while sending tx.",
  "values": {}
}
```
</details>