### PR TITLE
Tolerate undefined certificate type

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
+++ b/packages/yoroi-extension/app/api/ada/lib/storage/bridge/updateTransactions.js
@@ -2861,7 +2861,8 @@ async function certificateToDb(
         }));
         break;
       }
-      default: throw new Error(`${nameof(certificateToDb)} unknown cert kind ` + cert.kind);
+      default:
+        console.debug(`${nameof(certificateToDb)} unknown cert kind ` + cert.kind);
     }
   }
   return result;


### PR DESCRIPTION
Rather than throw an exception and make the sync process fail, just ignore the certificate in question.