### PR TITLE
connector init error fix

### DIFF
--- a/packages/yoroi-extension/app/api/ada/lib/cardanoCrypto/rustLoaderForBackground.js
+++ b/packages/yoroi-extension/app/api/ada/lib/cardanoCrypto/rustLoaderForBackground.js
@@ -10,6 +10,7 @@ import type { BigNum, LinearFee, TransactionBuilder } from '@emurgo/cardano-seri
 import * as WasmV4 from '@emurgo/cardano-serialization-lib-browser/cardano_serialization_lib';
 import * as SigmaRust from 'ergo-lib-wasm-browser';
 import * as WasmMessageSigning from '@emurgo/cardano-message-signing-browser/cardano_message_signing';
+import * as CrossCslBrowser from '@emurgo/cross-csl-browser';
 
 // TODO: unmagic the constants
 const MAX_VALUE_BYTES = 5000;
@@ -221,6 +222,10 @@ class Module {
 
   get MessageSigning(): typeof WasmMessageSigning {
     return WasmMessageSigning;
+  }
+
+  get CrossCsl(): typeof CrossCslBrowser {
+    return CrossCslBrowser;
   }
 
   WalletV4TxBuilderFromConfig(config: {

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/transactions.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/transactions.js
@@ -895,8 +895,8 @@ async function newAdaUnsignedTxFromUtxoForConnector(
   if (requiredSigners != null) {
     txBuilder.addRequiredSigners(requiredSigners);
   }
-  if (Object.keys(auxiliaryData.metadata ?? {}).length > 0) {
-    const metadata = auxiliaryData.metadata;
+  const metadata = auxiliaryData.metadata ?? {};
+  if (Object.keys(metadata).length > 0) {
     const record = {};
     for (const tag of Object.keys(metadata)) {
       record[parseInt(tag, 10)] = metadata[tag];

--- a/packages/yoroi-extension/app/api/ada/transactions/shelley/transactions.js
+++ b/packages/yoroi-extension/app/api/ada/transactions/shelley/transactions.js
@@ -829,7 +829,7 @@ async function newAdaUnsignedTxFromUtxoForConnector(
   |},
 ): Promise<V4UnsignedTxUtxoResponse> {
   await RustModule.load();
-  setRuntime(RustModule.CrossCsl.init());
+  setRuntime(RustModule.CrossCsl.init);
 
   const defaultNetworkConfig = {
     linearFee: {
@@ -839,6 +839,12 @@ async function newAdaUnsignedTxFromUtxoForConnector(
     coinsPerUtxoWord: protocolParams.coinsPerUtxoWord,
     poolDeposit: protocolParams.poolDeposit,
     keyDeposit: protocolParams.keyDeposit,
+    maxValueSize: 5000,
+    maxTxSize: 16384,
+    memPriceFrom: 577,
+    memPriceTo: 1000,
+    stepPriceFrom: 721,
+    stepPriceTo: 10000000,
   };
 
   const utxoSet = new UTxOSet(
@@ -889,8 +895,13 @@ async function newAdaUnsignedTxFromUtxoForConnector(
   if (requiredSigners != null) {
     txBuilder.addRequiredSigners(requiredSigners);
   }
-  if (auxiliaryData.metadata) {
-    txBuilder.withMetadata(auxiliaryData.metadata);
+  if (Object.keys(auxiliaryData.metadata ?? {}).length > 0) {
+    const metadata = auxiliaryData.metadata;
+    const record = {};
+    for (const tag of Object.keys(metadata)) {
+      record[parseInt(tag, 10)] = metadata[tag];
+    }
+    txBuilder.withMetadata(record);
   }
   if (auxiliaryData.nativeScripts) {
     txBuilder.addNativeScripts(auxiliaryData.nativeScripts);


### PR DESCRIPTION
1. A missing function in `rustLoaderForBackground` fixed
2. An incorrect passing of a function into `setRuntime` fixed
3. Missing fields in `defaultNetworkConfig` fixed
4. Incorrect handling of `auxiliaryData.metadata` fixed