### PR TITLE
fix(ds): add fixed header for dialog content

### DIFF
--- a/packages/yoroi-extension/app/components/swap/SelectAssetDialog.js
+++ b/packages/yoroi-extension/app/components/swap/SelectAssetDialog.js
@@ -62,52 +62,55 @@ export default function SelectAssetDialog({
       styleOverride={{ minWidth: '612px', maxWidth: '612px', minHeight: '600px' }}
       styleContentOverride={{ paddingTop: '16px' }}
       scrollableContentClass="scrollable-content"
+      contentHeader={
+        <>
+          <Box mb="8px" position="relative" height="40px">
+            <Box
+              sx={{
+                position: 'absolute',
+                left: '7px',
+                top: '30px',
+                transform: 'translateY(-50%)',
+                display: 'inline-flex',
+                color: 'grayscale.600',
+                height: '40px',
+              }}
+            >
+              <SearchIcon />
+            </Box>
+            <Box
+              component="input"
+              type="text"
+              placeholder="Search"
+              sx={{
+                border: '1px solid',
+                borderColor: 'grayscale.400',
+                borderRadius: '8px',
+                padding: '8px',
+                paddingLeft: '34px',
+                outline: 'none',
+                width: '100%',
+                fontSize: '14px',
+                fontFamily: 'Rubik',
+                height: '40px',
+                '&:focus': {
+                  borderWidth: '2px',
+                  borderColor: 'grayscale.max',
+                },
+              }}
+              onChange={e => {
+                setSearchTerm(e.target.value?.trim() ?? '');
+              }}
+            />
+          </Box>
+          <Box>
+            <Typography component="div" variant="body2" color="grayscale.700">
+              {filteredAssets.length} assets {searchTerm ? 'found' : 'available'}
+            </Typography>
+          </Box>
+        </>
+      }
     >
-      <Box mb="8px" position="relative" height="40px">
-        <Box
-          sx={{
-            position: 'absolute',
-            left: '7px',
-            top: '30px',
-            transform: 'translateY(-50%)',
-            display: 'inline-flex',
-            color: 'grayscale.600',
-            height: '40px',
-          }}
-        >
-          <SearchIcon />
-        </Box>
-        <Box
-          component="input"
-          type="text"
-          placeholder="Search"
-          sx={{
-            border: '1px solid',
-            borderColor: 'grayscale.400',
-            borderRadius: '8px',
-            padding: '8px',
-            paddingLeft: '34px',
-            outline: 'none',
-            width: '100%',
-            fontSize: '14px',
-            fontFamily: 'Rubik',
-            height: '40px',
-            '&:focus': {
-              borderWidth: '2px',
-              borderColor: 'grayscale.max',
-            },
-          }}
-          onChange={e => {
-            setSearchTerm(e.target.value?.trim() ?? '');
-          }}
-        />
-      </Box>
-      <Box>
-        <Typography component="div" variant="body2" color="grayscale.700">
-          {filteredAssets.length} assets {searchTerm ? 'found' : 'available'}
-        </Typography>
-      </Box>
-
       {filteredAssets.length !== 0 && (
         <Table
           rowGap="0px"

--- a/packages/yoroi-extension/app/components/widgets/Dialog.js
+++ b/packages/yoroi-extension/app/components/widgets/Dialog.js
@@ -44,6 +44,7 @@ export type Props = {|
   id?: string,
   +styleFlags?: StyleFlag,
   +forceBottomDivider?: boolean,
+  +contentHeader?: Node,
 |};
 
 type InjectedProps = {| isRevampLayout: boolean |};
@@ -64,6 +65,7 @@ function Dialog(props: Props & InjectedProps): Node {
     id,
     styleFlags,
     forceBottomDivider,
+    contentHeader,
   } = props;
 
   const [contentHasScroll, setContentHasScroll] = useState(false);
@@ -81,7 +83,7 @@ function Dialog(props: Props & InjectedProps): Node {
         // el.style.marginRight = '-24px';
       } else {
         setContentHasScroll(false);
-        el.style.marginRight = '0';
+        // el.style.marginRight = '0';
       }
     }, 30);
 
@@ -146,7 +148,20 @@ function Dialog(props: Props & InjectedProps): Node {
             className="ModalContent"
             style={props.styleContentOverride}
           >
-            {children}
+            {contentHeader && <Box>{contentHeader}</Box>}
+            <Box
+              sx={{
+                maxHeight: '100%',
+                overflowY: 'auto',
+                overflowX: 'hidden',
+                flexGrow: 1,
+                // <TODO:STYLES> Check if needed
+                // maxWidth: 'calc(100% + 20px)',
+                // marginRight: '-20px',
+              }}
+            >
+              {children}
+            </Box>
           </ModalContent>
         ) : null}
         {hasActions && (
@@ -197,6 +212,7 @@ Dialog.defaultProps = {
   backButton: undefined,
   className: undefined,
   scrollableContentClass: undefined,
+  contentHeader: null,
   styleOverride: undefined,
   onClose: undefined,
   closeOnOverlayClick: false,
@@ -207,7 +223,7 @@ export const CloseButton = ({
   onClose,
   closeButton,
   sx,
-  idLocatorPath='modalWindow',
+  idLocatorPath = 'modalWindow',
 }: {|
   onClose: ?(void) => PossiblyAsync<void>,
   closeButton: React$Node,
@@ -283,6 +299,8 @@ const ModalContent = styled(Box)(({ theme }) => ({
   paddingTop: theme.name === 'classic' ? '0px' : '24px',
   paddingBottom: theme.name === 'classic' || theme.name === 'modern' ? '0px' : '24px',
   flexGrow: 1,
+  display: 'flex',
+  flexFlow: 'column',
 }));
 
 const ModalFooter = styled(Box)(({ theme, hasDivider }) => ({


### PR DESCRIPTION
**Description**
When we have an open Dialog with a search bar, the bar scrolls as we scroll the content. We should have the option to fix content after the modal title.

**Screenshot**
![image](https://github.com/Emurgo/yoroi-frontend/assets/22194171/9809eee1-a709-40a0-b127-264927fdc12a)
