### PR TITLE
fix: change old var color

### DIFF
--- a/packages/yoroi-extension/app/styles/globalStyles.js
+++ b/packages/yoroi-extension/app/styles/globalStyles.js
@@ -106,8 +106,8 @@ export function getMainYoroiPalette(theme: ColorPaletteForStyles): { [string]: s
     '--yoroi-palette-secondary-contrastText': theme.palette.ds.text_gray_medium,
 
     '--yoroi-palette-error-50': theme.palette.ds.text_error,
-    '--yoroi-palette-error-100': theme.palette.ds.sys_magenta_100,
-    '--yoroi-palette-error-200': theme.palette.ds.sys_magenta_300,
+    '--yoroi-palette-error-100': theme.palette.ds.text_error,
+    '--yoroi-palette-error-200': theme.palette.ds.text_error,
 
     '--yoroi-palette-cyan-50': theme.palette.ds.sys_cyan_100,
     '--yoroi-palette-cyan-100': theme.palette.ds.sys_cyan_500,


### PR DESCRIPTION
- The old UI had different colors for error cases, the new UI has more consistency in design, and now we have just one color for error text. Have added the same token for all old CSS vars until will be removed 