### PR TITLE
[fix/4.22.100] Ledger app 5 catalyst registration adaptation

### DIFF
--- a/packages/yoroi-extension/app/api/ada/index.js
+++ b/packages/yoroi-extension/app/api/ada/index.js
@@ -297,6 +297,7 @@ export type CreateLedgerSignTxDataRequest = {|
   signRequest: HaskellShelleyTxSignRequest,
   network: $ReadOnly<NetworkRow>,
   addressingMap: string => (void | $PropertyType<Addressing, 'addressing'>),
+  cip36: boolean,
 |};
 export type CreateLedgerSignTxDataResponse = {|
   ledgerSignTxPayload: SignTransactionRequest,
@@ -961,6 +962,7 @@ export default class AdaApi {
         byronNetworkMagic: config.ByronNetworkId,
         networkId: Number.parseInt(config.ChainNetworkId, 10),
         addressingMap: request.addressingMap,
+        cip36: request.cip36,
       });
 
       Logger.debug(`${nameof(AdaApi)}::${nameof(this.createLedgerSignTxData)} success: ` + stringifyData(ledgerSignTxPayload));

--- a/packages/yoroi-extension/app/api/ada/index.js
+++ b/packages/yoroi-extension/app/api/ada/index.js
@@ -2384,6 +2384,8 @@ export default class AdaApi {
     const usedUtxos = signRequest.senderUtxos.map(utxo => (
       { txHash: utxo.tx_hash, index: utxo.tx_index }
     ));
+    const metadata = signRequest.unsignedTx.get_auxiliary_data;
+
     const transaction = CardanoShelleyTransaction.fromData({
       txid: txId,
       type: isIntraWallet ? 'self' : 'expend',
@@ -2399,8 +2401,8 @@ export default class AdaApi {
       block: null,
       certificates: [],
       ttl: new BigNumber(String(signRequest.unsignedTx.build().ttl())),
-      metadata: signRequest.metadata
-        ? Buffer.from(signRequest.metadata.to_bytes()).toString('hex')
+      metadata: metadata
+        ? Buffer.from(metadata.to_bytes()).toString('hex')
         : null,
       withdrawals: signRequest.withdrawals().map(withdrawal => ({
         address: withdrawal.address,

--- a/packages/yoroi-extension/app/api/ada/index.js
+++ b/packages/yoroi-extension/app/api/ada/index.js
@@ -2384,7 +2384,7 @@ export default class AdaApi {
     const usedUtxos = signRequest.senderUtxos.map(utxo => (
       { txHash: utxo.tx_hash, index: utxo.tx_index }
     ));
-    const metadata = signRequest.unsignedTx.get_auxiliary_data;
+    const metadata = signRequest.unsignedTx.get_auxiliary_data();
 
     const transaction = CardanoShelleyTransaction.fromData({
       txid: txId,

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/ledgerTx.test.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/ledgerTx.test.js
@@ -351,6 +351,7 @@ test('Create Ledger transaction', async () => {
       }
       return undefined;
     },
+    cip36: true,
   });
 
   expect(response).toStrictEqual(({

--- a/packages/yoroi-extension/app/stores/ada/send/LedgerSendStore.js
+++ b/packages/yoroi-extension/app/stores/ada/send/LedgerSendStore.js
@@ -45,7 +45,10 @@ import type {
 import { genAddressingLookup } from '../../stateless/addressStores';
 import type { ActionsMap } from '../../../actions/index';
 import type { StoresMap } from '../../index';
-import { generateRegistrationMetadata } from '../../../api/ada/lib/cardanoCrypto/catalyst';
+import {
+  generateRegistrationMetadata,
+  generateCip15RegistrationMetadata,
+} from '../../../api/ada/lib/cardanoCrypto/catalyst';
 
 /** Note: Handles Ledger Signing */
 export default class LedgerSendStore extends Store<StoresMap, ActionsMap> {
@@ -207,18 +210,29 @@ export default class LedgerSendStore extends Store<StoresMap, ActionsMap> {
         locale: this.stores.profile.currentLocale,
       });
 
+      let cip36: boolean = false;
+      if (request.signRequest.ledgerNanoCatalystRegistrationTxSignData) {
+        const getVersionResponse = await ledgerConnect.getVersion({
+          serial: request.expectedSerial,
+          dontCloseTab: true,
+        });
+        cip36 = getVersionResponse.compatibility.supportsCIP36Vote === true;
+      }
+
       const network = request.publicDeriver.getParent().getNetworkInfo();
 
       const { ledgerSignTxPayload } = await this.api.ada.createLedgerSignTxData({
         signRequest: request.signRequest,
         network,
         addressingMap: request.addressingMap,
+        cip36,
       });
 
       const ledgerSignTxResp: LedgerSignTxResponse =
         await ledgerConnect.signTransaction({
           serial: request.expectedSerial,
           params: ledgerSignTxPayload,
+          useOpenTab: true,
         });
 
       // There is no need of ledgerConnect after this line.
@@ -247,15 +261,27 @@ export default class LedgerSendStore extends Store<StoresMap, ActionsMap> {
         const { cip36VoteRegistrationSignatureHex } =
           ledgerSignTxResp.auxiliaryDataSupplement;
 
-        metadata = generateRegistrationMetadata(
-          votingPublicKey,
-          stakingKey,
-          paymentAddress,
-          nonce,
-          (_hashedMetadata) => {
-            return cip36VoteRegistrationSignatureHex;
-          },
-        );
+        if (cip36) {
+          metadata = generateRegistrationMetadata(
+            votingPublicKey,
+            stakingKey,
+            paymentAddress,
+            nonce,
+            (_hashedMetadata) => {
+              return cip36VoteRegistrationSignatureHex;
+            },
+          );
+        } else {
+          metadata = generateCip15RegistrationMetadata(
+            votingPublicKey,
+            stakingKey,
+            paymentAddress,
+            nonce,
+            (_hashedMetadata) => {
+              return cip36VoteRegistrationSignatureHex;
+            },
+          );
+        }
         // We can verify that
         //  Buffer.from(
         //    blake2b(256 / 8).update(metadata.to_bytes()).digest('binary')

--- a/packages/yoroi-extension/ledger/stores/ConnectStore.js
+++ b/packages/yoroi-extension/ledger/stores/ConnectStore.js
@@ -64,7 +64,7 @@ export default class ConnectStore {
   @observable response: void | MessageType;
   @observable expectedSerial: ?string;
   @observable extension: ?string;
-  userInteractableRequest: RequestType;
+  userInteractableRequest: ?RequestType;
   sendResponseFunc: ?(any) => void;
 
   constructor(transportId: TransportIdType) {
@@ -192,6 +192,9 @@ export default class ConnectStore {
       this.setProgressState(PROGRESS_STATE.DEVICE_TYPE_SELECTED);
     });
 
+    if (!this.userInteractableRequest) {
+      return;
+    }
     const actn = this.userInteractableRequest.action;
     const { params } = this.userInteractableRequest;
 
@@ -387,7 +390,7 @@ export default class ConnectStore {
       const adaApp = new AdaApp(transport);
       const resp: GetVersionResponse = await adaApp.getVersion();
 
-      this._replyMessageWrap(actn, true, resp);
+      this._replyMessageWrap(actn, true, resp, true);
     } catch (err) {
       this._replyError(actn, err);
     } finally {
@@ -512,13 +515,18 @@ export default class ConnectStore {
    * @param {*} success success status boolean
    * @param {*} payload payload object
    */
-  _replyMessageWrap: (string, boolean, any) => void = (actn, success, payload) => {
-    this._replyMessage({
-      success,
-      payload,
-      action: actn,
-      extension: this.extension,
-    });
+  _replyMessageWrap: (string, boolean, any, ?boolean) => void = (
+    actn, success, payload, dontClose,
+  ) => {
+    this._replyMessage(
+      {
+        success,
+        payload,
+        action: actn,
+        extension: this.extension,
+      },
+      dontClose,
+    );
   }
 
   /**
@@ -538,12 +546,19 @@ export default class ConnectStore {
    * Reply message to Content Script  [ Website ==> Content Script ]
    * @param {*} msg MessageType object as reply
    */
-  _replyMessage: (MessageType) => void = (msg) => {
-    if (ENV.isDevelopment) {
-      this.setResponse(msg);
-      this.setProgressState(PROGRESS_STATE.DEVICE_RESPONSE);
+  _replyMessage: (MessageType, ?boolean) => void = (msg, dontClose) => {
+    if (dontClose) {
+      runInAction(() => {
+        this.userInteractableRequest = null;
+        this.setProgressState(PROGRESS_STATE.DEVICE_TYPE_SELECTED);
+      });
     } else {
-      window.close();
+      if (ENV.isDevelopment) {
+        this.setResponse(msg);
+        this.setProgressState(PROGRESS_STATE.DEVICE_RESPONSE);
+      } else {
+        window.close();
+      }
     }
     msg.action = `${msg.action}-reply`;
     if (this.sendResponseFunc != null) {

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.22.0",
+  "version": "4.22.100",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "4.22.0",
+  "version": "4.22.100",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:build": "rimraf dev/ && babel-node scripts/build --type=debug",


### PR DESCRIPTION
When signing a catalyst registration tx, first check Ledger app version. If the version is 5, fallback to old CIP15 metadata format (but use payment address as reward address). 