### PR TITLE
[5.2.100] fix pool transition

### DIFF
--- a/packages/yoroi-extension/app/components/wallet/staking/dashboard-revamp/DelegatedStakePoolCard.js
+++ b/packages/yoroi-extension/app/components/wallet/staking/dashboard-revamp/DelegatedStakePoolCard.js
@@ -14,7 +14,7 @@ import type { PoolTransition } from '../../../../stores/toplevel/DelegationStore
 type Props = {|
   delegatedPool: PoolData,
   +undelegate: void | (void => Promise<void>),
-  poolTransition?: PoolTransition,
+  poolTransition: ?PoolTransition,
   delegateToSpecificPool: (id: ?string) => void,
 |};
 

--- a/packages/yoroi-extension/app/containers/wallet/staking/StakingPageContent.js
+++ b/packages/yoroi-extension/app/containers/wallet/staking/StakingPageContent.js
@@ -34,16 +34,12 @@ import { compose, maybe, noop } from '../../../coreUtils';
 
 // populated by ConfigWebpackPlugin
 declare var CONFIG: ConfigType;
-type Props = {|
-  ...StoresAndActionsProps,
-  actions: any,
-  stores: any,
-|};
+
 type InjectedLayoutProps = {|
   +renderLayoutComponent: LayoutComponentMap => Node,
 |};
 
-type AllProps = {| ...Props, ...InjectedLayoutProps |};
+type AllProps = {| ...StoresAndActionsProps, ...InjectedLayoutProps |};
 @observer
 class StakingPageContent extends Component<AllProps> {
   static contextTypes: {| intl: $npm$ReactIntl$IntlFormat |} = {
@@ -62,7 +58,7 @@ class StakingPageContent extends Component<AllProps> {
 
     if (this.props.stores.delegation.getPoolTransitionConfig(publicDeriver).shouldUpdatePool) {
       const poolTransitionInfo = this.props.stores.delegation.getPoolTransitionInfo(publicDeriver);
-      if (poolTransitionInfo) {
+      if (poolTransitionInfo?.suggestedPool) {
         this.props.stores.delegation.delegateToSpecificPool(poolTransitionInfo.suggestedPool.hash);
         noop(this.props.stores.delegation.createDelegationTransaction());
       }
@@ -243,7 +239,7 @@ class StakingPageContent extends Component<AllProps> {
                 if (!showRewardAmount) return undefined;
                 return currentlyDelegating
                   ? maybe(delegatedUtxo, w => delegatedRewards.joinAddCopy(w))
-                  : publicDeriver.getDefaultMultiToken();
+                  : maybe(publicDeriver, w => w.getParent().getDefaultMultiToken());
               })()}
               graphData={generateGraphData({
                 publicDeriver,
@@ -354,7 +350,7 @@ class StakingPageContent extends Component<AllProps> {
     );
   }
 }
-export default (withLayout(StakingPageContent): ComponentType<Props>);
+export default (withLayout(StakingPageContent): ComponentType<StoresAndActionsProps>);
 
 const WrapperCards = styled(Box)({
   display: 'flex',

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.2.0",
+  "version": "5.2.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.2.0",
+      "version": "5.2.100",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-browser": "^2.1.3",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.2.0",
+  "version": "5.2.100",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev-mv2": "rimraf dev/ && NODE_OPTIONS=--openssl-legacy-provider babel-node scripts-mv2/build --type=debug --env 'mainnet'",


### PR DESCRIPTION
There are two bugs in the pool transition code.

Flow did not catch them because the `any` type in `Props` propagates down and disables flow checks entirely.