### PR TITLE
Fix/yoext 582/design diff fixes

### DIFF
--- a/packages/yoroi-extension/app/components/common/walletInfo/WalletInfo.js
+++ b/packages/yoroi-extension/app/components/common/walletInfo/WalletInfo.js
@@ -13,8 +13,8 @@ import {
   truncateLongName,
   maxNameLengthBeforeTruncation,
 } from '../../../utils/formatters';
-import { ReactComponent as IconEyeOpen } from '../../../assets/images/my-wallets/icon_eye_open.inline.svg';
-import { ReactComponent as IconEyeClosed } from '../../../assets/images/my-wallets/icon_eye_closed.inline.svg';
+import { ReactComponent as IconEyeOpen } from '../../../assets/images/forms/password-eye.inline.svg';
+import { ReactComponent as IconEyeClosed } from '../../../assets/images/forms/password-eye-close.inline.svg';
 import { hiddenAmount } from '../../../utils/strings';
 import { MultiToken } from '../../../api/common/lib/MultiToken';
 import { getTokenName } from '../../../stores/stateless/tokenHelpers';

--- a/packages/yoroi-extension/app/components/wallet/add-wallet-revamp/AddWalletCard.scss
+++ b/packages/yoroi-extension/app/components/wallet/add-wallet-revamp/AddWalletCard.scss
@@ -3,6 +3,7 @@
   border-radius: 8px;
   padding: 16px;
   width: 312px;
+  min-height: 352px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/yoroi-extension/app/components/wallet/restore/RestoreWalletPage.js
+++ b/packages/yoroi-extension/app/components/wallet/restore/RestoreWalletPage.js
@@ -245,7 +245,9 @@ function RestoreWalletPage(props: Props & Intl): Node {
         <Box sx={{ width: '56px', height: '48px', mb: '38px' }}>
           <img src={YoroiLogo} alt="Yoroi" title="Yoroi" />
         </Box>
-        <Typography variant="h3">{intl.formatMessage(messages.title)}</Typography>
+        <Typography variant="h3" fontWeight={500}>
+          {intl.formatMessage(messages.title)}
+        </Typography>
       </Box>
       <Stepper currentStep={currentStep} setCurrentStep={setCurrentStep} steps={stepperSteps} />
       {CurrentStep}

--- a/packages/yoroi-extension/app/components/wallet/restore/steps/phrase/RestoreRecoveryPhraseForm.js
+++ b/packages/yoroi-extension/app/components/wallet/restore/steps/phrase/RestoreRecoveryPhraseForm.js
@@ -208,11 +208,12 @@ export default class RestoreRecoveryPhraseFormClass extends Component<Props, Sta
 
         {!isValidPhrase && (
           <>
-            <Box sx={{ width: '100px' }}>
+            <Box>
               <Button
                 variant="outlined"
                 color="primary"
                 onClick={form.onReset}
+                disabled={!recoveryPhrase.some(word => Boolean(word.value))}
                 sx={{
                   border: 0,
                   height: '1.5rem',
@@ -223,6 +224,7 @@ export default class RestoreRecoveryPhraseFormClass extends Component<Props, Sta
                   minWidth: 0,
                   minHeight: 0,
                   '&:hover': { border: 0 },
+                  '&.Mui-disabled': { border: 0 },
                 }}
               >
                 {intl.formatMessage(messages.clearAll)}

--- a/packages/yoroi-extension/app/components/wallet/restore/steps/type/SelectWalletTypeStep.js
+++ b/packages/yoroi-extension/app/components/wallet/restore/steps/type/SelectWalletTypeStep.js
@@ -50,16 +50,18 @@ function SelectWalletTypeStep(props: Props & Intl): Node {
             label={intl.formatMessage(messages.twentyfourWords)}
           />
         </Box>
-        <StepController
-          actions={[
-            {
-              label: intl.formatMessage(globalMessages.backButtonLabel),
-              disabled: false,
-              onClick: goBack,
-              type: 'secondary',
-            },
-          ]}
-        />
+        <Box mt="74px">
+          <StepController
+            actions={[
+              {
+                label: intl.formatMessage(globalMessages.backButtonLabel),
+                disabled: false,
+                onClick: goBack,
+                type: 'secondary',
+              },
+            ]}
+          />
+        </Box>
       </Stack>
     </Stack>
   );

--- a/packages/yoroi-extension/app/components/wallet/restore/steps/type/SelectWalletTypeStep.scss
+++ b/packages/yoroi-extension/app/components/wallet/restore/steps/type/SelectWalletTypeStep.scss
@@ -4,5 +4,4 @@
   justify-content: center;
   flex-direction: row;
   gap: 24px;
-  margin-top: 24px;
 }


### PR DESCRIPTION
Restore Flow
- Clear all button
- Select type page button margins, cards heights and title weight
- Eye icon on the duplicated wallet modal

More info: [YOEXT-582](https://emurgo.atlassian.net/browse/YOEXT-582)

[YOEXT-582]: https://emurgo.atlassian.net/browse/YOEXT-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