### PR TITLE
[Bump] Nightly Version: 5.17.0.1

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.17.0",
+  "version": "5.17.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.17.0",
+      "version": "5.17.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",
@@ -38,7 +38,7 @@
         "@yoroi/portfolio": "1.0.3",
         "@yoroi/resolver": "2.0.2",
         "@yoroi/staking": "^1.6.0",
-        "@yoroi/swap": "7.0.0",
+        "@yoroi/swap": "7.0.3",
         "@yoroi/types": "6.0.0",
         "assert": "2.1.0",
         "async-await-queue": "2.1.4",
@@ -9803,9 +9803,10 @@
       }
     },
     "node_modules/@yoroi/swap": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@yoroi/swap/-/swap-7.0.0.tgz",
-      "integrity": "sha512-iiX/2lhPj2UPPHWcc2losUPNw5V0qXYT3cFWXN6gKFk4NgMaNyenDcDsr+rqDb0RLuvQYQZd4LHf63h5kOGucA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@yoroi/swap/-/swap-7.0.3.tgz",
+      "integrity": "sha512-C702cBCWoT9Dq4n5uWH7ZihEatTfidJRx1QPcuBVtwql8Q8/q34xTS07Gqr8he2OgTu90kroNHNmspKj/e3vKw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 22.12.0"
       },

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.17.0",
+  "version": "5.17.0.1",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:main": "NODE_OPTIONS=--openssl-legacy-provider babel-node scripts/dev main --env mainnet",


### PR DESCRIPTION
This PR was created automatically using GitHub Actions.
Updating the version after publishing the new nightly version from branch `release/5.18.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps extension version to 5.17.0.1 and upgrades @yoroi/swap to 7.0.3.
> 
> - **Versioning**:
>   - Bump `packages/yoroi-extension` version to `5.17.0.1`.
> - **Dependencies**:
>   - Upgrade `@yoroi/swap` from `7.0.0` to `7.0.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caceba120f778392ab4f327dbf9ff56011d09530. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->