### PR TITLE
minimize ledger manual test panel when double-clicked

### DIFF
--- a/packages/yoroi-extension/ledger/components/manual-test/TestBlock.scss
+++ b/packages/yoroi-extension/ledger/components/manual-test/TestBlock.scss
@@ -1,4 +1,5 @@
 .component {
+  overflow: hidden;
   position: absolute;
   display: flex;
   z-index: 1;
@@ -50,8 +51,8 @@
   }  
 }
 .visible {
-  opacity: 1;
 }
 .hidden {
-  opacity: 0;
+  width: 10px;
+  height: 10px;
 }


### PR DESCRIPTION
The manual test panel of Ledger UI may block the buttons even when hidden. This PR fixes it.