### PR TITLE
Clean up the connector

### DIFF
--- a/packages/yoroi-extension/app/ergo-connector/actions/connector-actions.js
+++ b/packages/yoroi-extension/app/ergo-connector/actions/connector-actions.js
@@ -4,8 +4,6 @@ import type { WhitelistEntry } from '../../../chrome/extension/ergo-connector/ty
 // ======= CONNECTOR ACTIONS =======
 
 export default class ConnectorActions {
-  getResponse: AsyncAction<void> = new AsyncAction();
-  getSigningMsg: AsyncAction<void> = new AsyncAction();
   refreshActiveSites: AsyncAction<void> = new AsyncAction();
   refreshWallets: AsyncAction<void> = new AsyncAction();
   closeWindow: Action<void> = new Action();

--- a/packages/yoroi-extension/app/ergo-connector/containers/ConnectContainer.js
+++ b/packages/yoroi-extension/app/ergo-connector/containers/ConnectContainer.js
@@ -195,9 +195,6 @@ export default class ConnectContainer extends Component<
   @computed get generated(): {|
     actions: {|
       connector: {|
-        getResponse: {|
-          trigger: (params: void) => Promise<void>,
-        |},
         refreshWallets: {|
           trigger: (params: void) => Promise<void>,
         |},
@@ -269,7 +266,6 @@ export default class ConnectContainer extends Component<
       },
       actions: {
         connector: {
-          getResponse: { trigger: actions.connector.getResponse.trigger },
           refreshWallets: { trigger: actions.connector.refreshWallets.trigger },
           closeWindow: { trigger: actions.connector.closeWindow.trigger },
           getConnectorWhitelist: { trigger: actions.connector.getConnectorWhitelist.trigger },

--- a/packages/yoroi-extension/app/ergo-connector/containers/ConnectContainer.js
+++ b/packages/yoroi-extension/app/ergo-connector/containers/ConnectContainer.js
@@ -57,7 +57,6 @@ export default class ConnectContainer extends Component<
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     this.generated.actions.connector.refreshWallets.trigger();
-    this.generated.actions.connector.getConnectorWhitelist.trigger();
     window.addEventListener('unload', this.onUnload);
   }
 
@@ -201,9 +200,6 @@ export default class ConnectContainer extends Component<
         closeWindow: {|
           trigger: (params: void) => void,
         |},
-        getConnectorWhitelist: {|
-          trigger: (params: void) => Promise<void>,
-        |},
         updateHideBalance: {|
           trigger: (params: void) => Promise<void>,
         |},
@@ -268,7 +264,6 @@ export default class ConnectContainer extends Component<
         connector: {
           refreshWallets: { trigger: actions.connector.refreshWallets.trigger },
           closeWindow: { trigger: actions.connector.closeWindow.trigger },
-          getConnectorWhitelist: { trigger: actions.connector.getConnectorWhitelist.trigger },
           updateConnectorWhitelist: { trigger: actions.connector.updateConnectorWhitelist.trigger },
           updateHideBalance: { trigger: actions.profile.updateHideBalance.trigger },
         },

--- a/packages/yoroi-extension/app/ergo-connector/containers/ConnectContainer.stories.js
+++ b/packages/yoroi-extension/app/ergo-connector/containers/ConnectContainer.stories.js
@@ -92,7 +92,6 @@ export const Generic = (): Node => {
         },
         actions: {
           connector: {
-            getResponse: { trigger: async (req) => action('getResponse')(req) },
             getConnectorWhitelist: { trigger: async (req) => action('getConnectorWhitelist')(req) },
             updateConnectorWhitelist: { trigger: async (req) => action('updateConnectorWhitelist')(req) },
             refreshWallets: { trigger: async (req) => action('refreshWallets')(req) },

--- a/packages/yoroi-extension/app/ergo-connector/containers/ConnectContainer.stories.js
+++ b/packages/yoroi-extension/app/ergo-connector/containers/ConnectContainer.stories.js
@@ -92,7 +92,6 @@ export const Generic = (): Node => {
         },
         actions: {
           connector: {
-            getConnectorWhitelist: { trigger: async (req) => action('getConnectorWhitelist')(req) },
             updateConnectorWhitelist: { trigger: async (req) => action('updateConnectorWhitelist')(req) },
             refreshWallets: { trigger: async (req) => action('refreshWallets')(req) },
             closeWindow: { trigger: action('closeWindow') },

--- a/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
@@ -29,16 +29,13 @@ import type {
 import { LoadingWalletStates } from '../types';
 import { getWallets } from '../../api/common/index';
 import {
-  getCardanoHaskellBaseConfig,
   getErgoBaseConfig,
   isCardanoHaskell,
   isErgo,
 } from '../../api/ada/lib/storage/database/prepackaged/networks';
 import {
-  asGetAllUtxos,
   asGetBalance,
   asGetPublicKey,
-  asHasUtxoChains,
   asGetSigningKey,
   asHasLevels,
 } from '../../api/ada/lib/storage/models/PublicDeriver/traits';
@@ -52,7 +49,6 @@ import { toRemoteUtxo } from '../../api/ergo/lib/transactions/utils';
 import { mintedTokenInfo } from '../../../chrome/extension/ergo-connector/utils';
 import { Logger } from '../../utils/logging';
 import { asAddressedUtxo, multiTokenFromCardanoValue, multiTokenFromRemote, } from '../../api/ada/transactions/utils';
-import { genTimeToSlot, } from '../../api/ada/lib/storage/bridge/timeUtils';
 import {
   connectorGetUsedAddresses,
   connectorGetUnusedAddresses,

--- a/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
@@ -249,7 +249,6 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
 
   setup(): void {
     super.setup();
-    this.actions.connector.getResponse.listen(this._getConnectingMsg);
     this.actions.connector.getConnectorWhitelist.listen(this._getConnectorWhitelist);
     this.actions.connector.updateConnectorWhitelist.listen(this._updateConnectorWhitelist);
     this.actions.connector.removeWalletFromWhitelist.listen(this._removeWalletFromWhitelist);
@@ -257,7 +256,6 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
       this._confirmSignInTx(password);
     });
     this.actions.connector.cancelSignInTx.listen(this._cancelSignInTx);
-    this.actions.connector.getSigningMsg.listen(this._getSigningMsg);
     this.actions.connector.refreshActiveSites.listen(this._refreshActiveSites);
     this.actions.connector.refreshWallets.listen(this._getWallets);
     this.actions.connector.closeWindow.listen(this._closeWindow);

--- a/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
+++ b/packages/yoroi-extension/app/ergo-connector/stores/ConnectorStore.js
@@ -249,7 +249,6 @@ export default class ConnectorStore extends Store<StoresMap, ActionsMap> {
 
   setup(): void {
     super.setup();
-    this.actions.connector.getConnectorWhitelist.listen(this._getConnectorWhitelist);
     this.actions.connector.updateConnectorWhitelist.listen(this._updateConnectorWhitelist);
     this.actions.connector.removeWalletFromWhitelist.listen(this._removeWalletFromWhitelist);
     this.actions.connector.confirmSignInTx.listen((password) => {

--- a/packages/yoroi-extension/chrome/extension/ergo-connector/types.js
+++ b/packages/yoroi-extension/chrome/extension/ergo-connector/types.js
@@ -463,10 +463,6 @@ export type PendingSignData = {|
   uid: RpcUid,
   tx: CardanoTx,
 |} | {|
-  type: 'tx-create-req/cardano',
-  uid: RpcUid,
-  tx: CardanoTxRequest,
-|} | {|
   type: 'tx-reorg/cardano',
   uid: RpcUid,
   tx: {|


### PR DESCRIPTION
Some dead code are removed:
1. The signing request type `tx-create-req/cardano` and its handler function is removed. This request type was there when the `createTx` connector API signs the created tx.

2. The `getResponse` and `getSigningMsg` actions are removed. They are not used at all.

3. The `getConnectorWhitelist` action is removed from `ConnectorStore` and `ConnectorContainer`. It's unnecessary for the `ConnectorContainer` to trigger the action in `ConnectorStore` because the latter calls `this._getConnectorWhitelist()` in `setup()`. The action is only used by `DappConnectorStore` and `ConnectedWebsitesContainer`.