### PR TITLE
Make the `revamp` is the new default theme

### DIFF
--- a/packages/yoroi-extension/app/containers/profile/LanguageSelectionPage.js
+++ b/packages/yoroi-extension/app/containers/profile/LanguageSelectionPage.js
@@ -49,11 +49,15 @@ export default class LanguageSelectionPage extends Component<InjectedOrGenerated
     }
 
     await this.generated.actions.profile.resetLocale.trigger();
-    // Make`revamp` the default theme when it's the first time to install Yoroi.
-    // Do it here as this is the first screen users see.
-    await this.generated.actions.profile.updateTheme.trigger({
-      theme: THEMES.YOROI_REVAMP
-    });
+
+    // Todo: Should be removed with the first release
+    if (environment.isNightly() || environment.isDev()) {
+      // Make`revamp` the default theme when it's the first time to install Yoroi.
+      // Do it here as this is the first screen users see.
+      await this.generated.actions.profile.updateTheme.trigger({
+        theme: THEMES.YOROI_REVAMP
+      });
+    }
   }
 
   onSelectLanguage: {| locale: string |} => void = (values) => {

--- a/packages/yoroi-extension/app/containers/profile/LanguageSelectionPage.js
+++ b/packages/yoroi-extension/app/containers/profile/LanguageSelectionPage.js
@@ -51,7 +51,7 @@ export default class LanguageSelectionPage extends Component<InjectedOrGenerated
     await this.generated.actions.profile.resetLocale.trigger();
     // Make`revamp` the default theme when it's the first time to install Yoroi.
     // Do it here as this is the first screen users see.
-    this.generated.actions.profile.updateTheme.trigger({
+    await this.generated.actions.profile.updateTheme.trigger({
       theme: THEMES.YOROI_REVAMP
     });
   }
@@ -116,6 +116,11 @@ export default class LanguageSelectionPage extends Component<InjectedOrGenerated
         |},
         resetLocale: {|
           trigger: (params: void) => Promise<void>
+        |},
+        updateTheme: {|
+          trigger: (params: {|
+            theme: string,
+          |}) => Promise<void>,
         |},
         updateTentativeLocale: {|
           trigger: (params: {| locale: string |}) => void

--- a/packages/yoroi-extension/app/containers/profile/LanguageSelectionPage.js
+++ b/packages/yoroi-extension/app/containers/profile/LanguageSelectionPage.js
@@ -20,6 +20,7 @@ import LocalizableError from '../../i18n/LocalizableError';
 import type { ServerStatusErrorType } from '../../types/serverStatusErrorType';
 import { PublicDeriver } from '../../api/ada/lib/storage/models/PublicDeriver/index';
 import { isTestnet } from '../../api/ada/lib/storage/database/prepackaged/networks';
+import { THEMES } from '../../styles/utils';
 
 const messages = defineMessages({
   title: {
@@ -48,6 +49,11 @@ export default class LanguageSelectionPage extends Component<InjectedOrGenerated
     }
 
     await this.generated.actions.profile.resetLocale.trigger();
+    // Make`revamp` the default theme when it's the first time to install Yoroi.
+    // Do it here as this is the first screen users see.
+    this.generated.actions.profile.updateTheme.trigger({
+      theme: THEMES.YOROI_REVAMP
+    });
   }
 
   onSelectLanguage: {| locale: string |} => void = (values) => {
@@ -163,6 +169,7 @@ export default class LanguageSelectionPage extends Component<InjectedOrGenerated
       actions: {
         profile: {
           resetLocale: { trigger: actions.profile.resetLocale.trigger },
+          updateTheme: { trigger: actions.profile.updateTheme.trigger },
           updateTentativeLocale: { trigger: actions.profile.updateTentativeLocale.trigger },
           commitLocaleToStorage: { trigger: actions.profile.commitLocaleToStorage.trigger },
         },

--- a/packages/yoroi-extension/app/containers/profile/LanguageSelectionPage.stories.js
+++ b/packages/yoroi-extension/app/containers/profile/LanguageSelectionPage.stories.js
@@ -47,6 +47,7 @@ export const Generic = (): Node => (
           resetLocale: { trigger: async (req) => action('resetLocale')(req) },
           updateTentativeLocale: { trigger: action('updateTentativeLocale') },
           commitLocaleToStorage: { trigger: async (req) => action('commitLocaleToStorage')(req) },
+          updateTheme: { trigger: async (req) => action('updateTheme')(req) },
         }
       }
     }}
@@ -86,6 +87,7 @@ export const NonTier1 = (): Node => (
           resetLocale: { trigger: async (req) => action('resetLocale')(req) },
           updateTentativeLocale: { trigger: action('updateTentativeLocale') },
           commitLocaleToStorage: { trigger: async (req) => action('commitLocaleToStorage')(req) },
+          updateTheme: { trigger: async (req) => action('updateTheme')(req) },
         }
       }
     }}
@@ -122,6 +124,7 @@ export const IsExecuting = (): Node => (
           resetLocale: { trigger: async (req) => action('resetLocale')(req) },
           updateTentativeLocale: { trigger: action('updateTentativeLocale') },
           commitLocaleToStorage: { trigger: async (req) => action('commitLocaleToStorage')(req) },
+          updateTheme: { trigger: async (req) => action('updateTheme')(req) },
         }
       }
     }}
@@ -154,6 +157,7 @@ export const ServerError = (): Node => (
           resetLocale: { trigger: async (req) => action('resetLocale')(req) },
           updateTentativeLocale: { trigger: action('updateTentativeLocale') },
           commitLocaleToStorage: { trigger: async (req) => action('commitLocaleToStorage')(req) },
+          updateTheme: { trigger: async (req) => action('updateTheme')(req) },
         }
       }
     }}


### PR DESCRIPTION
The switch should only be applied to the `nightly` and `dev` build.

Jira [Default new users to the revamp version (and announcement)](https://emurgo.atlassian.net/browse/YOEXT-314)