### PR TITLE
fix cashbak wrong wallet popup

### DIFF
--- a/packages/yoroi-extension/app/containers/cashback/CashbackPage.js
+++ b/packages/yoroi-extension/app/containers/cashback/CashbackPage.js
@@ -392,7 +392,7 @@ const CashbackPageContainer = observer((props: AllProps) => {
         return 'nonsense';
       })
       .catch(console.error);
-  }, []);
+  }, [stores.wallets.selected?.publicDeriverId]);
 
   const [shouldShowDisclaimer, setShouldShowDisclaimer] = useState(false);
 
@@ -461,6 +461,8 @@ const CashbackPageContainer = observer((props: AllProps) => {
             }}
             onSwitchToCashbackWallet={() => {
               stores.wallets.setActiveWallet({ publicDeriverId: shownCashbackWallet.publicDeriverId });
+              setShownCashbackWallet(null);
+              setPopup(false);
             }}
           />
         )}


### PR DESCRIPTION
Fix two issues with the cashback page pop-up dialog:

1. If the user is already on this page and the current wallet is the cashback wallet, after switching wallet, the pop-up should show.

2. After the user confirms to switch wallet, the pop-up should disappear.