### PR TITLE
fixing collateral api response in connector

### DIFF
--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -1733,7 +1733,9 @@ async function handleInjectorMessage(message, sender) {
                   await connectorGenerateReorgTx(
                     wallet,
                     usedUtxoIds,
-                    reorgTargetAmount,
+                    // `requiredAmount` is used here instead of the `reorgTargetAmount`
+                    // this is by design to minimise the number of collateral utxos
+                    requiredAmount,
                     addressedUtxos,
                     submittedTxs,
                   );

--- a/packages/yoroi-extension/chrome/extension/background.js
+++ b/packages/yoroi-extension/chrome/extension/background.js
@@ -676,9 +676,10 @@ const yoroiMessageHandler = async (
           rpcResponse({ err: 'unexpected error' });
           return;
         }
-        const { utxosToUse, isCBOR } = responseData.continuationData;
+        const { isCBOR } = responseData.continuationData;
         const utxos = await transformCardanoUtxos(
-          [...utxosToUse, ...(request.tx: any)],
+          // Only one utxo from the result of the reorg transaction is packed and returned here
+          [...(request.tx: any)],
           isCBOR
         );
         rpcResponse({ ok: utxos });
@@ -1727,7 +1728,7 @@ async function handleInjectorMessage(message, sender) {
                 // not enough suitable UTXOs for collateral
                 // see if we can re-organize the UTXOs
                 // `utxosToUse` are UTXOs that are already picked
-                // `reorgTargetAmount` is the amount still needed
+                // `requiredAmount` is the amount needed to respond
                 const usedUtxoIds = utxosToUse.map(utxo => utxo.utxo_id);
                 try {
                   await connectorGenerateReorgTx(
@@ -1766,7 +1767,7 @@ async function handleInjectorMessage(message, sender) {
                     type: 'tx-reorg/cardano',
                     tx: {
                       usedUtxoIds,
-                      reorgTargetAmount,
+                      reorgTargetAmount: requiredAmount,
                       utxos: walletUtxos,
                     },
                     uid: message.uid,

--- a/packages/yoroi-extension/chrome/extension/connector/api.js
+++ b/packages/yoroi-extension/chrome/extension/connector/api.js
@@ -355,6 +355,7 @@ export async function connectorGetCollateralUtxos(
       utxosToUse.length > MAX_COLLATERAL_COUNT
       || sum.minus(utxosToUse[0].amount).gte(required)
     ) {
+      // Removing the first (hence the smallest) utxo from the list
       const removedUtxo = utxosToUse.shift()
       sum = sum.minus(removedUtxo.amount)
     }

--- a/packages/yoroi-extension/chrome/extension/connector/api.js
+++ b/packages/yoroi-extension/chrome/extension/connector/api.js
@@ -346,17 +346,17 @@ export async function connectorGetCollateralUtxos(
     (utxo1, utxo2) => (new BigNumber(utxo1.amount)).comparedTo(utxo2.amount)
   )
   const utxosToUse = []
-  let sum = new BigNumber('0');
-  let enough = false;
+  let sum = new BigNumber('0')
+  let enough = false
   for (const utxo of utxosToConsider) {
-    utxosToUse.push(utxo);
-    sum = sum.plus(utxo.amount);
+    utxosToUse.push(utxo)
+    sum = sum.plus(utxo.amount)
     while (
       utxosToUse.length > MAX_COLLATERAL_COUNT
       || sum.minus(utxosToUse[0].amount).gte(required)
     ) {
-      const removedUtxo = utxosToUse.shift();
-      sum = sum.minus(removedUtxo.amount);
+      const removedUtxo = utxosToUse.shift()
+      sum = sum.minus(removedUtxo.amount)
     }
     if (sum.gte(required)) {
       enough = true

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,1 +1,1 @@
-nvm i && . install-all.sh && npm run dev:stable --prefix packages/yoroi-extension
+nvm i && . install-all.sh && npm run dev-mv2 --prefix packages/yoroi-extension


### PR DESCRIPTION
Changing the connector to not return ever more collateral UTxOs than the maximum allowed of collateral inputs for a TX, which is currently `3` 