### PR TITLE
Connector `.getCollateral` parameters fix

### DIFF
--- a/packages/yoroi-connector/src/inject.js
+++ b/packages/yoroi-connector/src/inject.js
@@ -264,11 +264,15 @@ class CardanoAPI {
 
     // DEPRECATED
     getCollateralUtxos(requiredAmount) {
-      return CardanoAPI._cardano_rpc_call("get_collateral_utxos", [requiredAmount]);
+      const amount = typeof requiredAmount === 'object' ? requiredAmount.amount : requiredAmount;
+      const strAmount = amount == null || amount === '' ? null : String(amount);
+      return CardanoAPI._cardano_rpc_call("get_collateral_utxos", [strAmount]);
     }
 
     getCollateral(requiredAmount) {
-      return CardanoAPI._cardano_rpc_call("get_collateral_utxos", [requiredAmount]);
+      const amount = typeof requiredAmount === 'object' ? requiredAmount.amount : requiredAmount;
+      const strAmount = amount == null || amount === '' ? null : String(amount);
+      return CardanoAPI._cardano_rpc_call("get_collateral_utxos", [strAmount]);
     }
 }
 `

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -56,7 +56,7 @@ import {
   getAddressing,
   connectorSignData,
   connectorGetAssets,
-  getTokenMetadataFromIds,
+  getTokenMetadataFromIds, MAX_COLLATERAL,
 } from './connector/api';
 import { updateTransactions as ergoUpdateTransactions } from '../../app/api/ergo/lib/storage/bridge/updateTransactions';
 import {
@@ -1577,7 +1577,7 @@ function handleInjectorConnect(port) {
             try {
               checkParamCount(1);
               await RustModule.load();
-              let requiredAmount: string = message.params[0];
+              let requiredAmount: string = message.params[0] || String(MAX_COLLATERAL);
               if (!/^\d+$/.test(requiredAmount)) {
                 try {
                   requiredAmount = RustModule.WalletV4.Value.from_bytes(

--- a/packages/yoroi-extension/chrome/extension/connector/api.js
+++ b/packages/yoroi-extension/chrome/extension/connector/api.js
@@ -300,7 +300,7 @@ export async function connectorGetUtxosCardano(
   return Promise.resolve(selectedUtxo);
 }
 
-const MAX_COLLATERAL = new BigNumber('5000000');
+export const MAX_COLLATERAL = new BigNumber('5000000');
 // only consider UTXO value <= (${requiredAmount} + 1 ADA)
 const MAX_PER_UTXO_SURPLUS = new BigNumber('2000000');
 

--- a/packages/yoroi-extension/chrome/extension/connector/api.js
+++ b/packages/yoroi-extension/chrome/extension/connector/api.js
@@ -300,7 +300,7 @@ export async function connectorGetUtxosCardano(
   return Promise.resolve(selectedUtxo);
 }
 
-export const MAX_COLLATERAL = new BigNumber('5000000');
+export const MAX_COLLATERAL: BigNumber = new BigNumber('5000000');
 // only consider UTXO value <= (${requiredAmount} + 1 ADA)
 const MAX_PER_UTXO_SURPLUS = new BigNumber('2000000');
 


### PR DESCRIPTION
Both `.getCollateral` and the deprecated `.getCollateralUtxos` functions can now be called with one of these parameters:
1. A number as a `number`
2. A number as a `string`
3. An object `{ amount: string | number }` (proper CIP30)
4. A CBOR encoding of type `Value`
5. No parameter (in which case the default max allowed value of 5 ADA will be used)