### PR TITLE
Fix- Asset Details UI 

### DIFF
--- a/packages/yoroi-extension/app/UI/components/buttons/CopyButton.tsx
+++ b/packages/yoroi-extension/app/UI/components/buttons/CopyButton.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from 'react';
 import { Icons, IconWrapper } from '../icons/index';
 import { Tooltip } from '../Tooltip';
-import type { PlacesType } from 'react-tooltip';
 import { defineMessages, useIntl } from 'react-intl';
 import { Box } from '@mui/material';
 
@@ -21,10 +20,9 @@ interface Props {
   textToCopy: string;
   disabled?: boolean;
   pathTestId?: string;
-  place?: PlacesType;
 }
 
-export const CopyButton = ({ textToCopy, disabled, pathTestId = '', place = 'bottom', ...props }: Props) => {
+export const CopyButton = ({ textToCopy, disabled, pathTestId = '', ...props }: Props) => {
   const [copied, setCopied] = useState(false);
   const intl = useIntl();
   const strings = useRef({
@@ -42,7 +40,7 @@ export const CopyButton = ({ textToCopy, disabled, pathTestId = '', place = 'bot
 
   return (
     <Box onClick={handleCopy} {...props} id={`${pathTestId}-copy-button`}>
-      <Tooltip title={copied ? strings.copied : strings.copyToClipboard} arrow place={place}>
+      <Tooltip title={copied ? strings.copied : strings.copyToClipboard} arrow place="left-start">
         <IconWrapper
           disabled={disabled}
           buttonProps={{ sx: { padding: 0 } }}

--- a/packages/yoroi-extension/app/UI/components/buttons/CopyButton.tsx
+++ b/packages/yoroi-extension/app/UI/components/buttons/CopyButton.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { Icons, IconWrapper } from '../icons/index';
 import { Tooltip } from '../Tooltip';
+import type { PlacesType } from 'react-tooltip';
 import { defineMessages, useIntl } from 'react-intl';
 import { Box } from '@mui/material';
 
@@ -16,14 +17,14 @@ export const messages = Object.freeze(
     },
   })
 );
-
 interface Props {
   textToCopy: string;
   disabled?: boolean;
   pathTestId?: string;
+  place?: PlacesType;
 }
 
-export const CopyButton = ({ textToCopy, disabled, pathTestId = '', ...props }: Props) => {
+export const CopyButton = ({ textToCopy, disabled, pathTestId = '', place = 'bottom', ...props }: Props) => {
   const [copied, setCopied] = useState(false);
   const intl = useIntl();
   const strings = useRef({
@@ -41,7 +42,7 @@ export const CopyButton = ({ textToCopy, disabled, pathTestId = '', ...props }: 
 
   return (
     <Box onClick={handleCopy} {...props} id={`${pathTestId}-copy-button`}>
-      <Tooltip title={copied ? strings.copied : strings.copyToClipboard} arrow place="left-start">
+      <Tooltip title={copied ? strings.copied : strings.copyToClipboard} arrow place={place}>
         <IconWrapper
           disabled={disabled}
           buttonProps={{ sx: { padding: 0 } }}

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/components/AssetSummary.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/components/AssetSummary.tsx
@@ -21,6 +21,7 @@ export const AssetSummary = ({ tokenId, value, direction }: AssetSummaryProps) =
   const effective = swapForm?.estimate?.priceImpact ?? 0;
   const risk = getPriceImpactRisk(effective);
   const { text: textColor } = usePriceImpactRiskThemeWeb(risk);
+  const tokenTicker = tokenInfo?.ticker ?? tokenInfo?.name ?? '-';
 
   return (
     <Stack direction="row" justifyContent="space-between" alignItems="center">
@@ -38,14 +39,14 @@ export const AssetSummary = ({ tokenId, value, direction }: AssetSummaryProps) =
             {isPrimaryToken ? primaryTokenInfo.ticker : tokenInfo?.name}
           </Typography>
           <Typography variant="body2" color="ds.text_gray_low">
-            {isPrimaryToken ? primaryTokenInfo.name : (tokenInfo?.name ?? truncateLongName(tokenInfo?.fingerprint))}
+            {isPrimaryToken ? primaryTokenInfo.name : (tokenTicker ?? truncateLongName(tokenInfo?.fingerprint))}
           </Typography>
         </Stack>
       </Stack>
       <Stack spacing={4} direction="row" alignItems="center">
         {direction === ASSET_DIRECTION_OUT && <PriceImpactIcon risk={risk} />}
         <Typography variant="body1" color={textColor}>
-          {value} {isPrimaryToken ? primaryTokenInfo.name : tokenInfo?.name}
+          {value} {isPrimaryToken ? primaryTokenInfo.name : tokenTicker}
         </Typography>
       </Stack>
     </Stack>

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/components/AssetSummary.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/components/AssetSummary.tsx
@@ -21,7 +21,7 @@ export const AssetSummary = ({ tokenId, value, direction }: AssetSummaryProps) =
   const effective = swapForm?.estimate?.priceImpact ?? 0;
   const risk = getPriceImpactRisk(effective);
   const { text: textColor } = usePriceImpactRiskThemeWeb(risk);
-  const tokenTicker = tokenInfo?.ticker ?? tokenInfo?.name ?? '-';
+  const tokenTicker = tokenInfo?.ticker ?? tokenInfo?.name;
 
   return (
     <Stack direction="row" justifyContent="space-between" alignItems="center">
@@ -46,7 +46,7 @@ export const AssetSummary = ({ tokenId, value, direction }: AssetSummaryProps) =
       <Stack spacing={4} direction="row" alignItems="center">
         {direction === ASSET_DIRECTION_OUT && <PriceImpactIcon risk={risk} />}
         <Typography variant="body1" color={textColor}>
-          {value} {isPrimaryToken ? primaryTokenInfo.name : tokenTicker}
+          {value} {isPrimaryToken ? primaryTokenInfo.name : (tokenTicker ?? truncateLongName(tokenInfo?.fingerprint))}
         </Typography>
       </Stack>
     </Stack>

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/components/DisplayInfoInRow.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/components/DisplayInfoInRow.tsx
@@ -7,12 +7,13 @@ type DisplayInfoInRowProps = {
   tooltip?: string | ReactNode;
   value: string | ReactNode;
   textToCopy?: string;
+  valueInSameRow?: boolean;
 };
 
-export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy }: DisplayInfoInRowProps) => {
+export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy, valueInSameRow = true }: DisplayInfoInRowProps) => {
   const { atoms }: any = useTheme();
   return (
-    <Stack direction="row" width="100%" justifyContent="space-between" alignItems="start">
+    <Stack direction={valueInSameRow ? 'row' : 'column'} width="100%" justifyContent="space-between" alignItems="start" gap={4}>
       <Stack direction="row" alignItems="start">
         <Typography variant="body2" color="ds.el_gray_low" {...atoms.mr_xs}>
           {label}
@@ -25,7 +26,7 @@ export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy }: DisplayI
       </Stack>
       <Stack direction="row" alignItems="center" gap={4}>
         {typeof value === 'string' ? (
-          <Typography variant="body2" color="ds.text_gray_max">
+          <Typography variant="body1" color="ds.text_gray_max">
             {value}
           </Typography>
         ) : (

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/components/DisplayInfoInRow.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/components/DisplayInfoInRow.tsx
@@ -1,17 +1,15 @@
 import { Stack, Typography, useTheme } from '@mui/material';
 import { ReactNode } from 'react';
 import { CopyButton, Icons, IconWrapper, Tooltip } from '../../../../components';
-import type { PlacesType } from 'react-tooltip';
 
 type DisplayInfoInRowProps = {
   label: string;
   tooltip?: string | ReactNode;
   value: string | ReactNode;
   textToCopy?: string;
-  tooltipPlace?: PlacesType;
 };
 
-export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy, tooltipPlace = 'bottom' }: DisplayInfoInRowProps) => {
+export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy }: DisplayInfoInRowProps) => {
   const { atoms }: any = useTheme();
   return (
     <Stack direction="row" width="100%" justifyContent="space-between" alignItems="start">
@@ -33,7 +31,7 @@ export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy, tooltipPla
         ) : (
           value
         )}
-        {textToCopy && <CopyButton textToCopy={textToCopy} place={tooltipPlace} />}
+        {textToCopy && <CopyButton textToCopy={textToCopy} />}
       </Stack>
     </Stack>
   );

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/components/DisplayInfoInRow.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/components/DisplayInfoInRow.tsx
@@ -1,19 +1,21 @@
 import { Stack, Typography, useTheme } from '@mui/material';
 import { ReactNode } from 'react';
 import { CopyButton, Icons, IconWrapper, Tooltip } from '../../../../components';
+import type { PlacesType } from 'react-tooltip';
 
 type DisplayInfoInRowProps = {
   label: string;
   tooltip?: string | ReactNode;
   value: string | ReactNode;
   textToCopy?: string;
+  tooltipPlace?: PlacesType;
 };
 
-export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy }: DisplayInfoInRowProps) => {
+export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy, tooltipPlace = 'bottom' }: DisplayInfoInRowProps) => {
   const { atoms }: any = useTheme();
   return (
-    <Stack direction="row" width="100%" justifyContent="space-between" alignItems="center">
-      <Stack direction="row" alignItems="center">
+    <Stack direction="row" width="100%" justifyContent="space-between" alignItems="start">
+      <Stack direction="row" alignItems="start">
         <Typography variant="body2" color="ds.el_gray_low" {...atoms.mr_xs}>
           {label}
         </Typography>
@@ -31,7 +33,7 @@ export const DisplayInfoInRow = ({ label, tooltip, value, textToCopy }: DisplayI
         ) : (
           value
         )}
-        {textToCopy && <CopyButton textToCopy={textToCopy} />}
+        {textToCopy && <CopyButton textToCopy={textToCopy} place={tooltipPlace} />}
       </Stack>
     </Stack>
   );

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/components/Modals/TokenInfoModal.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/components/Modals/TokenInfoModal.tsx
@@ -18,8 +18,8 @@ const TokenInfoModal = ({ token }) => {
       </Typography>
       {!isPrimary && (
         <>
-          <DisplayInfoInRow label="Policy ID" value={truncateAddressShort(token.id)} textToCopy={token.id}  />
-          <DisplayInfoInRow label="Fingerprint" value={token.fingerprint} textToCopy={token.fingerprint} />
+          <DisplayInfoInRow label="Policy ID" value={truncateAddressShort(token.id)} textToCopy={token.id} tooltipPlace="top" />
+          <DisplayInfoInRow label="Fingerprint" value={token.fingerprint} textToCopy={token.fingerprint} tooltipPlace="bottom" />
         </>
       )}
 
@@ -36,23 +36,23 @@ const TokenInfoModal = ({ token }) => {
         <DisplayInfoInRow label="Name" value={token.name} />
         <DisplayInfoInRow label="Tiker" value={token.ticker} />
         <DisplayInfoInRow label="Description" value={token.description || '-'} />
-        <DisplayInfoInRow
-          label="Details On"
-          value={
-            <LinkMui
-              target="_blank"
-              href={
-                isPrimary
-                  ? explorer.tokenInfo.baseUrl.replace(/^(https?:\/\/[^\/]+)\/.*/, '$1')
-                  : `${explorer.tokenInfo.baseUrl}${token.fingerprint}`
-              }
-              rel="noopener noreferrer"
-              sx={{ textDecoration: 'none' }}
-            >
-              {explorer.tokenInfo.name}
-            </LinkMui>
-          }
-        />
+        <Stack direction="column" gap={4}>
+          <Typography variant="body2" color="ds.el_gray_low">
+            {strings.detailsOn}
+          </Typography>
+          <LinkMui
+            target="_blank"
+            href={
+              isPrimary
+                ? explorer.tokenInfo.baseUrl.replace(/^(https?:\/\/[^\/]+)\/.*/, '$1')
+                : `${explorer.tokenInfo.baseUrl}${token.fingerprint}`
+            }
+            rel="noopener noreferrer"
+            sx={{ textDecoration: 'none' }}
+          >
+            {explorer.tokenInfo.name}
+          </LinkMui>
+        </Stack>
       </Stack>
     </Stack>
   );

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/components/Modals/TokenInfoModal.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/components/Modals/TokenInfoModal.tsx
@@ -18,8 +18,8 @@ const TokenInfoModal = ({ token }) => {
       </Typography>
       {!isPrimary && (
         <>
-          <DisplayInfoInRow label="Policy ID" value={truncateAddressShort(token.id)} textToCopy={token.id} tooltipPlace="top" />
-          <DisplayInfoInRow label="Fingerprint" value={token.fingerprint} textToCopy={token.fingerprint} tooltipPlace="bottom" />
+          <DisplayInfoInRow label="Policy ID" value={truncateAddressShort(token.id)} textToCopy={token.id} />
+          <DisplayInfoInRow label="Fingerprint" value={token.fingerprint} textToCopy={token.fingerprint} />
         </>
       )}
 

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/components/Modals/TokenInfoModal.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/components/Modals/TokenInfoModal.tsx
@@ -35,24 +35,25 @@ const TokenInfoModal = ({ token }) => {
         </Typography>
         <DisplayInfoInRow label="Name" value={token.name} />
         <DisplayInfoInRow label="Tiker" value={token.ticker} />
-        <DisplayInfoInRow label="Description" value={token.description || '-'} />
-        <Stack direction="column" gap={4}>
-          <Typography variant="body2" color="ds.el_gray_low">
-            {strings.detailsOn}
-          </Typography>
-          <LinkMui
-            target="_blank"
-            href={
-              isPrimary
-                ? explorer.tokenInfo.baseUrl.replace(/^(https?:\/\/[^\/]+)\/.*/, '$1')
-                : `${explorer.tokenInfo.baseUrl}${token.fingerprint}`
-            }
-            rel="noopener noreferrer"
-            sx={{ textDecoration: 'none' }}
-          >
-            {explorer.tokenInfo.name}
-          </LinkMui>
-        </Stack>
+        <DisplayInfoInRow label="Description" value={token.description || '-'} valueInSameRow={false} />
+        <DisplayInfoInRow
+          label="Details On"
+          value={
+            <LinkMui
+              target="_blank"
+              href={
+                isPrimary
+                  ? explorer.tokenInfo.baseUrl.replace(/^(https?:\/\/[^\/]+)\/.*/, '$1')
+                  : `${explorer.tokenInfo.baseUrl}${token.fingerprint}`
+              }
+              rel="noopener noreferrer"
+              sx={{ textDecoration: 'none' }}
+            >
+              {explorer.tokenInfo.name}
+            </LinkMui>
+          }
+          valueInSameRow={false}
+        />
       </Stack>
     </Stack>
   );

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/hooks/useStrings.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/hooks/useStrings.tsx
@@ -272,6 +272,10 @@ export const messages = Object.freeze(
       id: 'portfolio.tokenInfo.menuLabel.overview',
       defaultMessage: '!!!Overview',
     },
+    detailsOn: {
+      id: 'wallet.assets.detailsOn',
+      defaultMessage: '!!!Details on',
+    },
   })
 );
 
@@ -340,6 +344,7 @@ export const useStrings = () => {
     confirmLabel: intl.formatMessage(messages.confirm),
     assetDetails: intl.formatMessage(messages.assetDetails),
     overviewLabel: intl.formatMessage(messages.overviewLabel),
+    detailsOn: intl.formatMessage(messages.detailsOn),
     numYourAssets: num => intl.formatMessage(messages.numYourAssets, { num }),
     priceImpactSevere: intl.formatMessage(messages.priceImpactSevere, {
       strong: chunks => React.createElement('strong', null, chunks),


### PR DESCRIPTION
task:
- https://emurgo.atlassian.net/browse/YOEXT-2254

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves swap token details by showing tickers when available, adding flexible row/column info rows, updating Token Info modal layout, and introducing an i18n string for “Details on.”
> 
> - **Swap UI**:
>   - `AssetSummary`: use `tokenTicker` (ticker fallback to name) in labels/values; fallback to truncated fingerprint.
>   - `DisplayInfoInRow`: add `valueInSameRow` prop to switch between row/column layouts; align content start; change value typography to `body1`.
>   - `TokenInfoModal`: render Description and external Details in separate rows using `valueInSameRow={false}`.
> - **i18n**:
>   - Add `messages.detailsOn` and expose via `useStrings`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54a51e6ed700caf5215736919e4340d378d30950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->