### PR TITLE
[E2E] Fix download logs test

### DIFF
--- a/packages/e2e-tests/test/extension/settings/Settings_08_downloadingLogs.test.js
+++ b/packages/e2e-tests/test/extension/settings/Settings_08_downloadingLogs.test.js
@@ -50,10 +50,14 @@ describe('Downloading logs for support', function () {
     expect(allDownloadedFiles.length).to.equal(1);
     // check file name
     const fileName = allDownloadedFiles[0];
-    expect(fileName).to.match(/(\d+.?)+yoroi\.log/gi);
+    expect(fileName).to.match(/\d{4}(-\d{2}){2}T\d{2}(-\d{2}){2}-yoroi-logs\.zip/gi);
     // check downloaded file is not empty
-    const fileContent = getDownloadedFileContent(fileName);
-    expect(fileContent, 'Support log file is empty').to.not.be.empty;
+    const fileContent = await getDownloadedFileContent(fileName);
+    expect(Object.keys(fileContent).length, 'Support log archive contains no files').to.be.greaterThan(0);
+    for (const key in fileContent) {
+      const content = fileContent[key];
+      expect(content, `Support log file "${key}" is empty`).to.not.be.empty;
+    }
   });
 
   afterEach(async function () {

--- a/packages/e2e-tests/test/extension/transactions/Transactions_01_exportTransactions.test.js
+++ b/packages/e2e-tests/test/extension/transactions/Transactions_01_exportTransactions.test.js
@@ -69,7 +69,7 @@ describe('Export transactions, positive', function () {
     const expectedFileName = `Yoroi-Transaction-History_TADA-${testWallet1.plate}_${todayStr}.csv`;
     expect(fileName, 'Exported file name is different').to.equal(expectedFileName);
     // check exported file content
-    const fileContent = getDownloadedFileContent(fileName);
+    const fileContent = await getDownloadedFileContent(fileName);
     const parsedFileContent = parseExportedCSV(fileContent);
     // get txs info from the transactions page <list of objects>
     expect(parsedFileContent.length, 'Something wrong in the exported file').to.equal(5);
@@ -78,7 +78,7 @@ describe('Export transactions, positive', function () {
   it('Compare displayed txs with the exported txs', async function () {
     const allDownloadedFiles = getListOfDownloadedFiles();
     const fileName = allDownloadedFiles[0];
-    const fileContent = getDownloadedFileContent(fileName);
+    const fileContent = await getDownloadedFileContent(fileName);
     const parsedFileContent = parseExportedCSV(fileContent);
 
     const displayedTxs = await transactionsPage.getTxsInfo(startDate, endDate);

--- a/packages/e2e-tests/utils/utils.js
+++ b/packages/e2e-tests/utils/utils.js
@@ -121,12 +121,12 @@ export const getFileContent = (fileName, fileDir) => {
 export const getDownloadedFileContent = async fileName => {
   const fullPath = path.resolve(getDownloadsDir(), fileName);
   const isZipFile = fileName.toLowerCase().endsWith('.zip');
-  
+
   if (isZipFile) {
     const zipBuffer = fs.readFileSync(fullPath);
     const zip = await JSZip.loadAsync(zipBuffer);
     const result = {};
-    
+
     for (const [filePath, file] of Object.entries(zip.files)) {
       if (!file.dir) {
         const content = await file.async('string');
@@ -134,7 +134,7 @@ export const getDownloadedFileContent = async fileName => {
         result[extractedFileName] = content;
       }
     }
-    
+
     return result;
   } else {
     const data = fs.readFileSync(fullPath, 'utf8');

--- a/packages/e2e-tests/utils/utils.js
+++ b/packages/e2e-tests/utils/utils.js
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import path from 'path';
 import pkg from 'simple-node-logger';
 import axios from 'axios';
+import JSZip from 'jszip';
 const { createSimpleFileLogger } = pkg;
 
 export function getMethod(locatorMethod) {
@@ -117,11 +118,28 @@ export const getFileContent = (fileName, fileDir) => {
   return data;
 };
 
-export const getDownloadedFileContent = fileName => {
+export const getDownloadedFileContent = async fileName => {
   const fullPath = path.resolve(getDownloadsDir(), fileName);
-  const data = fs.readFileSync(fullPath, 'utf8');
-
-  return data;
+  const isZipFile = fileName.toLowerCase().endsWith('.zip');
+  
+  if (isZipFile) {
+    const zipBuffer = fs.readFileSync(fullPath);
+    const zip = await JSZip.loadAsync(zipBuffer);
+    const result = {};
+    
+    for (const [filePath, file] of Object.entries(zip.files)) {
+      if (!file.dir) {
+        const content = await file.async('string');
+        const extractedFileName = path.basename(filePath);
+        result[extractedFileName] = content;
+      }
+    }
+    
+    return result;
+  } else {
+    const data = fs.readFileSync(fullPath, 'utf8');
+    return data;
+  }
 };
 
 export const cleanDownloads = () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update E2E to validate zipped support logs and make `getDownloadedFileContent` async with ZIP extraction; adjust transaction tests to await it.
> 
> - **E2E Tests**:
>   - **Settings/Support logs**: Expect ZIP filename pattern `YYYY-MM-DDTHH-MM-yoroi-logs.zip`; verify archive contains files and each file is non-empty.
>   - **Transactions export**: Await `getDownloadedFileContent` before parsing CSV.
> - **Utils**:
>   - **`getDownloadedFileContent`**: Convert to `async`; detect `.zip`, extract files using `JSZip`, return `{ filename: content }`; fallback to UTF-8 string for non-zip files.
>   - Import `JSZip` in `utils.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac95cfbc842a3a8125c6b47759126caf4a227fb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->