### PR TITLE
[E2E] Ignore unstoppable domains

### DIFF
--- a/packages/e2e-tests/test/Send_01_handles.test.js
+++ b/packages/e2e-tests/test/Send_01_handles.test.js
@@ -1,4 +1,3 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import BasePage from '../pages/basepage.js';
 import driversPoolsManager from '../utils/driversPool.js';
@@ -54,6 +53,9 @@ describe('Handle handles', function () {
   ];
 
   for (const testDatum of testDataPositive) {
+    if (testDatum.provider === 'Unstoppable Domains') {
+      continue;
+    }
     describe(`Positive case, ${testDatum.provider}`, function () {
       it(`Refresh page, ${testDatum.provider}`, async function () {
         const transactionsPage = new TransactionsSubTab(webdriver, logger);
@@ -121,7 +123,7 @@ describe('Handle handles', function () {
   }
 
   for (const testNegativeDatum of testDataNegative) {
-    if (testNegativeDatum.provider === 'Unstoppable Domains' && isLocalRun()) {
+    if (testNegativeDatum.provider === 'Unstoppable Domains') {
       continue;
     }
     describe(`Negative case, ${testNegativeDatum.provider}`, function () {


### PR DESCRIPTION
Not great and not fix. We will ignore unstoppable domains until we find a way to set correct header in browser.
Part of the task: https://emurgo.atlassian.net/browse/YOEXT-2327