### PR TITLE
[Bump] Nightly Version: 5.18.0.1

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.18.0",
+  "version": "5.18.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.18.0",
+      "version": "5.18.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",
@@ -39,7 +39,7 @@
         "@yoroi/resolver": "2.0.2",
         "@yoroi/staking": "^1.6.0",
         "@yoroi/swap": "7.0.3",
-        "@yoroi/types": "6.0.0",
+        "@yoroi/types": "6.1.0",
         "assert": "2.1.0",
         "async-await-queue": "2.1.4",
         "bech32": "2.0.0",
@@ -9829,18 +9829,23 @@
       }
     },
     "node_modules/@yoroi/types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@yoroi/types/-/types-6.0.0.tgz",
-      "integrity": "sha512-LqAbhw9/cWR0Yq122UMgpmXwaSZPsUZQ2HRfKDU/pfAbb7tOIRwI4Fc4OwXnw8v4QgRceaMSROg4PpqX+4yIEw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@yoroi/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-J1jBdEZeDu2I5DogezQgE9tQQEiqWvRvk4dXkJ06PC/dd1pVFWrdaPrfkYFEwa62ZrP7aeVYShekT1UG660DDw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 22.12.0"
       },
       "peerDependencies": {
         "@emurgo/yoroi-lib": "3.0.0-beta.1",
-        "axios": "^1.10.0",
+        "@react-native-async-storage/async-storage": "2.1.2",
+        "@tanstack/react-query": "5.81.5",
+        "axios": "1.10.0",
         "bignumber.js": "9.3.0",
         "immer": "10.1.1",
-        "rxjs": "7.8.2"
+        "react-native-mmkv": "3.2.0",
+        "rxjs": "7.8.2",
+        "zod": "3.25.17"
       }
     },
     "node_modules/abab": {

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.18.0",
+  "version": "5.18.0.1",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:main": "NODE_OPTIONS=--openssl-legacy-provider babel-node scripts/dev main --env mainnet",


### PR DESCRIPTION
This PR was created automatically using GitHub Actions.
Updating the version after publishing the new nightly version from branch `release/5.18.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps extension to 5.18.0.1 and updates @yoroi/types to 6.1.0 with lockfile/peer-deps adjustments.
> 
> - **packages/yoroi-extension**:
>   - **Versioning**: Bump `version` to `5.18.0.1` in `package.json` and `package-lock.json`.
>   - **Dependencies**: Update `@yoroi/types` from `6.0.0` to `6.1.0` with corresponding lockfile updates (including peer deps adjustments).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a08678bf382f6db92304c2af1599923f562022ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->