### PR TITLE
[Bump] Nightly Version: 5.18.1.1

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.18.1",
+  "version": "5.18.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.18.1",
+      "version": "5.18.1.1",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.18.1",
+  "version": "5.18.1.1",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:main": "NODE_OPTIONS=--openssl-legacy-provider babel-node scripts/dev main --env mainnet",


### PR DESCRIPTION
This PR was created automatically using GitHub Actions.
Updating the version after publishing the new nightly version from branch `release/5.19.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump `packages/yoroi-extension` version from 5.18.1 to 5.18.1.1 (including package-lock).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 633b1f3ca20025c18fb56297d547ed70279ac463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->