### PR TITLE
[E2E] Fix e2e-tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -303,7 +303,7 @@ jobs:
     needs: [Build-Extension]
     steps:
       - name: Pull Speculos Docker image
-        run: docker pull ghcr.io/ledgerhq/speculos
+        run: docker pull ghcr.io/ledgerhq/speculos:0.25.9
 
       - uses: browser-actions/setup-chrome@v2
         id: setup-chrome

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -235,7 +235,7 @@ jobs:
             -p 9002:9002 \
             -p 21326:21326 \
             -p 127.0.0.1:21325:21326 \
-            -d ghcr.io/trezor/trezor-user-env
+            -d ghcr.io/trezor/trezor-user-env:4c194889610c3f21f1da3799e7ddb82004fd4e91
 
       - uses: browser-actions/setup-chrome@v2
         id: setup-chrome

--- a/packages/e2e-tests/helpers/ledgerEmulatorController.js
+++ b/packages/e2e-tests/helpers/ledgerEmulatorController.js
@@ -15,7 +15,7 @@ export class LedgerEmulatorController {
   constructor(logger, model) {
     this.logger = logger;
     this.model = model;
-    this.speculosEndpoint = `http://${hostname()}:5001`;
+    this.speculosEndpoint = `http://127.0.0.1:5001`;
     this.logger.info(`LedgerEmulator::constructor speculos endpoint: ${this.speculosEndpoint}`);
   }
 

--- a/packages/e2e-tests/helpers/ledgerEmulatorController.js
+++ b/packages/e2e-tests/helpers/ledgerEmulatorController.js
@@ -2,6 +2,7 @@ import { sleep } from '../utils/utils.js';
 import { hostname } from 'os';
 import { LedgerModels } from './ledgerHelper.js';
 import { quarterSecond, threeSeconds } from './timeConstants.js';
+import { isLocalRun } from '../utils/utils.js';
 
 class LedgerEmulatorControllerError extends Error {}
 
@@ -15,7 +16,7 @@ export class LedgerEmulatorController {
   constructor(logger, model) {
     this.logger = logger;
     this.model = model;
-    this.speculosEndpoint = `http://127.0.0.1:5001`;
+    this.speculosEndpoint = `http://${isLocalRun() ? '127.0.0.1' : hostname()}:5001`;
     this.logger.info(`LedgerEmulator::constructor speculos endpoint: ${this.speculosEndpoint}`);
   }
 

--- a/packages/e2e-tests/helpers/speculos/speculosDockerController.js
+++ b/packages/e2e-tests/helpers/speculos/speculosDockerController.js
@@ -16,7 +16,7 @@ export class SpeculosDockerController {
 
   getContainerOptions = (model, seedPhrase, appFile) => {
     return {
-      Image: 'ghcr.io/ledgerhq/speculos',
+      Image: 'ghcr.io/ledgerhq/speculos:0.25.9',
       ExposedPorts: {
         '5001/tcp': {},
       },

--- a/packages/e2e-tests/pages/basepage.js
+++ b/packages/e2e-tests/pages/basepage.js
@@ -366,11 +366,11 @@ class BasePage {
    * @param {boolean} [hideInLog=false]
    * @returns {Promise<void>}
    */
-  async inputElem(webElement, value, hideInLog = false) {
+  async inputElem(webElement, value, hideInLog = false, delayBetweenChars = 5) {
     this.logger.info(`BasePage::inputElem is called. Value: ${hideInLog ? '******' : value}`);
     for (let index = 0; index < value.length; index++) {
       await webElement.sendKeys(value[index]);
-      await this.sleep(5, false);
+      await this.sleep(delayBetweenChars, false);
     }
   }
   /**
@@ -421,6 +421,20 @@ class BasePage {
     await this.sleep(500);
     await input.sendKeys(Key.NULL);
     await input.sendKeys(Key.BACK_SPACE);
+  }
+  /**
+   * Clears the value in an input WebElement.
+   * @param {WebElement} inputWebElement
+   * @returns {Promise<void>}
+   */
+  async clearInputAllElem(inputWebElement) {
+    this.logger.info(`BasePage::clearInputAllElem is called.`);
+    await inputWebElement.click();
+    await this.sleep(250);
+    await inputWebElement.sendKeys(Key.chord(isMacOS() ? Key.COMMAND : Key.CONTROL, 'a'));
+    await this.sleep(500);
+    await inputWebElement.sendKeys(Key.NULL);
+    await inputWebElement.sendKeys(Key.BACK_SPACE);
   }
   /**
    * Sets the implicit wait timeout for driver commands.

--- a/packages/e2e-tests/pages/basepage.js
+++ b/packages/e2e-tests/pages/basepage.js
@@ -368,6 +368,8 @@ class BasePage {
    */
   async inputElem(webElement, value, hideInLog = false, delayBetweenChars = 5) {
     this.logger.info(`BasePage::inputElem is called. Value: ${hideInLog ? '******' : value}`);
+    await webElement.click();
+    await this.sleep(50, false);
     for (let index = 0; index < value.length; index++) {
       await webElement.sendKeys(value[index]);
       await this.sleep(delayBetweenChars, false);

--- a/packages/e2e-tests/pages/newWalletPages/restoreWalletSteps/restoreWalletStepTwo.page.js
+++ b/packages/e2e-tests/pages/newWalletPages/restoreWalletSteps/restoreWalletStepTwo.page.js
@@ -67,7 +67,7 @@ class RestoreWalletStepTwo extends AddWalletBase {
     for (let wordIndex = 0; wordIndex < wordsAmount; wordIndex++) {
       const phraseWord = phraseTemplate[wordIndex];
       const inputElement = allInputs[wordIndex];
-      await this.inputElem(inputElement, phraseWord + Key.RETURN, true);
+      await this.inputElem(inputElement, phraseWord + Key.RETURN, true, 15);
     }
   };
   enterRecoveryPhrase15Words = async recoveryPhrase => {
@@ -96,10 +96,7 @@ class RestoreWalletStepTwo extends AddWalletBase {
   clearAllInputsManually = async () => {
     const allInputs = await this.getAllRecoveryPhrasesInputs();
     for (const seedInput of allInputs) {
-      const wordInputLength = (await this.getAttributeElement(seedInput, 'value')).length;
-      for (let charIndex = 0; charIndex < wordInputLength; charIndex++) {
-        await this.inputElem(seedInput, Key.BACK_SPACE);
-      }
+      await this.clearInputAllElem(seedInput);
     }
   };
   allInputsAreEmpty = async () => {

--- a/packages/e2e-tests/test/extension/general/General_06_restoringClearInputs.test.js
+++ b/packages/e2e-tests/test/extension/general/General_06_restoringClearInputs.test.js
@@ -62,13 +62,15 @@ describe('Restoring 15-wallet, clear input and restore other 15-wallet', functio
     expect(walletPlate, 'Wallet plate is different from expected').to.equal(testWallet1.plate);
   });
 
-  it('Clear all inputs and restore the second wallet', async function () {
+  it('Back to the previous step and clear all inputs', async function () {
     await walletDetailsPage.backOnPreviousStep();
     await restoreWalletStepTwoPage.clearAllInputsManually();
 
     const inputsAreEmpty = await restoreWalletStepTwoPage.allInputsAreEmpty();
     expect(inputsAreEmpty, 'Seed phrase inputs are not empty').to.be.true;
+  });
 
+  it('Enter the wallet seed phrase of second wallet', async function () {
     await restoreWalletStepTwoPage.enterRecoveryPhrase15Words(testWallet2.mnemonic);
     const phraseIsVerified = await restoreWalletStepTwoPage.recoveryPhraseIsVerified();
     expect(phraseIsVerified, 'The recovery phrase is not verified').to.be.true;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins emulator Docker images, adjusts Speculos endpoint resolution, improves input typing/clearing, and updates recovery phrase test flow.
> 
> - **CI (GitHub Actions)**:
>   - Pin Trezor user env image to `ghcr.io/trezor/trezor-user-env:4c194889610c3f21f1da3799e7ddb82004fd4e91` in `/.github/workflows/e2e-tests.yml`.
>   - Pin Ledger Speculos image to `ghcr.io/ledgerhq/speculos:0.25.9` for Ledger job.
> - **Helpers**:
>   - `packages/e2e-tests/helpers/ledgerEmulatorController.js`: Use `127.0.0.1` for Speculos endpoint when `isLocalRun()`; keep hostname otherwise.
>   - `packages/e2e-tests/helpers/speculos/speculosDockerController.js`: Use Speculos image `:0.25.9` in container options.
> - **Pages**:
>   - `packages/e2e-tests/pages/basepage.js`: Enhance `inputElem` (pre-click, delay parameter); add `clearInputAllElem` method.
>   - `packages/e2e-tests/pages/newWalletPages/restoreWalletSteps/restoreWalletStepTwo.page.js`: Type recovery words with slower per-char delay; replace manual clearing with `clearInputAllElem`.
> - **Tests**:
>   - `packages/e2e-tests/test/extension/general/General_06_restoringClearInputs.test.js`: Split and clarify steps (back to previous, clear inputs, re-enter phrase); minor timing tweak after first phrase entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 540e5d207099b96624414c74c314bb874b52e011. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->