### PR TITLE
chore: YOEXT-2357 [Swap] remove new swap on testnet

### DIFF
--- a/packages/yoroi-extension/app/stores/stateless/sidebarCategories.js
+++ b/packages/yoroi-extension/app/stores/stateless/sidebarCategories.js
@@ -78,7 +78,7 @@ export const allCategoriesRevamp: Array<SidebarCategoryRevamp> = [
     route: ROUTES.SWAP_REVAMP.ASSET_SWAP,
     icon: swapIcon,
     label: globalMessages.sidebarSwap,
-    isVisible: existsSelectedWallet && isOnMainnet,
+    isVisible: isOnMainnet,
   },
   {
     className: 'portfolio',

--- a/packages/yoroi-extension/app/stores/stateless/sidebarCategories.js
+++ b/packages/yoroi-extension/app/stores/stateless/sidebarCategories.js
@@ -78,7 +78,7 @@ export const allCategoriesRevamp: Array<SidebarCategoryRevamp> = [
     route: ROUTES.SWAP_REVAMP.ASSET_SWAP,
     icon: swapIcon,
     label: globalMessages.sidebarSwap,
-    isVisible: existsSelectedWallet,
+    isVisible: existsSelectedWallet && isOnMainnet,
   },
   {
     className: 'portfolio',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts `ROUTES.SWAP_REVAMP.ASSET_SWAP` sidebar item visibility to mainnet wallets.
> 
> - **Sidebar visibility**:
>   - Change `swap2` (`ROUTES.SWAP_REVAMP.ASSET_SWAP`) `isVisible` from `existsSelectedWallet` to `isOnMainnet` to hide the new Swap on testnet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fd0b8237d1b00c247a7d0ccde37697aef9dce5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->