### PR TITLE
[Fix] Swap reset issue

### DIFF
--- a/packages/yoroi-extension/app/UI/features/swap-new/common/hooks/useWalletSwitchReset.ts
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/hooks/useWalletSwitchReset.ts
@@ -16,14 +16,14 @@ type UseWalletSwitchResetOptions = {
 
 /**
  * Hook to automatically reset the swap form when the wallet is switched.
- * 
+ *
  * @param options - Configuration options for the hook
  * @returns void
- * 
+ *
  * @example
  * // Basic usage - resets form on wallet switch
  * useWalletSwitchReset();
- * 
+ *
  * @example
  * // With navigation callback
  * const navigateTo = useNavigateTo();
@@ -38,13 +38,12 @@ export const useWalletSwitchReset = (options: UseWalletSwitchResetOptions = {}) 
 
   useEffect(() => {
     const currentWalletId = walletId ?? stores?.wallets?.selected?.publicDeriverId ?? null;
-    
+
     if (previousWalletIdRef.current !== null && previousWalletIdRef.current !== currentWalletId) {
       swapForm.action({ type: SwapActionType.ResetForm });
       onWalletSwitch?.();
     }
-    
+
     previousWalletIdRef.current = currentWalletId;
   }, [walletId, stores?.wallets?.selected?.publicDeriverId, swapForm.action, onWalletSwitch]);
 };
-

--- a/packages/yoroi-extension/app/UI/features/swap-new/common/hooks/useWalletSwitchReset.ts
+++ b/packages/yoroi-extension/app/UI/features/swap-new/common/hooks/useWalletSwitchReset.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+import { SwapActionType, useSwapRevamp } from '../../module/SwapContextProvider';
+
+type UseWalletSwitchResetOptions = {
+  /**
+   * Optional callback to execute when wallet is switched.
+   * Called after the form is reset.
+   */
+  onWalletSwitch?: () => void;
+  /**
+   * Optional wallet ID to use instead of getting it from stores.
+   * Useful when you have direct access to the wallet object.
+   */
+  walletId?: number | null;
+};
+
+/**
+ * Hook to automatically reset the swap form when the wallet is switched.
+ * 
+ * @param options - Configuration options for the hook
+ * @returns void
+ * 
+ * @example
+ * // Basic usage - resets form on wallet switch
+ * useWalletSwitchReset();
+ * 
+ * @example
+ * // With navigation callback
+ * const navigateTo = useNavigateTo();
+ * useWalletSwitchReset({
+ *   onWalletSwitch: () => navigateTo.swapAssets()
+ * });
+ */
+export const useWalletSwitchReset = (options: UseWalletSwitchResetOptions = {}) => {
+  const { swapForm, stores } = useSwapRevamp();
+  const { onWalletSwitch, walletId } = options;
+  const previousWalletIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const currentWalletId = walletId ?? stores?.wallets?.selected?.publicDeriverId ?? null;
+    
+    if (previousWalletIdRef.current !== null && previousWalletIdRef.current !== currentWalletId) {
+      swapForm.action({ type: SwapActionType.ResetForm });
+      onWalletSwitch?.();
+    }
+    
+    previousWalletIdRef.current = currentWalletId;
+  }, [walletId, stores?.wallets?.selected?.publicDeriverId, swapForm.action, onWalletSwitch]);
+};
+

