### PR TITLE
fix(swap): disable switch if pair token is not selected

### DIFF
--- a/packages/yoroi-extension/app/containers/swap/asset-swap/actions/MiddleActions.js
+++ b/packages/yoroi-extension/app/containers/swap/asset-swap/actions/MiddleActions.js
@@ -4,16 +4,24 @@ import { ReactComponent as SwitchIcon } from '../../../../assets/images/revamp/i
 import { useSwapForm } from '../../context/swap-form';
 
 export const MiddleActions = (): React$Node => {
-  const { clearSwapForm, switchTokens, onChangeLimitPrice } = useSwapForm();
+  const { clearSwapForm, switchTokens, onChangeLimitPrice, buyTokenInfo = {} } = useSwapForm();
+
+  const handleSwitchTokens = () => {
+    // we have ticker on the buy side, so we can safely switch
+    if (buyTokenInfo?.ticker) {
+      onChangeLimitPrice('');
+      return switchTokens();
+    }
+  };
 
   return (
     <Box display="flex" alignItems="center" justifyContent="space-between">
       <Box
-        sx={{ cursor: 'pointer', color: 'primary.500' }}
-        onClick={() => {
-          onChangeLimitPrice('');
-          return switchTokens();
+        sx={{
+          cursor: buyTokenInfo?.ticker ? 'pointer' : 'not-allowed',
+          color: buyTokenInfo?.ticker ? 'primary.500' : 'grayscale.400',
         }}
+        onClick={handleSwitchTokens}
       >
         <SwitchIcon />
       </Box>


### PR DESCRIPTION
**Description**
Disable the swap icon if the second token to swap is not selected to avoid weird user interaction + status bugged. Once buy token is selected, the button is enabled again.

**Screenshots**
_Disabled_
![image](https://github.com/user-attachments/assets/7396de89-38b2-4c68-a165-25e415b5a5c7)

_Enabled_
![image](https://github.com/user-attachments/assets/ea342bcb-416b-41fe-bdd2-d2392276b04f)
