### PR TITLE
fix(txs): remove wallet notification from revamped txs pages

### DIFF
--- a/packages/yoroi-extension/app/containers/wallet/WalletSummaryPage.js
+++ b/packages/yoroi-extension/app/containers/wallet/WalletSummaryPage.js
@@ -334,15 +334,6 @@ class WalletSummaryPage extends Component<AllProps> {
 
     const walletSummaryPageRevamp = (
       <Box>
-        <NotificationMessage icon={successIcon} show={!!notification}>
-          {!!notification && (
-            <FormattedHTMLMessage
-              {...notification.message}
-              values={notification.values == null ? undefined : notification.values(intl)}
-            />
-          )}
-        </NotificationMessage>
-
         <WalletSummaryRevamp
           pendingAmount={unconfirmedAmount}
           shouldHideBalance={profile.shouldHideBalance}


### PR DESCRIPTION
<details><summary>Bfore</summary>
<p>

![Screenshot 2023-10-09 at 11 33 16 AM](https://github.com/Emurgo/yoroi-frontend/assets/72753578/e7a4fd6b-31c5-4c1d-86f5-b33a85309012)


</p>
</details> 


After merging this fix, the "notification" above will not be shown