### PR TITLE
fix(fiat-price): convert date from milliseconds into seconds

### DIFF
--- a/packages/yoroi-extension/app/stores/base/BaseCoinPriceStore.js
+++ b/packages/yoroi-extension/app/stores/base/BaseCoinPriceStore.js
@@ -126,7 +126,8 @@ export default class BaseCoinPriceStore
       return null;
     }
     const lastUpdateTimestamp: number = this.lastUpdateTimestamp;
-    if (Date.now() - lastUpdateTimestamp > CONFIG.app.coinPriceFreshnessThreshold) {
+
+    if (Date.now() / 1_000 - lastUpdateTimestamp > CONFIG.app.coinPriceFreshnessThreshold) {
       return null;
     }
     const normalizedFrom = from === 'TADA' ? 'ADA' : from;


### PR DESCRIPTION
It seems that due to a recent backend update https://github.com/Emurgo/yoroi-backend/pull/5 the timestamp is now in seconds not in milliseconds. 

This causes the front end to think that it **has outdated prices** so it doesn't show the prices to the users. 

This PR is making sure that we are comparing the same date unit (seconds). 