### PR TITLE
[Fix] Orders after switching wallet

### DIFF
--- a/packages/yoroi-extension/app/UI/features/swap-new/module/SwapContextProvider.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/module/SwapContextProvider.tsx
@@ -54,13 +54,14 @@ export const SwapContextProvider = ({ children, currentWallet, stores }: any) =>
   const strings = useStrings();
 
   useEffect(() => {
-    const stakignAddr = stores.wallets.selected.stakingAddress;
+    if (!selectedWallet) return;
+    const stakignAddr = selectedWallet.stakingAddress;
     const skey = unwrapStakingKey(stakignAddr).to_keyhash()?.to_hex();
     if (skey == null) {
       throw new Error('Cannot get staking key from the wallet!');
     }
     setStakingKey(skey);
-  }, []);
+  }, [selectedWallet?.stakingAddress, selectedWallet?.publicDeriverId]);
 
   const swapManager = useMemo(() => {
     const storage = swapStorageMaker();
@@ -75,7 +76,7 @@ export const SwapContextProvider = ({ children, currentWallet, stores }: any) =>
       isPrimaryToken,
       partners,
     });
-  }, [stakingKey, primaryTokenInfo, partners]);
+  }, [stakingKey, walletAddresses, primaryTokenInfo, partners]);
 
   const { data: orders = [], refetch: refetchOrders } = useQuery({
     queryKey: ['useSwapOrders', stakingKey, swapManager.settings.routingPreference],

--- a/packages/yoroi-extension/app/UI/features/swap-new/module/SwapContextProvider.tsx
+++ b/packages/yoroi-extension/app/UI/features/swap-new/module/SwapContextProvider.tsx
@@ -76,7 +76,7 @@ export const SwapContextProvider = ({ children, currentWallet, stores }: any) =>
       isPrimaryToken,
       partners,
     });
-  }, [stakingKey, walletAddresses, primaryTokenInfo, partners]);
+  }, [stakingKey, primaryTokenInfo, partners]);
 
   const { data: orders = [], refetch: refetchOrders } = useQuery({
     queryKey: ['useSwapOrders', stakingKey, swapManager.settings.routingPreference],


### PR DESCRIPTION
Task: https://emurgo.atlassian.net/browse/YOEXT-2338

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure staking key and orders refresh when switching wallets by using `selectedWallet.stakingAddress` and updating effect dependencies.
> 
> - **Swap context (`packages/yoroi-extension/app/UI/features/swap-new/module/SwapContextProvider.tsx`)**:
>   - Use `selectedWallet.stakingAddress` (with null-guard) instead of `stores.wallets.selected.stakingAddress` to derive `stakingKey`.
>   - Update `useEffect` dependencies to `[selectedWallet?.stakingAddress, selectedWallet?.publicDeriverId]` so staking key and related data refresh on wallet change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f1ae512d59a7f1b5e6324e572ba176c57e1f032. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->