### PR TITLE
fix(swap): limit price on the confirmation screen

### DIFF
--- a/packages/yoroi-extension/app/components/swap/PriceImpact.js
+++ b/packages/yoroi-extension/app/components/swap/PriceImpact.js
@@ -135,6 +135,12 @@ export function FormattedMarketPrice(): Node {
   return <FormattedPrice price={marketPrice} />;
 }
 
+export function FormattedLimitPrice(): Node {
+  const { orderData } = useSwap();
+  const limitPrice = orderData.limitPrice ?? '0';
+  return <FormattedPrice price={limitPrice} />;
+}
+
 export function FormattedActualPrice(): Node {
   const { orderData } = useSwap();
   const actualPrice = orderData.selectedPoolCalculation?.prices.actualPrice ?? '0';

--- a/packages/yoroi-extension/app/components/swap/SwapInput.js
+++ b/packages/yoroi-extension/app/components/swap/SwapInput.js
@@ -37,28 +37,31 @@ export default function SwapInput({
   getTokenInfo,
   focusState,
 }: Props): Node {
-
   const [remoteTokenLogo, setRemoteTokenLogo] = useState<?string>(null);
   const { id, amount: quantity = undefined, image, ticker } = tokenInfo || {};
 
   const handleChange = e => {
-    handleAmountChange(e.target.value);
+    if (!disabled && value != quantity) {
+      handleAmountChange(e.target.value);
+    }
   };
 
   const isFocusedColor = focusState.value ? 'grayscale.max' : 'grayscale.400';
 
   useEffect(() => {
     if (id != null) {
-      getTokenInfo(id).then(remoteTokenInfo => {
-        if (remoteTokenInfo.logo != null) {
-          setRemoteTokenLogo(`data:image/png;base64,${remoteTokenInfo.logo}`);
-        }
-        return null;
-      }).catch(e => {
-        console.warn('Failed to resolve remote info for token: ' + id, e);
-      });
+      getTokenInfo(id)
+        .then(remoteTokenInfo => {
+          if (remoteTokenInfo.logo != null) {
+            setRemoteTokenLogo(`data:image/png;base64,${remoteTokenInfo.logo}`);
+          }
+          return null;
+        })
+        .catch(e => {
+          console.warn('Failed to resolve remote info for token: ' + id, e);
+        });
     }
-  }, [id])
+  }, [id]);
 
   const imgSrc =
     ticker === defaultTokenInfo.ticker
