### PR TITLE
change condition for more txs

### DIFF
--- a/packages/yoroi-extension/app/stores/toplevel/TransactionsStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TransactionsStore.js
@@ -53,7 +53,6 @@ import {
   loadSubmittedTransactions,
   persistSubmittedTransactions,
 } from '../../api/localStorage';
-import { FETCH_TXS_BATCH_SIZE } from '../../api/ada';
 import LegacyTransactionsStore from './LegacyTransactionsStore';
 import type { Api } from '../../api/index';
 import { getAllAddressesForWallet } from '../../api/ada/lib/storage/bridge/traitUtils';
@@ -571,7 +570,7 @@ export default class TransactionsStore extends Store<StoresMap, ActionsMap> {
     const result = await tailRequest.promise;
     runInAction(() => {
       state.txs.splice(state.txs.length, 0, ...result);
-      state.hasMoreToLoad = result.length === FETCH_TXS_BATCH_SIZE;
+      state.hasMoreToLoad = result.length > 0;
     });
 
     await this._afterLoadingNewTxs(


### PR DESCRIPTION
Original the Postgresql backend always returns 20 txs for the `txs/summaries` query. Now the neo4j backend returns an indeterminate ( but always < 20) number of txs. So the condition for determined whether there is possibly more txs must change accordining.