### PR TITLE
fix(opt-out-analytics): add height, padding and overflow to analytics page

### DIFF
--- a/packages/yoroi-extension/app/containers/profile/OptForAnalyticsPage.js
+++ b/packages/yoroi-extension/app/containers/profile/OptForAnalyticsPage.js
@@ -1,43 +1,41 @@
 // @flow
 import type { Node } from 'react';
-import { Component } from 'react';
 import type { InjectedOrGenerated } from '../../types/injectedPropsType';
-import IntroBanner from '../../components/profile/language-selection/IntroBanner';
-import environment from '../../environment';
 import type { $npm$ReactIntl$IntlFormat } from 'react-intl';
+import { Component } from 'react';
 import { observer } from 'mobx-react';
 import { intlShape } from 'react-intl';
 import { computed } from 'mobx';
+import { Box } from '@mui/material';
+import IntroBanner from '../../components/profile/language-selection/IntroBanner';
+import environment from '../../environment';
 import OptForAnalyticsForm from '../../components/profile/terms-of-use/OptForAnalyticsForm';
 
 type GeneratedData = typeof OptForAnalyticsPage.prototype.generated;
 
 @observer
 export default class OptForAnalyticsPage extends Component<InjectedOrGenerated<GeneratedData>> {
-
-  static contextTypes: {|intl: $npm$ReactIntl$IntlFormat|} = {
+  static contextTypes: {| intl: $npm$ReactIntl$IntlFormat |} = {
     intl: intlShape.isRequired,
   };
 
   render(): Node {
     return (
-      <>
-        <IntroBanner
-          isNightly={environment.isNightly()}
-        />
+      <Box height="100vh" paddingBottom="24px" sx={{ overflowY: 'auto' }}>
+        <IntroBanner isNightly={environment.isNightly()} />
         <OptForAnalyticsForm
           onOpt={this.generated.actions.profile.optForAnalytics.trigger}
           variant="startup"
           isOptedIn={false}
         />
-      </>
+      </Box>
     );
   }
 
   @computed get generated(): {|
     actions: {|
       profile: {|
-        optForAnalytics: {| trigger: (boolean) => void |},
+        optForAnalytics: {| trigger: boolean => void |},
       |},
     |},
   |} {


### PR DESCRIPTION
**Description**
If a browser window height is around 560px then the Opt-Out Analytics page is not passable because both buttons are hidden.

**Screenshots**
<img width="1018" alt="image" src="https://github.com/Emurgo/yoroi-frontend/assets/22194171/5d8aa9c5-5153-41cb-92af-81390393ce29">