@@ -116,7 +119,7 @@ export default function SwapInput({
           variant="body1"
           color="grayscale.max"
           placeholder="0"
-          onChange={disabled ? () => {} : handleChange}
+          onChange={handleChange}
           value={disabled ? '' : value}
           onFocus={() => focusState.update(true)}
           onBlur={() => focusState.update(false)}

--- a/packages/yoroi-extension/app/components/swap/SwapInput.js
+++ b/packages/yoroi-extension/app/components/swap/SwapInput.js
@@ -41,7 +41,7 @@ export default function SwapInput({
   const { id, amount: quantity = undefined, image, ticker } = tokenInfo || {};
 
   const handleChange = e => {
-    if (!disabled && value != quantity) {
+    if (!disabled && value !== quantity) {
       handleAmountChange(e.target.value);
     }
   };

--- a/packages/yoroi-extension/app/components/swap/SwapPriceInput.js
+++ b/packages/yoroi-extension/app/components/swap/SwapPriceInput.js
@@ -43,9 +43,6 @@ function SwapPriceInput({ priceImpactState }: Props): Node {
 
   const formattedPrice = marketPrice ? format(marketPrice) : pricePlaceholder;
 
-  // if (limitPrice.displayValue === '' && marketPrice != null) {
-  //   onChangeLimitPrice(formattedPrice);
-  // }
   const displayValue = isMarketOrder ? formattedPrice : limitPrice.displayValue;
   const isValidTickers = sellTokenInfo?.ticker && buyTokenInfo?.ticker;
   const isReadonly = !isValidTickers || isMarketOrder;

--- a/packages/yoroi-extension/app/components/swap/SwapPriceInput.js
+++ b/packages/yoroi-extension/app/components/swap/SwapPriceInput.js
@@ -7,7 +7,6 @@ import { Quantities } from '../../utils/quantities';
 import { useSwap } from '@yoroi/swap';
 import { PRICE_PRECISION } from './common';
 import { useSwapForm } from '../../containers/swap/context/swap-form';
-import SwapStore from '../../stores/ada/SwapStore';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react';
 import {
@@ -18,7 +17,6 @@ import {
 } from './PriceImpact';
 
 type Props = {|
-  swapStore: SwapStore,
   priceImpactState: ?PriceImpact,
 |};
 
@@ -39,15 +37,16 @@ function SwapPriceInput({ priceImpactState }: Props): Node {
   const pricePlaceholder = isMarketOrder ? NO_PRICE_VALUE_PLACEHOLDER : '0';
   const marketPrice = orderData.selectedPoolCalculation?.prices.market;
 
-  const format = s => Quantities.format(s, orderData.tokens.priceDenomination, PRICE_PRECISION) + (s.endsWith('.') ? '.' : '');
+  const format = s =>
+    Quantities.format(s, orderData.tokens.priceDenomination, PRICE_PRECISION) +
+    (s.endsWith('.') ? '.' : '');
+
   const formattedPrice = marketPrice ? format(marketPrice) : pricePlaceholder;
 
-  if (swapStore.limitOrderDisplayValue === '' && marketPrice != null) {
-    runInAction(() => {
-      swapStore.setLimitOrderDisplayValue(formattedPrice);
-    });
-  }
-  const displayValue = isMarketOrder ? formattedPrice : swapStore.limitOrderDisplayValue;
+  // if (limitPrice.displayValue === '' && marketPrice != null) {
+  //   onChangeLimitPrice(formattedPrice);
+  // }
+  const displayValue = isMarketOrder ? formattedPrice : limitPrice.displayValue;
   const isValidTickers = sellTokenInfo?.ticker && buyTokenInfo?.ticker;
   const isReadonly = !isValidTickers || isMarketOrder;
   const valueToDisplay = endsWithDot ? displayValue + '.' : displayValue;
@@ -121,6 +120,8 @@ function SwapPriceInput({ priceImpactState }: Props): Node {
               setEndsWithDot(false);
             }
           }}
+          onFocus={() => !isMarketOrder && limitPriceFocusState.update(true)}
+          onBlur={() => !isMarketOrder && limitPriceFocusState.update(false)}
         />
         <Box sx={{ justifySelf: 'end' }}>
           <Box height="100%" width="max-content" display="flex" alignItems="center">

--- a/packages/yoroi-extension/app/components/swap/SwapPriceInput.js
+++ b/packages/yoroi-extension/app/components/swap/SwapPriceInput.js
@@ -7,7 +7,6 @@ import { Quantities } from '../../utils/quantities';
 import { useSwap } from '@yoroi/swap';
 import { PRICE_PRECISION } from './common';
 import { useSwapForm } from '../../containers/swap/context/swap-form';
-import { runInAction } from 'mobx';
 import { observer } from 'mobx-react';
 import {
   FormattedActualPrice,

--- a/packages/yoroi-extension/app/components/swap/SwapPriceInput.js
+++ b/packages/yoroi-extension/app/components/swap/SwapPriceInput.js
@@ -1,14 +1,12 @@
 // @flow
 import type { Node } from 'react';
+import type { PriceImpact } from './types';
 import { Box, Typography } from '@mui/material';
 import { Quantities } from '../../utils/quantities';
 import { useSwap } from '@yoroi/swap';
 import { PRICE_PRECISION } from './common';
 import { useSwapForm } from '../../containers/swap/context/swap-form';
-import SwapStore from '../../stores/ada/SwapStore';
-import { runInAction } from 'mobx';
 import { observer } from 'mobx-react';
-import type { PriceImpact } from './types';
 import {
   FormattedActualPrice,
   PriceImpactColored,
@@ -17,29 +15,31 @@ import {
 } from './PriceImpact';
 
 type Props = {|
-  swapStore: SwapStore,
   priceImpactState: ?PriceImpact,
 |};
 
 const NO_PRICE_VALUE_PLACEHOLDER = ' ';
 
-function SwapPriceInput({ swapStore, priceImpactState }: Props): Node {
-  const { orderData, limitPriceChanged } = useSwap();
-  const { sellTokenInfo, buyTokenInfo } = useSwapForm();
+function SwapPriceInput({ priceImpactState }: Props): Node {
+  const { orderData } = useSwap();
+  const {
+    sellTokenInfo,
+    buyTokenInfo,
+    limitPriceFocusState,
+    onChangeLimitPrice,
+    limitPrice,
+  } = useSwapForm();
 
   const isMarketOrder = orderData.type === 'market';
   const pricePlaceholder = isMarketOrder ? NO_PRICE_VALUE_PLACEHOLDER : '0';
   const marketPrice = orderData.selectedPoolCalculation?.prices.market;
 
-  const format = s => Quantities.format(s, orderData.tokens.priceDenomination, PRICE_PRECISION) + (s.endsWith('.') ? '.' : '');
+  const format = s =>
+    Quantities.format(s, orderData.tokens.priceDenomination, PRICE_PRECISION) +
+    (s.endsWith('.') ? '.' : '');
   const formattedPrice = marketPrice ? format(marketPrice) : pricePlaceholder;
 
-  if (swapStore.limitOrderDisplayValue === '' && marketPrice != null) {
-    runInAction(() => {
-      swapStore.setLimitOrderDisplayValue(formattedPrice);
-    });
-  }
-  const displayValue = isMarketOrder ? formattedPrice : swapStore.limitOrderDisplayValue;
+  const displayValue = isMarketOrder ? formattedPrice : limitPrice.displayValue;
   const isValidTickers = sellTokenInfo?.ticker && buyTokenInfo?.ticker;
   const isReadonly = !isValidTickers || isMarketOrder;
 
@@ -90,18 +90,16 @@ function SwapPriceInput({ swapStore, priceImpactState }: Props): Node {
           bgcolor={isReadonly ? 'grayscale.50' : 'common.white'}
           readOnly={isReadonly}
           value={isValidTickers ? displayValue : NO_PRICE_VALUE_PLACEHOLDER}
-          onChange={({ target: { value: val } }) => {
+          onChange={event => {
+            const val = event.target.value;
             let value = val.replace(/[^\d.]+/g, '');
-            if (!value) value = '0';
-            if (/^\d+\.?\d*$/.test(value)) {
-              runInAction(() => {
-                swapStore.setLimitOrderDisplayValue(format(value));
-              });
-              if (!value.endsWith('.')) {
-                limitPriceChanged(value);
-              }
+            if (!value) value = '';
+            if (/^\d+\.?\d*$/.test(value) && !value.endsWith('.')) {
+              onChangeLimitPrice(value);
             }
           }}
+          onFocus={() => !isMarketOrder && limitPriceFocusState.update(true)}
+          onBlur={() => !isMarketOrder && limitPriceFocusState.update(false)}
         />
         <Box sx={{ justifySelf: 'end' }}>
           <Box height="100%" width="max-content" display="flex" alignItems="center">

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/ConfirmSwapTransaction.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/ConfirmSwapTransaction.js
@@ -12,6 +12,7 @@ import type { RemoteTokenInfo } from '../../../api/ada/lib/state-fetch/types';
 import {
   FormattedActualPrice,
   FormattedMarketPrice,
+  FormattedLimitPrice,
   PriceImpactBanner,
   PriceImpactColored,
   PriceImpactIcon,
@@ -32,6 +33,19 @@ type Props = {|
   defaultTokenInfo: RemoteTokenInfo,
   getFormattedPairingValue: (amount: string) => string,
 |};
+
+const priceStrings = {
+  market: {
+    label: 'Market price',
+    info:
+      'Market price is the best price available on the market among several DEXes that lets you buy or sell an asset instantly',
+  },
+  limit: {
+    label: 'Limit price',
+    info:
+      "Limit price in a DEX is a specific pre-set price at which you can trade an asset. Unlike market orders, which execute immediately at the current market price, limit orders are set to execute only when the market reaches the trader's specified price.",
+  },
+};
 
 export default function ConfirmSwapTransaction({
   slippageValue,
@@ -136,16 +150,16 @@ export default function ConfirmSwapTransaction({
         <SummaryRow col1="Slippage tolerance">{slippageValue}%</SummaryRow>
         <SwapPoolFullInfo defaultTokenInfo={defaultTokenInfo} showMinAda />
         <SummaryRow
-          col1="Market price"
+          col1={priceStrings[orderData.type].label}
           withInfo
-          infoText="Market price is the best price available on the market among several DEXes that lets you buy or sell an asset instantly"
+          infoText={priceStrings[orderData.type].info}
         >
-          <FormattedMarketPrice />
+          {orderData.type === 'market' ? <FormattedMarketPrice /> : <FormattedLimitPrice />}
         </SummaryRow>
         <SummaryRow
           col1="Price impact"
           withInfo
-          infoText="Limit price in a DEX is a specific pre-set price at which you can trade an asset. Unlike market orders, which execute immediately at the current market price, limit orders are set to execute only when the market reaches the trader's specified price."
+          infoText="Price impact is a difference between the actual market price and your price due to trade size."
         >
           <PriceImpactColored priceImpactState={priceImpactState} sx={{ display: 'flex' }}>
             {priceImpactState && <PriceImpactIcon isSevere={priceImpactState.isSevere} />}

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/CreateSwapOrder.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/CreateSwapOrder.js
@@ -1,4 +1,6 @@
 // @flow
+import type { RemoteTokenInfo } from '../../../api/ada/lib/state-fetch/types';
+import type { PriceImpact } from '../../../components/swap/types';
 import { useState } from 'react';
 import { Box } from '@mui/material';
 import SwapPriceInput from '../../../components/swap/SwapPriceInput';
@@ -12,12 +14,10 @@ import EditSwapPool from './edit-pool/EditPool';
 import SelectSwapPoolFromList from './edit-pool/SelectPoolFromList';
 import SwapStore from '../../../stores/ada/SwapStore';
 import { useAsyncPools } from '../hooks';
-import type { RemoteTokenInfo } from '../../../api/ada/lib/state-fetch/types';
-import type { PriceImpact } from '../../../components/swap/types';
-
 import { TopActions } from './actions/TopActions';
 import { MiddleActions } from './actions/MiddleActions';
 import { EditSlippage } from './actions/EditSlippage';
+import { useSwapForm } from '../context/swap-form';
 
 type Props = {|
   slippageValue: string,
@@ -50,11 +50,17 @@ export const CreateSwapOrder = ({
     buyTokenInfoChanged,
   } = useSwap();
 
+  const { onChangeLimitPrice } = useSwapForm();
+
+  const resetLimitPrice = () => {
+    onChangeLimitPrice('');
+  };
+
   if (orderType === 'market') {
     const selectedPoolId = selectedPoolCalculation?.pool.poolId;
     if (selectedPoolId !== prevSelectedPoolId) {
       setPrevSelectedPoolId(selectedPoolId);
-      swapStore.resetLimitOrderDisplayValue();
+      resetLimitPrice();
     }
   }
 
@@ -94,10 +100,7 @@ export const CreateSwapOrder = ({
         />
 
         {/* Price between assets */}
-        <SwapPriceInput
-          swapStore={swapStore}
-          priceImpactState={priceImpactState}
-        />
+        <SwapPriceInput priceImpactState={priceImpactState} />
 
         {/* Slippage settings */}
         <EditSlippage
@@ -118,7 +121,7 @@ export const CreateSwapOrder = ({
           store={swapStore}
           onClose={() => setOpenedDialog('')}
           onTokenInfoChanged={val => {
-            swapStore.resetLimitOrderDisplayValue();
+            resetLimitPrice();
             sellTokenInfoChanged(val);
           }}
           defaultTokenInfo={defaultTokenInfo}
@@ -130,7 +133,7 @@ export const CreateSwapOrder = ({
           store={swapStore}
           onClose={() => setOpenedDialog('')}
           onTokenInfoChanged={val => {
-            swapStore.resetLimitOrderDisplayValue();
+            resetLimitPrice();
             buyTokenInfoChanged(val);
           }}
           defaultTokenInfo={defaultTokenInfo}

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/CreateSwapOrder.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/CreateSwapOrder.js
@@ -91,7 +91,7 @@ export const CreateSwapOrder = ({
         />
 
         {/* Clear and switch */}
-        <MiddleActions swapStore={swapStore} />
+        <MiddleActions />
 
         {/* To Field */}
         <EditBuyAmount

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/CreateSwapOrder.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/CreateSwapOrder.js
@@ -64,6 +64,7 @@ export const CreateSwapOrder = ({
     }
   }
 
+  // TODO: refactor, this hook call will be removed and replaced with store function
   useAsyncPools(sell.tokenId, buy.tokenId)
     .then(() => null)
     .catch(() => null);

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/CreateSwapOrder.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/CreateSwapOrder.js
@@ -95,7 +95,6 @@ export const CreateSwapOrder = ({
 
         {/* Price between assets */}
         <SwapPriceInput
-          swapStore={swapStore}
           priceImpactState={priceImpactState}
         />
 

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/SwapPage.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/SwapPage.js
@@ -88,8 +88,8 @@ function SwapPage(props: StoresAndActionsProps): Node {
   const defaultTokenInfo = props.stores.tokenInfoStore.getDefaultTokenInfoSummary(
     network.NetworkId
   );
-  const getTokenInfo: (string => Promise<RemoteTokenInfo>) =
-      id => props.stores.tokenInfoStore.getLocalOrRemoteMetadata(network, id);
+  const getTokenInfo: string => Promise<RemoteTokenInfo> = id =>
+    props.stores.tokenInfoStore.getLocalOrRemoteMetadata(network, id);
 
   const disclaimerFlag = props.stores.substores.ada.swapStore.swapDisclaimerAcceptanceFlag;
 

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/actions/MiddleActions.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/actions/MiddleActions.js
@@ -2,21 +2,16 @@
 import { Box, Button } from '@mui/material';
 import { ReactComponent as SwitchIcon } from '../../../../assets/images/revamp/icons/switch.inline.svg';
 import { useSwapForm } from '../../context/swap-form';
-import SwapStore from '../../../../stores/ada/SwapStore';
 
-type Props = {|
-  swapStore: SwapStore,
-|};
-
-export const MiddleActions = ({ swapStore }: Props): React$Node => {
-  const { clearSwapForm, switchTokens } = useSwapForm();
+export const MiddleActions = (): React$Node => {
+  const { clearSwapForm, switchTokens, onChangeLimitPrice } = useSwapForm();
 
   return (
     <Box display="flex" alignItems="center" justifyContent="space-between">
       <Box
         sx={{ cursor: 'pointer', color: 'primary.500' }}
         onClick={() => {
-          swapStore.resetLimitOrderDisplayValue();
+          onChangeLimitPrice('');
           return switchTokens();
         }}
       >

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/edit-buy-amount/EditBuyAmount.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/edit-buy-amount/EditBuyAmount.js
@@ -11,7 +11,11 @@ type Props = {|
   getTokenInfo: string => Promise<RemoteTokenInfo>,
 |};
 
-export default function EditBuyAmount({ onAssetSelect, defaultTokenInfo, getTokenInfo }: Props): Node {
+export default function EditBuyAmount({
+  onAssetSelect,
+  defaultTokenInfo,
+  getTokenInfo,
+}: Props): Node {
   const { orderData } = useSwap();
   const {
     buyQuantity: { displayValue: buyDisplayValue, error: fieldError },
@@ -27,14 +31,16 @@ export default function EditBuyAmount({ onAssetSelect, defaultTokenInfo, getToke
   const error = isInvalidPair ? 'Selected pair is not available in any liquidity pool' : fieldError;
 
   // Amount input is blocked in case invalid pair
-  const handleAmountChange = isInvalidPair ? () => {} : onChangeBuyQuantity;
+  const handleAmountChange = () => {
+    return isInvalidPair ? () => {} : onChangeBuyQuantity;
+  };
 
   return (
     <SwapInput
       key={tokenId}
       label="Swap to"
       disabled={!isValidTickers}
-      handleAmountChange={handleAmountChange}
+      handleAmountChange={handleAmountChange()}
       value={buyDisplayValue}
       tokenInfo={buyTokenInfo}
       defaultTokenInfo={defaultTokenInfo}

--- a/packages/yoroi-extension/app/containers/swap/asset-swap/edit-pool/SelectPoolFromList.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/edit-pool/SelectPoolFromList.js
@@ -1,24 +1,34 @@
 // @flow
+import type { RemoteTokenInfo } from '../../../../api/ada/lib/state-fetch/types';
 import SelectPoolDialog from '../../../../components/swap/SelectPoolDialog';
 import { useSwap } from '@yoroi/swap';
-import type { RemoteTokenInfo } from '../../../../api/ada/lib/state-fetch/types';
+import { useSwapForm } from '../../context/swap-form';
 
 type Props = {|
   +onClose: void => void,
   defaultTokenInfo: RemoteTokenInfo,
-|}
+|};
 
 export default function SelectSwapPoolFromList({ onClose, defaultTokenInfo }: Props): React$Node {
+  const {
+    orderData: { tokens, pools, selectedPoolId, amounts },
+    selectedPoolChanged,
+  } = useSwap();
 
-  const { orderData: { tokens, pools, selectedPoolId, amounts }, selectedPoolChanged } = useSwap();
+  const { poolTouched } = useSwapForm();
 
-  return <SelectPoolDialog
-    onPoolSelected={poolId => selectedPoolChanged(poolId)}
-    sellTokenId={amounts.sell.tokenId}
-    denomination={tokens.priceDenomination}
-    defaultTokenInfo={defaultTokenInfo}
-    poolList={pools}
-    currentPool={selectedPoolId}
-    onClose={onClose}
-  />;
+  return (
+    <SelectPoolDialog
+      onPoolSelected={poolId => {
+        selectedPoolChanged(poolId);
+        poolTouched();
+      }}
+      sellTokenId={amounts.sell.tokenId}
+      denomination={tokens.priceDenomination}
+      defaultTokenInfo={defaultTokenInfo}
+      poolList={pools}
+      currentPool={selectedPoolId}
+      onClose={onClose}
+    />
+  );
 }

--- a/packages/yoroi-extension/app/containers/swap/context/swap-form/SwapFormProvider.js
+++ b/packages/yoroi-extension/app/containers/swap/context/swap-form/SwapFormProvider.js
@@ -190,7 +190,6 @@ export default function SwapFormProvider({ swapStore, children }: Props): Node {
   };
 
   const buyUpdateHandler = ({ input, quantity }) => {
-    console.log('🚀 ~ buyUpdateHandler ~ input:', input);
     if (quantity !== buyQuantity) {
       buyQuantityChanged(quantity);
     }

--- a/packages/yoroi-extension/app/containers/swap/context/swap-form/SwapFormProvider.js
+++ b/packages/yoroi-extension/app/containers/swap/context/swap-form/SwapFormProvider.js
@@ -1,14 +1,15 @@
 //@flow
 import type { Node } from 'react';
-import { useCallback, useEffect, useReducer, useState } from 'react';
 import type { SwapFormAction, SwapFormState } from './types';
-import { StateWrap, SwapFormActionTypeValues } from './types';
 import type { AssetAmount } from '../../../../components/swap/types';
+import { useCallback, useEffect, useReducer, useState } from 'react';
+import { StateWrap, SwapFormActionTypeValues } from './types';
 import { useSwap } from '@yoroi/swap';
 import Context from './context';
 import { Quantities } from '../../../../utils/quantities';
 import SwapStore from '../../../../stores/ada/SwapStore';
 import { defaultSwapFormState } from './DefaultSwapFormState';
+import { PRICE_PRECISION } from '../../../../components/swap/common';
 
 // const PRECISION = 14;
 
@@ -28,6 +29,7 @@ export default function SwapFormProvider({ swapStore, children }: Props): Node {
     sellTokenInfoChanged,
     switchTokens,
     resetQuantities,
+    limitPriceChanged,
   } = useSwap();
 
   const { quantity: buyQuantity } = orderData.amounts.buy;
@@ -195,6 +197,10 @@ export default function SwapFormProvider({ swapStore, children }: Props): Node {
     actions.buyInputValueChanged(input);
   };
 
+  const limitPriceUpdateHandler = ({ input }) => {
+    actions.limitPriceInputValueChanged(input);
+  };
+
   const onChangeSellQuantity = useCallback(
     baseSwapFieldChangeHandler(swapFormState.sellTokenInfo, sellUpdateHandler),
     [sellQuantityChanged, actions, clearErrors]
@@ -205,8 +211,25 @@ export default function SwapFormProvider({ swapStore, children }: Props): Node {
     [buyQuantityChanged, actions, clearErrors]
   );
 
+  const onChangeLimitPrice = useCallback(
+    text => {
+      const [formattedPrice, price] = Quantities.parseFromText(
+        text,
+        orderData.tokens.priceDenomination,
+        numberLocale,
+        PRICE_PRECISION
+      );
+      actions.limitPriceInputValueChanged(formattedPrice);
+      limitPriceChanged(price);
+
+      clearErrors();
+    },
+    [actions, clearErrors, orderData.tokens.priceDenomination, limitPriceChanged, numberLocale]
+  );
+
   const sellFocusState = StateWrap<boolean>(useState(false));
   const buyFocusState = StateWrap<boolean>(useState(false));
+  const limitPriceFocusState = StateWrap<boolean>(useState(false));
 
   const updateSellInput = useCallback(() => {
     if (swapFormState.sellQuantity.isTouched && !sellFocusState.value) {
@@ -224,15 +247,43 @@ export default function SwapFormProvider({ swapStore, children }: Props): Node {
     }
   }, [buyQuantity, swapFormState.buyTokenInfo.decimals, swapFormState.buyQuantity.isTouched]);
 
+  const updateLimitPrice = useCallback(() => {
+    if (orderData.type === 'limit' && !limitPriceFocusState.value) {
+      const formatted = Quantities.format(
+        orderData.limitPrice ?? Quantities.zero,
+        orderData.tokens.priceDenomination,
+        PRICE_PRECISION
+      );
+
+      limitPriceUpdateHandler({ input: formatted });
+    } else if (orderData.type === 'market') {
+      const formatted = Quantities.format(
+        orderData.selectedPoolCalculation?.prices.market ?? Quantities.zero,
+        orderData.tokens.priceDenomination,
+        PRICE_PRECISION
+      );
+
+      limitPriceUpdateHandler({ input: formatted });
+    }
+  }, [
+    orderData.tokens.priceDenomination,
+    orderData.limitPrice,
+    orderData.selectedPoolCalculation?.prices.market,
+    orderData.type,
+  ]);
+
   useEffect(updateSellInput, [updateSellInput]);
   useEffect(updateBuyInput, [updateBuyInput]);
+  useEffect(updateLimitPrice, [updateLimitPrice]);
 
   const allActions = {
     ...actions,
     sellFocusState,
     buyFocusState,
+    limitPriceFocusState,
     onChangeSellQuantity,
     onChangeBuyQuantity,
+    onChangeLimitPrice,
   };
 
   return (

--- a/packages/yoroi-extension/app/containers/swap/context/swap-form/context.js
+++ b/packages/yoroi-extension/app/containers/swap/context/swap-form/context.js
@@ -26,6 +26,7 @@ const initialSwapFormContext: SwapFormContext = {
   canSwapChanged: missingInit,
   sellFocusState: ConstantState(false),
   buyFocusState: ConstantState(false),
+  limitPriceFocusState: ConstantState(false),
   onChangeSellQuantity: missingInit,
   onChangeBuyQuantity: missingInit,
   onChangeLimitPrice: missingInit,

--- a/packages/yoroi-extension/app/containers/swap/context/swap-form/types.js
+++ b/packages/yoroi-extension/app/containers/swap/context/swap-form/types.js
@@ -85,6 +85,7 @@ export type SwapFormContext = {|
   ...SwapFormActions,
   sellFocusState: State<boolean>,
   buyFocusState: State<boolean>,
+  limitPriceFocusState: State<boolean>,
   onChangeSellQuantity: (text: string) => void,
   onChangeBuyQuantity: (text: string) => void,
   onChangeLimitPrice: (text: string) => void,

--- a/packages/yoroi-extension/app/stores/ada/SwapStore.js
+++ b/packages/yoroi-extension/app/stores/ada/SwapStore.js
@@ -37,7 +37,6 @@ const FRONTEND_FEE_ADDRESS_PREPROD =
   'addr_test1qrgpjmyy8zk9nuza24a0f4e7mgp9gd6h3uayp0rqnjnkl54v4dlyj0kwfs0x4e38a7047lymzp37tx0y42glslcdtzhqzp57km';
 
 export default class SwapStore extends Store<StoresMap, ActionsMap> {
-  @observable limitOrderDisplayValue: string = '';
   @observable orderStep: number = 0;
   @observable transactionTimestamps: { [string]: Date } = {};
 
@@ -45,14 +44,6 @@ export default class SwapStore extends Store<StoresMap, ActionsMap> {
     'SwapStore.swapDisclaimerAcceptanceFlag',
     false
   );
-
-  @action setLimitOrderDisplayValue: string => void = (val: string) => {
-    this.limitOrderDisplayValue = val;
-  };
-
-  @action resetLimitOrderDisplayValue: void => void = () => {
-    this.limitOrderDisplayValue = '';
-  };
 
   @action setOrderStepValue: number => void = (val: number) => {
     this.orderStep = val;


### PR DESCRIPTION
**Description**
While we had selected "Limit order" and we try to edit the price, if we press the delete button or any number on keyboard, several zeros are added/removed and the value does not update the token quantities. This PR fixes it.

**Screenshots**
![image](https://github.com/Emurgo/yoroi-frontend/assets/22194171/d7a5038e-6075-451c-a875-a1de993587cf)
![image](https://github.com/Emurgo/yoroi-frontend/assets/22194171/63b19630-322e-44e9-8c68-41975a2272af)

