### PR TITLE
Fix Catalyst Vote registration amount field appearance 

### DIFF
--- a/packages/yoroi-extension/app/components/common/NumericInputRP.js
+++ b/packages/yoroi-extension/app/components/common/NumericInputRP.js
@@ -484,7 +484,7 @@ class AmountInput extends Component<AmountInputProps> {
           variant="body3"
           sx={{
             position: 'absolute',
-            bottom: '45px',
+            bottom: '72px',
             right: error != null && error !== '' ? '45px' : '10px',
             color: 'grayscale.900',
             textTransform: 'uppercase',


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/d7bfc793-4e6e-4c07-938a-c69735845661)


After

![Screenshot 2024-10-09 at 19 21 24](https://github.com/user-attachments/assets/21a62869-a739-487f-95c6-77a104e0ce59)
