### PR TITLE
Handle TrezorConnect not firing device event

### DIFF
--- a/packages/yoroi-extension/app/stores/ada/TrezorConnectStore.js
+++ b/packages/yoroi-extension/app/stores/ada/TrezorConnectStore.js
@@ -201,9 +201,6 @@ export default class TrezorConnectStore
         this._onTrezorUIEvent,
       );
 
-      if (this.trezorEventDevice == null) {
-        throw new Error(`${nameof(this._checkAndStoreHWDeviceInfo)} no ${nameof(this.trezorEventDevice)}`);
-      }
       const trezorEventDevice = this.trezorEventDevice;
 
       /** Converts a valid hardware wallet response to a common storable format
@@ -231,21 +228,17 @@ export default class TrezorConnectStore
 
     const { trezorResp, trezorEventDevice } = resp;
 
-    /** This check already done in _validateHWResponse but flow needs this */
-    const device = trezorEventDevice.payload;
-    const { features } = device;
-    if (features == null) {
-      throw new Error('Trezor device hardware info not valid');
-    }
+    const device = trezorEventDevice?.payload;
+    const features = device?.features;
 
     return {
       publicMasterKey: trezorResp.payload.publicKey,
       hwFeatures: {
-        Vendor: features.vendor ?? Config.wallets.hardwareWallet.trezorT.VENDOR,
-        Model: features.model,
-        DeviceId: features.device_id || '',
+        Vendor: features?.vendor ?? Config.wallets.hardwareWallet.trezorT.VENDOR,
+        Model: features?.model ?? Config.wallets.hardwareWallet.trezorT.MODEL,
+        DeviceId: features?.device_id || '',
       },
-      defaultName: device.label || '',
+      defaultName: device?.label || '',
     };
   }
 
@@ -274,13 +267,6 @@ export default class TrezorConnectStore
       || trezorResp.payload.publicKey == null
       || trezorResp.payload.publicKey.length <= 0) {
       throw new Error('Invalid public key received from Trezor device');
-    }
-
-    if (trezorEventDevice == null
-      || trezorEventDevice.payload == null
-      || trezorEventDevice.payload.type !== 'acquired'
-      || trezorEventDevice.payload.features == null) {
-      throw new Error('Invalid trezor device event');
     }
 
     return true;

--- a/packages/yoroi-extension/app/stores/ada/TrezorConnectStore.js
+++ b/packages/yoroi-extension/app/stores/ada/TrezorConnectStore.js
@@ -246,7 +246,7 @@ export default class TrezorConnectStore
   _validateHWResponse: TrezorConnectionResponse => boolean = (
     resp,
   ) => {
-    const { trezorResp, trezorEventDevice } = resp;
+    const { trezorResp } = resp;
 
     if (trezorResp && !trezorResp.success) {
       switch (trezorResp.payload.error) {


### PR DESCRIPTION
TrezorConnect hasn't been firing device events recently. The "Connecting to Trezor" function should not rely on device events being fired.