--- a/packages/yoroi-extension/app/UI/features/swap-new/useCases/AssetSwap/AssetSwap.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/useCases/AssetSwap/AssetSwap.tsx
@@ -26,7 +26,7 @@ export const AssetSwap = () => {
   const { openModal } = useModal();
   const navigateTo = useNavigateTo();
   const strings = useStrings();
-  
+
   useWalletSwitchReset();
 
   const openSelectAssetModal = (direction: AssetDirectionType) => {

--- a/packages/yoroi-extension/app/UI/features/swap-new/useCases/AssetSwap/AssetSwap.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/useCases/AssetSwap/AssetSwap.tsx
@@ -9,7 +9,7 @@ import { SwitchAssets } from '../../common/components/SwitchAssets';
 import { SelectAssetTo } from '../../common/components/Modals/SelectAssetTo';
 import { AssetDirectionType } from '../../common/types';
 import { ASSET_DIRECTION_IN, ASSET_DIRECTION_OUT, MARKET_ORDER } from '../../common/constants';
-import { SwapActionType, useSwapRevamp } from '../../module/SwapContextProvider';
+import { useSwapRevamp } from '../../module/SwapContextProvider';
 import { useEffect } from 'react';
 import { ErrorMessage } from '../../common/components/ErrorMessage';
 import { LimitInput } from '../../common/components/LimitInput';
@@ -17,16 +17,17 @@ import { useStrings } from '../../common/hooks/useStrings';
 import { DisclaimerDialog } from '../../common/components/Modals/DisclaimerDialog';
 import PriceImpact from '../../common/components/PriceImpact';
 import { useNavigateTo } from '../../common/hooks/useNavigateTo';
+import { useWalletSwitchReset } from '../../common/hooks/useWalletSwitchReset';
 import { captureEvent } from '../../../../../../posthog';
-import { useLocation } from 'react-router';
 
 export const AssetSwap = () => {
   const { atoms }: any = useTheme();
   const { createOrder, swapForm, isCreateOrderLoading } = useSwapRevamp();
   const { openModal } = useModal();
   const navigateTo = useNavigateTo();
-  const location = useLocation();
   const strings = useStrings();
+  
+  useWalletSwitchReset();
 
   const openSelectAssetModal = (direction: AssetDirectionType) => {
     openModal({
@@ -42,13 +43,10 @@ export const AssetSwap = () => {
   }, []);
 
   useEffect(() => {
-    if (location.search.includes('newWallet=true')) {
-      swapForm.action({ type: SwapActionType.ResetForm });
-    }
     if (swapForm.createTx?.cbor && swapForm.reviewSwapSelected === false) {
       navigateTo.swapReview();
     }
-  }, [swapForm.createTx]);
+  }, [swapForm.createTx, swapForm.reviewSwapSelected, navigateTo]);
 
   return (
     <Content direction="column" justifyContent="space-between" alignItems="center">

--- a/packages/yoroi-extension/app/UI/features/swap-new/useCases/ReviewReview/ReviewSwap.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/useCases/ReviewReview/ReviewSwap.tsx
@@ -24,7 +24,7 @@ const ReviewSwap = ({ stores }: ReviewSwapProps) => {
   const navigateTo = useNavigateTo();
   const { palette }: any = useTheme();
   const { openTxReviewModal, closeTxReviewModal, showTxResultModal } = useTxReviewModal();
-  
+
   useWalletSwitchReset({
     walletId: wallet?.publicDeriverId,
     onWalletSwitch: () => navigateTo.swapAssets(),

--- a/packages/yoroi-extension/app/UI/features/swap-new/useCases/ReviewReview/ReviewSwap.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/useCases/ReviewReview/ReviewSwap.tsx
@@ -6,6 +6,7 @@ import { EstimateSummary } from '../AssetSwap/EstimateSummary';
 import { AssetSummary } from '../../common/components/AssetSummary';
 import { useTxReviewModal } from '../../../transaction-review/module/ReviewTxProvider';
 import { SwapActionType, useSwapRevamp } from '../../module/SwapContextProvider';
+import { useWalletSwitchReset } from '../../common/hooks/useWalletSwitchReset';
 import { TransactionResult } from '../../../transaction-review/common/types';
 import { captureEvent } from '../../../../../../posthog';
 import { useNavigateTo } from '../../common/hooks/useNavigateTo';
@@ -23,6 +24,11 @@ const ReviewSwap = ({ stores }: ReviewSwapProps) => {
   const navigateTo = useNavigateTo();
   const { palette }: any = useTheme();
   const { openTxReviewModal, closeTxReviewModal, showTxResultModal } = useTxReviewModal();
+  
+  useWalletSwitchReset({
+    walletId: wallet?.publicDeriverId,
+    onWalletSwitch: () => navigateTo.swapAssets(),
+  });
 
   const tokenInInfo = swapForm['tokenInInput'];
   const tokenOutInfo = swapForm['tokenOutInput'];
@@ -35,7 +41,7 @@ const ReviewSwap = ({ stores }: ReviewSwapProps) => {
     if (swapForm.createTx?.cbor === undefined) {
       navigateTo.swapAssets();
     }
-  }, [swapForm.createTx?.cbor]);
+  }, [swapForm.createTx?.cbor, navigateTo]);
 
   // @ts-ignore
   const handleSubmitTransaction = async password => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a `useWalletSwitchReset` hook to reset the swap form on wallet change and wires it into `AssetSwap` and `ReviewSwap`, replacing ad-hoc logic and tightening effect deps/navigation.
> 
> - **Swap UI**
>   - **New hook**: `common/hooks/useWalletSwitchReset` resets `swapForm` on wallet change; supports optional `walletId` and `onWalletSwitch` callback.
>   - **Integration**:
>     - `useCases/AssetSwap/AssetSwap.tsx`: uses `useWalletSwitchReset`; removes location-based reset and unused `SwapActionType` import; refines effect deps for navigation to review.
>     - `useCases/ReviewReview/ReviewSwap.tsx`: uses `useWalletSwitchReset` with `walletId` and navigates back to assets on switch; updates effect deps for navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b273a399eb7a6b7176f5be21304d194a7487956e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->