### PR TITLE
fix: YOEXT-2216 [Portfolio] A token with zero percentage change is sorted incorrectly

### DIFF
--- a/packages/yoroi-extension/app/UI/features/portfolio/common/hooks/useTableSort.ts
+++ b/packages/yoroi-extension/app/UI/features/portfolio/common/hooks/useTableSort.ts
@@ -25,7 +25,7 @@ const useTableSort = ({ order, orderBy, setSortState, headCells, data }: Props) 
   };
 
   const compareValues = (a: any, b: any, sortType: TableSortType, sortOrder: 'asc' | 'desc', sortKey: string): number => {
-    const isInvalid = (val: any) => isNaN(Number(val)) || Number(val) === 0;
+    const isInvalid = (val: any) => isNaN(Number(val));
 
     if (['price', 'portfolio', 'totalAmount', '24h', '1W', '1M'].includes(sortKey)) {
       const aInvalid = isInvalid(a[sortKey]);


### PR DESCRIPTION
<img width="1079" height="859" alt="Screenshot 2025-09-22 at 2 59 02 PM" src="https://github.com/user-attachments/assets/559e0871-7670-4122-b334-225305e583ac" />
<img width="1079" height="859" alt="Screenshot 2025-09-22 at 2 58 58 PM" src="https://github.com/user-attachments/assets/3e065989-cd6d-4ef2-98a1-52bc7a5cda7d" />
