### PR TITLE
[Feature] Support `open_url` action

### DIFF
--- a/packages/yoroi-extension/api/appState.ts
+++ b/packages/yoroi-extension/api/appState.ts
@@ -7,6 +7,7 @@ interface NotificationData {
   title: string;
   body: string;
   time: string;
+  isExternalUrl: boolean;
   redirection?: string | null;
 }
 interface Notification extends NotificationData {

--- a/packages/yoroi-extension/api/appState.ts
+++ b/packages/yoroi-extension/api/appState.ts
@@ -7,7 +7,7 @@ interface NotificationData {
   title: string;
   body: string;
   time: string;
-  isExternalUrl: boolean;
+  isExternalUrl?: boolean;
   redirection?: string | null;
 }
 interface Notification extends NotificationData {

--- a/packages/yoroi-extension/app/UI/features/notifications/module/NotificationCenter.tsx
+++ b/packages/yoroi-extension/app/UI/features/notifications/module/NotificationCenter.tsx
@@ -33,9 +33,15 @@ const Notification = (props: { notification: (typeof appState.notifications.all)
     if (!notification.redirection) {
       throw new Error('unexpectedly missing redirection in notification data');
     }
-    navigateTo(notification.redirection);
-    setIsNotificationCenterOpen(false);
-    call(appState.notifications.setRead, notification.fcmMessageId);
+    if (notification.isExternalUrl) {
+      window.open(notification.redirection, '_blank', 'noopener,noreferrer');
+      setIsNotificationCenterOpen(false);
+      call(appState.notifications.setRead, notification.fcmMessageId);
+    } else {
+      navigateTo(notification.redirection);
+      setIsNotificationCenterOpen(false);
+      call(appState.notifications.setRead, notification.fcmMessageId);
+    }
   };
 
   const content = (

--- a/packages/yoroi-extension/app/UI/features/notifications/module/NotificationCenter.tsx
+++ b/packages/yoroi-extension/app/UI/features/notifications/module/NotificationCenter.tsx
@@ -33,15 +33,11 @@ const Notification = (props: { notification: (typeof appState.notifications.all)
     if (!notification.redirection) {
       throw new Error('unexpectedly missing redirection in notification data');
     }
-    if (notification.isExternalUrl) {
-      window.open(notification.redirection, '_blank', 'noopener,noreferrer');
-      setIsNotificationCenterOpen(false);
-      call(appState.notifications.setRead, notification.fcmMessageId);
-    } else {
-      navigateTo(notification.redirection);
-      setIsNotificationCenterOpen(false);
-      call(appState.notifications.setRead, notification.fcmMessageId);
-    }
+    notification.isExternalUrl
+      ? window.open(notification.redirection, '_blank', 'noopener,noreferrer')
+      : navigateTo(notification.redirection);
+    setIsNotificationCenterOpen(false);
+    call(appState.notifications.setRead, notification.fcmMessageId);
   };
 
   const content = (

--- a/packages/yoroi-extension/chrome/extension/background/pushNotificationHandler.ts
+++ b/packages/yoroi-extension/chrome/extension/background/pushNotificationHandler.ts
@@ -10,8 +10,9 @@ let currentNotificationId;
 type Screen = 'wallet' | 'staking_center' | 'swap' | 'cashback' | 'governance';
 interface EventData {
   data: {
-    action?: 'open_screen';
+    action?: 'open_screen' | 'open_url';
     screen?: Screen;
+    url?: string;
   };
   notification: {
     title: string;
@@ -46,6 +47,7 @@ const REDIRECTIONS: { id: Screen; route: string }[] = [
 interface NotificationData {
   fcmMessageId: string;
   route: null | string;
+  url: null | string;
 }
 
 // missing builtin
@@ -58,7 +60,9 @@ interface NotificationEvent<DataType> {
 
 // @ts-ignore
 self.addEventListener('notificationclick', (event: NotificationEvent<NotificationData>) => {
-  if (event.notification.data.route) {
+  if (event.notification.data.url) {
+    chrome.tabs.create({ url: event.notification.data.url });
+  } else if (event.notification.data.route) {
     chrome.tabs.create({ url: `main_window.html#${event.notification.data.route}` });
   }
   event.notification.close();
@@ -79,11 +83,17 @@ async function pushHandler(eventData) {
   const locale = (await localStorageApi.getUserLocale()) ?? 'en-US';
 
   let redirectionRoute: null | string = null;
+  let externalUrl: null | string = null;
+  const isExternalUrl = eventData.data.action === 'open_url' && eventData.data.url && typeof eventData.data.url === 'string';
 
-  const redirection =
-    eventData.data.action === 'open_screen' ? REDIRECTIONS.find(({ id }) => id === eventData.data.screen) : null;
-  if (redirection) {
-    redirectionRoute = redirection.route;
+  if (isExternalUrl) {
+    externalUrl = eventData.data.url;
+  } else {
+    const redirection =
+      eventData.data.action === 'open_screen' ? REDIRECTIONS.find(({ id }) => id === eventData.data.screen) : null;
+    if (redirection) {
+      redirectionRoute = redirection.route;
+    }
   }
 
   const title = eventData.data['title-' + locale] ?? eventData.notification.title;
@@ -98,6 +108,7 @@ async function pushHandler(eventData) {
     data: {
       fcmMessageId: eventData.fcmMessageId,
       route: redirectionRoute,
+      url: externalUrl,
     },
   });
 
@@ -107,7 +118,8 @@ async function pushHandler(eventData) {
     fcmMessageId: eventData.fcmMessageId,
     read: false,
     time: new Date().toISOString(),
-    redirection: redirectionRoute,
+    isExternalUrl: isExternalUrl,
+    redirection: isExternalUrl ? externalUrl : redirectionRoute,
   });
 
   currentNotificationId = eventData.fcmMessageId;


### PR DESCRIPTION
Task: https://emurgo.atlassian.net/browse/YOEXT-2420

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for `open_url` notifications that open external tabs and are tracked in state/UI.
> 
> - **Notifications Handling (background)**:
>   - Support new action `open_url` in `pushNotificationHandler.ts`; parse `url`, distinguish from `open_screen`.
>   - On `notificationclick`, open external `url` in a new tab or internal `route` as before.
>   - Include `url` in notification `data`; build `redirection` accordingly and set `isExternalUrl`.
> - **UI**:
>   - `NotificationCenter.tsx`: when `isExternalUrl` use `window.open` for `redirection`; otherwise use internal navigation.
> - **State**:
>   - Extend `NotificationData` in `appState.ts` with `isExternalUrl?` to persist external link intent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a4795886c179a52f98ecc13f9912514f6257fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->