### PR TITLE
[5.4.200] Catalyst QR-code fix

### DIFF
--- a/packages/yoroi-extension/app/components/wallet/receive/StandardHeaderRevamp.js
+++ b/packages/yoroi-extension/app/components/wallet/receive/StandardHeaderRevamp.js
@@ -109,7 +109,7 @@ export default class StandardHeaderRevamp extends Component<Props> {
                   },
                 }}
               >
-                <QrCodeWrapper fgColor="#000" value={walletAddress} size={153} id={locationId + '-addressQrCode-image'} />
+                <QrCodeWrapper value={walletAddress} size={153} id={locationId + '-addressQrCode-image'} />
               </Box>
             </QrCodeBackground>
           </Box>

--- a/packages/yoroi-extension/app/components/wallet/receive/VerifyAddressDialog.js
+++ b/packages/yoroi-extension/app/components/wallet/receive/VerifyAddressDialog.js
@@ -145,7 +145,7 @@ class VerifyAddressDialog extends Component<Props & InjectedLayoutProps> {
     return (
       <>
         <div align="center">
-          <QrCodeWrapper fgColor="black" value={this.props.addressInfo.address} size={152} />
+          <QrCodeWrapper value={this.props.addressInfo.address} size={152} />
         </div>
         <br />
         <br />

--- a/packages/yoroi-extension/app/components/widgets/QrCodeWrapper.js
+++ b/packages/yoroi-extension/app/components/widgets/QrCodeWrapper.js
@@ -17,7 +17,7 @@ const QrCodeWrapper = ({ value, size, id = 'qr-code', includeMargin = false}: Pr
     <QRCode
       value={value}
       bgColor={theme.palette.ds.white_static}
-      fgColor={theme.palette.ds.static_dark}
+      fgColor={theme.palette.ds.black_static}
       size={size}
       includeMargin={includeMargin}
       id={id}

--- a/packages/yoroi-extension/app/components/widgets/QrCodeWrapper.js
+++ b/packages/yoroi-extension/app/components/widgets/QrCodeWrapper.js
@@ -8,21 +8,16 @@ type Props = {|
   +size: number,
   +id?: string,
   +includeMargin?: boolean,
-  +addBg?: boolean,
-  +fgColor?: string,
 |};
 
-const QrCodeWrapper = ({ value, size, id = 'qr-code', includeMargin = false, addBg = true }: Props): Node => {
+const QrCodeWrapper = ({ value, size, id = 'qr-code', includeMargin = false}: Props): Node => {
   const theme = useTheme();
-  // Get QRCode color value from active theme's CSS variable
-  const qrCodeBackgroundColor = addBg ? theme.palette.ds.el_gray_max : theme.palette.ds.white_static;
-  const qrCodeForegroundColor = theme.palette.ds.gray_min;
 
   return (
     <QRCode
       value={value}
-      bgColor={qrCodeBackgroundColor}
-      fgColor={qrCodeForegroundColor}
+      bgColor={theme.palette.ds.white_static}
+      fgColor={theme.palette.ds.static_dark}
       size={size}
       includeMargin={includeMargin}
       id={id}

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.4.100",
+  "version": "5.4.200",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.4.100",
+      "version": "5.4.200",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-browser": "^2.1.3",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.4.100",
+  "version": "5.4.200",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev-mv2": "rimraf dev/ && NODE_OPTIONS=--openssl-legacy-provider babel-node scripts-mv2/build --type=debug --env 'mainnet'",


### PR DESCRIPTION
Removed useless condition `addBg`, because it wasn't used anywhere in the app.
Removed unused property `fgColor`, because it wasn't used in the QrCodeWrapper.
Made qr-code colours static

https://emurgo.atlassian.net/browse/YOEXT-1447