### PR TITLE
[Bump] Nightly Version: 5.16.2.1

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.16.2",
+  "version": "5.16.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.16.2",
+      "version": "5.16.2.1",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-browser": "^2.1.3",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.16.2",
+  "version": "5.16.2.1",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:main": "NODE_OPTIONS=--openssl-legacy-provider babel-node scripts/dev main --env mainnet",


### PR DESCRIPTION
This PR was created automatically using GitHub Actions.
Updating the version after publishing the new nightly version from branch `release/5.17.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `packages/yoroi-extension` version from `5.16.2` to `5.16.2.1` in `package.json` and `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d86a0a91a2bceaa7bc8983b6d499dafbd130f13b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->