### PR TITLE
Support array-based IPFS image URLs for NFTs

### DIFF
--- a/packages/yoroi-extension/app/utils/nftMetadata.js
+++ b/packages/yoroi-extension/app/utils/nftMetadata.js
@@ -100,8 +100,11 @@ export function getImageFromTokenMetadata(
   if (typeof nftMetadata.image === 'string') {
     return nftMetadata.image;
   }
-  if (typeof nftMetadata.image?.[0] === 'string') {
-    return nftMetadata.image[0];
+  if (
+    isArray(nftMetadata.image) &&
+      nftMetadata.image.every(s => typeof s === 'string')
+  ) {
+    return nftMetadata.image.join('');
   }
   return null;
 }


### PR DESCRIPTION
This PR enables support for array-based IPFS image URLs in NFT metadata, e.g.

```
     image: [
            "ipfs://",
            "bafybeidreetdv5a4b7sc3iufvadrolhylkezlfcfkqaicvydicrlxmbwn4"
         ],
```
Currently, only the first string of an array is taken into account. This results in an invalid image URL for the above case.

This PR proposes to merge all strings in the image array and use that as the URL.

Fix for #3057

