### PR TITLE
Fix Staking page crash when using non-reward wallet (Not Shelly)

### DIFF
--- a/packages/yoroi-extension/app/containers/NavBarContainerRevamp.js
+++ b/packages/yoroi-extension/app/containers/NavBarContainerRevamp.js
@@ -48,11 +48,10 @@ export default class NavBarContainerRevamp extends Component<Props> {
 
   onSelectWallet: (PublicDeriver<>) => void = newWallet => {
     const { delegation, app } = this.generated.stores;
-    const delegationRequest = delegation.getDelegationRequests(newWallet);
-    const isRewardWallet = delegationRequest == null;
+    const isRewardWallet = !!delegation.getDelegationRequests(newWallet);
     const isStakingPage = app.currentRoute === ROUTES.STAKING;
 
-    const route = isRewardWallet && isStakingPage ? ROUTES.WALLETS.ROOT : app.currentRoute;
+    const route = !isRewardWallet && isStakingPage ? ROUTES.WALLETS.ROOT : app.currentRoute;
     this.generated.actions.router.goToRoute.trigger({ route, publicDeriver: newWallet });
   };
 

--- a/packages/yoroi-extension/app/containers/NavBarContainerRevamp.js
+++ b/packages/yoroi-extension/app/containers/NavBarContainerRevamp.js
@@ -47,10 +47,13 @@ export default class NavBarContainerRevamp extends Component<Props> {
   };
 
   onSelectWallet: (PublicDeriver<>) => void = newWallet => {
-    this.generated.actions.router.goToRoute.trigger({
-      route: this.generated.stores.app.currentRoute,
-      publicDeriver: newWallet,
-    });
+    const { delegation, app } = this.generated.stores;
+    const delegationRequest = delegation.getDelegationRequests(newWallet);
+    const isRewardWallet = delegationRequest == null;
+    const isStakingPage = app.currentRoute === ROUTES.STAKING;
+
+    const route = isRewardWallet && isStakingPage ? ROUTES.WALLETS.ROOT : app.currentRoute;
+    this.generated.actions.router.goToRoute.trigger({ route, publicDeriver: newWallet });
   };
 
   openDialogWrapper: any => void = dialog => {

--- a/packages/yoroi-extension/app/containers/SidebarContainer.js
+++ b/packages/yoroi-extension/app/containers/SidebarContainer.js
@@ -69,6 +69,9 @@ class SidebarContainer extends Component<AllProps> {
             hasAnyWallets: this.generated.stores.wallets.hasAnyWallets,
             selected: this.generated.stores.wallets.selected,
             currentRoute: this.generated.stores.app.currentRoute,
+            isRewardWallet: (
+              publicDeriver: PublicDeriver<>
+              ) => !!this.generated.stores.delegation.getDelegationRequests(publicDeriver),
           })
         )}
       />
@@ -104,6 +107,9 @@ class SidebarContainer extends Component<AllProps> {
         hasAnyWallets: boolean,
         selected: null | PublicDeriver<>,
       |},
+      delegation: {|
+        getDelegationRequests: (PublicDeriver<>) => void | DelegationRequests,
+      |},
     |},
   |} {
     if (this.props.generated !== undefined) {
@@ -124,6 +130,9 @@ class SidebarContainer extends Component<AllProps> {
         wallets: {
           selected: stores.wallets.selected,
           hasAnyWallets: stores.wallets.hasAnyWallets,
+        },
+        delegation: {
+          getDelegationRequests: stores.delegation.getDelegationRequests
         },
       },
       actions: {

--- a/packages/yoroi-extension/app/containers/SidebarContainer.js
+++ b/packages/yoroi-extension/app/containers/SidebarContainer.js
@@ -29,24 +29,24 @@ class SidebarContainer extends Component<AllProps> {
   };
 
   render(): Node {
-    const { stores } = this.generated;
+    const { stores, actions } = this.generated;
     const { profile } = stores;
 
     const SidebarComponent = (
       <Sidebar
         onCategoryClicked={category => {
-          this.generated.actions.router.goToRoute.trigger({
+          actions.router.goToRoute.trigger({
             route: category.route,
           });
         }}
         isActiveCategory={category =>
-          this.generated.stores.app.currentRoute.startsWith(category.route)
+          stores.app.currentRoute.startsWith(category.route)
         }
         categories={allCategories.filter(category =>
           category.isVisible({
-            hasAnyWallets: this.generated.stores.wallets.hasAnyWallets,
-            selected: this.generated.stores.wallets.selected,
-            currentRoute: this.generated.stores.app.currentRoute,
+            hasAnyWallets: stores.wallets.hasAnyWallets,
+            selected: stores.wallets.selected,
+            currentRoute: stores.app.currentRoute,
           })
         )}
         onToggleSidebar={this.toggleSidebar}
@@ -57,13 +57,11 @@ class SidebarContainer extends Component<AllProps> {
     const SidebarRevampComponent = (
       <SidebarRevamp
         onCategoryClicked={category => {
-          this.generated.actions.router.goToRoute.trigger({
+          actions.router.goToRoute.trigger({
             route: category.route,
           });
         }}
-        isActiveCategory={category =>
-          this.generated.stores.app.currentRoute.startsWith(category.route)
-        }
+        isActiveCategory={category => stores.app.currentRoute.startsWith(category.route)}
         categories={allCategoriesRevamp.filter(category =>
           category.isVisible({
             hasAnyWallets: this.generated.stores.wallets.hasAnyWallets,
@@ -71,7 +69,7 @@ class SidebarContainer extends Component<AllProps> {
             currentRoute: this.generated.stores.app.currentRoute,
             isRewardWallet: (
               publicDeriver: PublicDeriver<>
-              ) => !!this.generated.stores.delegation.getDelegationRequests(publicDeriver),
+              ) => !!stores.delegation.getDelegationRequests(publicDeriver),
           })
         )}
       />

--- a/packages/yoroi-extension/app/containers/SidebarContainer.js
+++ b/packages/yoroi-extension/app/containers/SidebarContainer.js
@@ -10,6 +10,7 @@ import { PublicDeriver } from '../api/ada/lib/storage/models/PublicDeriver';
 import SidebarRevamp from '../components/topbar/SidebarRevamp';
 import { withLayout } from '../styles/context/layout';
 import type { LayoutComponentMap } from '../styles/context/layout';
+import type { DelegationRequests } from '../stores/toplevel/DelegationStore';
 
 export type GeneratedData = typeof SidebarContainer.prototype.generated;
 
@@ -67,9 +68,8 @@ class SidebarContainer extends Component<AllProps> {
             hasAnyWallets: this.generated.stores.wallets.hasAnyWallets,
             selected: this.generated.stores.wallets.selected,
             currentRoute: this.generated.stores.app.currentRoute,
-            isRewardWallet: (
-              publicDeriver: PublicDeriver<>
-              ) => !!stores.delegation.getDelegationRequests(publicDeriver),
+            isRewardWallet: (publicDeriver: PublicDeriver<>) =>
+              stores.delegation.getDelegationRequests(publicDeriver) != null,
           })
         )}
       />

--- a/packages/yoroi-extension/app/containers/settings/Settings.mock.js
+++ b/packages/yoroi-extension/app/containers/settings/Settings.mock.js
@@ -54,6 +54,9 @@ export const mockSettingsProps: {
             selected: request.selected,
           },
           app: { currentRoute: request.location },
+          delegation: {
+            getDelegationRequests: () => undefined,
+          },
         },
         actions: {
           profile: {

--- a/packages/yoroi-extension/app/containers/transfer/Transfer.mock.js
+++ b/packages/yoroi-extension/app/containers/transfer/Transfer.mock.js
@@ -71,6 +71,9 @@ export const mockTransferProps: {
             selected: request.selected,
           },
           app: { currentRoute: request.currentRoute },
+          delegation: {
+            getDelegationRequests: () => undefined,
+          },
         },
         actions: {
           profile: {

--- a/packages/yoroi-extension/app/containers/wallet/MyWalletsPage.stories.js
+++ b/packages/yoroi-extension/app/containers/wallet/MyWalletsPage.stories.js
@@ -153,6 +153,9 @@ const genBaseProps: {|
           profile: {
             isSidebarExpanded: false,
           },
+          delegation: {
+            getDelegationRequests: () => undefined,
+          },
         },
         actions: {
           profile: {

--- a/packages/yoroi-extension/app/containers/wallet/Wallet.mock.js
+++ b/packages/yoroi-extension/app/containers/wallet/Wallet.mock.js
@@ -79,6 +79,9 @@ export const mockWalletProps: {
           profile: {
             isSidebarExpanded: false,
           },
+          delegation: {
+            getDelegationRequests: () => undefined,
+          },
         },
         actions: {
           profile: {

--- a/packages/yoroi-extension/app/containers/wallet/WalletAddPage.stories.js
+++ b/packages/yoroi-extension/app/containers/wallet/WalletAddPage.stories.js
@@ -148,6 +148,9 @@ const defaultProps: {|
           selected: null,
         },
         app: { currentRoute: ROUTES.WALLETS.ADD },
+        delegation: {
+          getDelegationRequests: () => undefined,
+        },
       },
       actions: {
         profile: {

--- a/packages/yoroi-extension/app/stores/stateless/sidebarCategories.js
+++ b/packages/yoroi-extension/app/stores/stateless/sidebarCategories.js
@@ -114,7 +114,10 @@ type isVisibleFunc = ({|
     hasAnyWallets: boolean,
     selected: null | PublicDeriver<>,
     currentRoute: string,
+    isRewardWallet: isRewardWalletFunc,
   |}) => boolean;
+
+type isRewardWalletFunc = (PublicDeriver<>) => boolean;
 
 export type SidebarCategoryRevamp = {|
   +className: string,

--- a/packages/yoroi-extension/app/stores/stateless/sidebarCategories.js
+++ b/packages/yoroi-extension/app/stores/stateless/sidebarCategories.js
@@ -141,8 +141,10 @@ export const allCategoriesRevamp: Array<SidebarCategoryRevamp> = [
     route: ROUTES.STAKING,
     icon: stakingIcon,
     label: globalMessages.sidebarStaking,
-    isVisible: ({ selected }) => (
-      !!selected && isCardanoHaskell(selected.getParent().getNetworkInfo())
+    isVisible: ({ selected, isRewardWallet }) => (
+      !!selected &&
+      isCardanoHaskell(selected.getParent().getNetworkInfo()) &&
+      isRewardWallet(selected)
     ),
   },
   {


### PR DESCRIPTION
## How to reproduce? 

Switch to the revamped theme and restore a non-reward wallet (not shelly, eg: paper wallet), and then navigate to the staking page. You should see the extension crashes with the error below 

<details> 
  <summary> Screenshot</summary>

![Screen Shot 2023-02-13 at 12 59 22 PM](https://user-images.githubusercontent.com/72753578/218449273-1355f3ef-7508-4e26-9bf1-f6be252cca48.png)

</details> 


## Expected Fix 

- Staking page will not be shown in the first place 
- While the user is on the **staking page** and he decided to switch to another non-reward wallet, the user will be redirected to the TXs page to prevent the extension from crashing. 