### PR TITLE
[E2E] Buy/Sell tests

### DIFF
--- a/packages/e2e-tests/helpers/constants.js
+++ b/packages/e2e-tests/helpers/constants.js
@@ -128,3 +128,6 @@ export const handlesEndpoints = Object.freeze({
     'https://api.yoroiwallet.com/api/asset/accounts?policy=e0c4c2d7c4a0ed2cf786753fd845dee82c45512cee03e92adfd3fb8d&asset=726168756c2e616461',
   'Unstoppable Domains': 'https://api.unstoppabledomains.com/resolve/domains/stackchain.blockchain',
 });
+
+export const PROVIDER_BUY_FEE = 2;
+export const PROVIDER_SELL_FEE = 2.5;

--- a/packages/e2e-tests/helpers/messages.js
+++ b/packages/e2e-tests/helpers/messages.js
@@ -14,3 +14,6 @@ export const ADA_HANDLE_UNEXPECTED_ERROR = 'ADA Handle: unexpected error';
 export const CASHBACK_ANOTHER_WALLET = 'Your cashback rewards are currently linked to another wallet';
 export const CASHBACK_SWITCH_WALLET = 'Switch wallet to access your rewards or set this wallet as your cashback wallet';
 export const PORTFOLIO_NO_RESULTS = 'No results for this search';
+export const PROVIDER_BUY = 'Banxa';
+export const PROVIDER_SELL = 'Encryptus';
+export const BUY_MINIMUM = 'Minimum 100 ADA required';

--- a/packages/e2e-tests/helpers/windowManager.js
+++ b/packages/e2e-tests/helpers/windowManager.js
@@ -137,6 +137,22 @@ export class WindowManager {
     return title;
   }
 
+  async waitTitleEquals(expectedTitle, timeoutMs = defaultWaitTimeout, repeatPeriodMs = defaultRepeatPeriod) {
+    this.logger.info(`WindowManager::waitTitleEquals Waiting for the title to be equal to "${expectedTitle}"`);
+    const endTime = Date.now() + timeoutMs;
+
+    while (endTime >= Date.now()) {
+      const windowTitle = await this.driver.getTitle();
+      if (windowTitle === expectedTitle) {
+        this.logger.info(`WindowManager::waitTitleEquals The title is equal to "${expectedTitle}"`);
+        return true;
+      }
+      await this.driver.sleep(repeatPeriodMs);
+    }
+    this.logger.error(`WindowManager::waitTitleEquals The title is not equal to "${expectedTitle}" after ${timeoutMs} ms`);
+    return false;
+  }
+
   async getCurrentUrl() {
     this.logger.info('WindowManager::getCurrentUrl is called');
     const url = await this.driver.getCurrentUrl();

--- a/packages/e2e-tests/helpers/windowManager.js
+++ b/packages/e2e-tests/helpers/windowManager.js
@@ -11,6 +11,8 @@ export const extensionTabName = 'Yoroi';
 export const faqTabName = 'Yoroi - EMURGO';
 export const trezorConnectTabName = 'Trezor';
 export const ledgerConnectTabName = 'Ledger Connect | Yoroi';
+export const buyTabName = 'Banxa – Buy Crypto';
+export const sellTabName = 'Encryptus';
 export const backgroungTabName = 'background';
 export const serviceWorkersTabName = 'chrome://serviceworker-internals';
 export const serviceWorkersLink = 'chrome://serviceworker-internals';
@@ -46,7 +48,9 @@ export class WindowManager {
 
     while (endTime >= Date.now()) {
       const windowTitle = await this.driver.getTitle();
-      if (windowTitle !== '') return windowTitle;
+      if (windowTitle !== '') {
+        return windowTitle;
+      }
       await this.driver.sleep(repeatPeriodMs);
     }
     this.logger.error(`WindowManager::_waitWindowTitle The window has the empty title`);
@@ -126,6 +130,20 @@ export class WindowManager {
     throw new WindowManagerError(`The handle with the title ${windowName} already exists`);
   }
 
+  async getCurrentPageTitle() {
+    this.logger.info('WindowManager::getCurrentPageTitle is called');
+    const title = await this.driver.getTitle();
+    this.logger.info(`WindowManager::getCurrentPageTitle. Result: ${title}`);
+    return title;
+  }
+
+  async getCurrentUrl() {
+    this.logger.info('WindowManager::getCurrentUrl is called');
+    const url = await this.driver.getCurrentUrl();
+    this.logger.info(`WindowManager::getCurrentUrl. Result: ${url}`);
+    return url;
+  }
+
   async openNewTab(tabTitle, url) {
     return await this._openNewWithCheck(browserWindowType.tab, tabTitle, url);
   }
@@ -191,20 +209,20 @@ export class WindowManager {
     this.logger.info(
       `WindowManager::findNewWindowAndSwitchTo Finding a new window and switching to it and set the title "${newWindowTitle}" to it`
     );
-    const popupWindowHandleArr = await this.findNewWindows();
-    if (popupWindowHandleArr.length !== 1) {
+    const windowHandleArr = await this.findNewWindows();
+    if (windowHandleArr.length !== 1) {
       this.logger.error(`WindowManager::findNewWindowAndSwitchTo Can not find the popup window`);
-      throw new WindowManagerError('Can not find the popup window');
+      throw new WindowManagerError('Can not find the new window');
     }
-    const popupWindowHandle = popupWindowHandleArr[0];
-    const popUpCustomHandle = { title: newWindowTitle, handle: popupWindowHandle };
-    this.windowHandles.push(popUpCustomHandle);
+    const windowHandle = windowHandleArr[0];
+    const customHandle = { title: newWindowTitle, handle: windowHandle };
+    this.windowHandles.push(customHandle);
 
-    await this.driver.switchTo().window(popupWindowHandle);
-    this.logger.info(`WindowManager::findNewWindowAndSwitchTo Switched to the new window ${JSON.stringify(popUpCustomHandle)}`);
+    await this.driver.switchTo().window(windowHandle);
+    this.logger.info(`WindowManager::findNewWindowAndSwitchTo Switched to the new window ${JSON.stringify(customHandle)}`);
     await this._waitWindowTitle();
 
-    return popUpCustomHandle;
+    return customHandle;
   }
 
   async isClosed(title) {

--- a/packages/e2e-tests/pages/basepage.js
+++ b/packages/e2e-tests/pages/basepage.js
@@ -276,12 +276,14 @@ class BasePage {
   /**
    * Gets the value of an attribute for an element by locator.
    * @param {ElementLocator} locator
-   * @param {string} property
+   * @param {string} attribute
    * @returns {Promise<*>}
    */
-  async getAttribute(locator, property) {
-    this.logger.info(`BasePage::getAttribute is called. Locator: ${JSON.stringify(locator)}, property: ${property}`);
-    return await this.driver.findElement(getByLocator(locator)).getAttribute(property);
+  async getAttribute(locator, attribute) {
+    this.logger.info(`BasePage::getAttribute is called. Locator: ${JSON.stringify(locator)}, Attribute: ${attribute}`);
+    const result = await this.driver.findElement(getByLocator(locator)).getAttribute(attribute);
+    this.logger.info(`BasePage::getAttribute. Attribute: ${attribute}, value: ${result}`);
+    return result;
   }
   /**
    * Gets the value of an attribute for a WebElement.
@@ -573,22 +575,45 @@ class BasePage {
     return this.driver.wait(condition);
   }
   /**
-   * Returns a boolean indicating if a button is enabled by checking the 'disabled' attribute.
+   * Returns a boolean indicating if a button is enabled or disabled by checking the 'disabled' attribute.
    * @param {ElementLocator} locator
+   * @param {string?} checkValue
    * @returns {Promise<boolean>}
    */
-  async buttonIsEnabled(locator) {
-    this.logger.info(`BasePage::buttonIsEnabled is called. Value: ${JSON.stringify(locator)}`);
+  async _buttonState(locator, checkValue) {
+    this.logger.info(`BasePage::_buttonState is called. Locator: ${JSON.stringify(locator)}. Value to check: ${checkValue}`);
     const buttonIsEnabled = await this.customWaiter(
       async () => {
         const buttonlIsEnabled = await this.getAttribute(locator, 'disabled');
-        return buttonlIsEnabled === null;
+        return buttonlIsEnabled === checkValue;
       },
       fiveSeconds,
       quarterSecond
     );
 
     return buttonIsEnabled;
+  }
+  /**
+   * Returns a boolean indicating if a button is enabled by checking the 'disabled' attribute.
+   * @param {ElementLocator} locator
+   * @returns {Promise<boolean>}
+   */
+  async buttonIsEnabled(locator) {
+    this.logger.info(`BasePage::buttonIsEnabled is called. Value: ${JSON.stringify(locator)}`);
+    const isEnabled = await this._buttonState(locator, null);
+    this.logger.info(`BasePage::buttonIsEnabled. Button is enabled: ${isEnabled}`);
+    return isEnabled;
+  }
+  /**
+   * Returns a boolean indicating if a button is disabled by checking the 'disabled' attribute.
+   * @param {ElementLocator} locator
+   * @returns {Promise<boolean>}
+   */
+  async buttonIsDisabled(locator) {
+    this.logger.info(`BasePage::buttonIsDisabled is called. Value: ${JSON.stringify(locator)}`);
+    const isDisabled = await this._buttonState(locator, 'true');
+    this.logger.info(`BasePage::buttonIsDisabled. Button is disabled: ${isDisabled}`);
+    return isDisabled;
   }
   /**
    * Waits for an element at the given locator to become disabled.

--- a/packages/e2e-tests/pages/buySell/buySell.page.js
+++ b/packages/e2e-tests/pages/buySell/buySell.page.js
@@ -1,4 +1,4 @@
-import { defaultWaitTimeout, quarterSecond } from '../../helpers/timeConstants.js';
+import { defaultWaitTimeout, fiveSeconds, quarterSecond, threeSeconds } from '../../helpers/timeConstants.js';
 import BasePage from '../basepage.js';
 import { ElementLocator } from '../locator.js';
 
@@ -84,13 +84,31 @@ class BuySell extends BasePage {
 
     return states.every(state => state === true);
   }
+  async closeModal() {
+    this.logger.info(`BuySell::closeModal is called`);
+    await this.click(this.closeModalBtnLocator);
+    const isClosed = await this.customWaitIsNotPresented(this.modalWindowLocator, fiveSeconds, quarterSecond);
+    this.logger.info(`BuySell::closeModal. Modal is closed: ${isClosed}`);
+    return isClosed;
+  }
   async enterAdaAmount(amount) {
     this.logger.info(`BuySell::enterAdaAmount is called. Amount ${amount}`);
     await this.input(this.adaAmountInputLocator, amount);
   }
   async getHelperText() {
     this.logger.info(`BuySell::getHelperText is called`);
-    return await this.getText(this.adaAmountHelperTextLocator);
+    const messageAppeared = await this.customWaiter(
+      async () => {
+        const currentText = await this.getText(this.adaAmountHelperTextLocator);
+        return currentText !== '';
+      },
+      threeSeconds,
+      quarterSecond
+    );
+    if (messageAppeared) {
+      return await this.getText(this.adaAmountHelperTextLocator);
+    }
+    return '';
   }
   async getProviderInfo() {
     this.logger.info(`BuySell::getProviderInfo is called`);
@@ -103,14 +121,26 @@ class BuySell extends BasePage {
   }
   async selectBuyTab() {
     this.logger.info(`BuySell::selectBuyTab is called`);
-    await this.click(this.buyTabBtnLocator);
+    return await this.selectTab(this.buyTabBtnLocator);
   }
   async selectSellTab() {
     this.logger.info(`BuySell::selectSellTab is called`);
-    await this.click(this.sellTabBtnLocator);
+    return await this.selectTab(this.sellTabBtnLocator);
+  }
+  async selectTab(tabBtnLocator) {
+    this.logger.info(`BuySell::selectTab is called. Locator: ${JSON.stringify(tabBtnLocator)}`);
+    await this.click(tabBtnLocator);
+    return await this.customWaiter(async () => {
+      const btnIsSelected = await this.getAttribute(tabBtnLocator, 'aria-selected');
+      return btnIsSelected === 'true';
+    });
+  }
+  async isProceedBtnDisabled() {
+    this.logger.info(`BuySell::isProceedBtnDisabled is called`);
+    return await this.buttonIsDisabled(this.proceedBtnLocator);
   }
   async isProceedBtnEnabled() {
-    this.logger.info(`BuySell::isProceedActive is called`);
+    this.logger.info(`BuySell::isProceedBtnEnabled is called`);
     return await this.buttonIsEnabled(this.proceedBtnLocator);
   }
   async proceed() {

--- a/packages/e2e-tests/pages/walletCommonBase.page.js
+++ b/packages/e2e-tests/pages/walletCommonBase.page.js
@@ -1,5 +1,13 @@
-import { balanceReplacer, WalletWordsSize } from '../helpers/constants.js';
-import { defaultWaitTimeout, fiveSeconds, halfSecond, oneMinute, oneSecond, quarterSecond } from '../helpers/timeConstants.js';
+import { balanceReplacer } from '../helpers/constants.js';
+import {
+  defaultWaitTimeout,
+  fiveSeconds,
+  halfSecond,
+  oneMinute,
+  oneSecond,
+  quarterSecond,
+  threeSeconds,
+} from '../helpers/timeConstants.js';
 import BasePage from './basepage.js';
 import { ElementLocator } from './locator.js';
 
@@ -377,7 +385,13 @@ export default class WalletCommonBase extends BasePage {
    */
   async titleIsCorrect(expectedPageTitle) {
     this.logger.info(`WalletCommonBase::titleIsCorrect is called`);
-    const displayedTitle = await this.getPageTitle();
-    return displayedTitle === expectedPageTitle;
+    return await this.customWaiter(
+      async () => {
+        const displayedTitle = await this.getPageTitle();
+        return displayedTitle === expectedPageTitle;
+      },
+      threeSeconds,
+      quarterSecond
+    );
   }
 }

--- a/packages/e2e-tests/test/extension/cashback/Cashback_01_one_wallet_added.test.js
+++ b/packages/e2e-tests/test/extension/cashback/Cashback_01_one_wallet_added.test.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import BasePage from '../../../pages/basepage.js';
 import CashbackPage from '../../../pages/wallet/cashback/cashback.page.js';
 import CashbackTermsModal from '../../../pages/wallet/cashback/modals/disclaimerModal.page.js';
 import WalletTab from '../../../pages/wallet/walletTab/walletTab.page.js';

--- a/packages/e2e-tests/test/extension/general/General_08_checkBuySell.test.js
+++ b/packages/e2e-tests/test/extension/general/General_08_checkBuySell.test.js
@@ -1,0 +1,71 @@
+import { customAfterEach } from '../../../utils/customHooks.js';
+import TransactionsSubTab from '../../../pages/wallet/walletTab/walletTransactions.page.js';
+import BuySell from '../../../pages/buySell/buySell.page.js';
+import { expect } from 'chai';
+import { getTestLogger } from '../../../utils/utils.js';
+import { oneMinute } from '../../../helpers/timeConstants.js';
+import driversPoolsManager from '../../../utils/driversPool.js';
+import { prepareWallet } from '../../../helpers/restoreWalletHelper.js';
+import { WebDriver } from 'selenium-webdriver';
+import { Logger } from 'simple-node-logger';
+import { PROVIDER_BUY, PROVIDER_SELL } from '../../../helpers/messages.js';
+import { PROVIDER_BUY_FEE, PROVIDER_SELL_FEE } from '../../../helpers/constants.js';
+
+describe('Checking BuySell dialog', function () {
+  this.timeout(2 * oneMinute);
+  /** @type {WebDriver} */
+  let webdriver = null;
+  /** @type {Logger} */
+  let logger = null;
+  /** @type {TransactionsSubTab} */
+  let transactionsPage = null;
+  /** @type {BuySell} */
+  let buySellPage = null;
+
+  before(async function () {
+    logger = getTestLogger(this.test.parent.title);
+    webdriver = await driversPoolsManager.getDriverFromPool();
+    await prepareWallet(webdriver, logger, 'testWallet1Mainnet', this, false);
+    transactionsPage = new TransactionsSubTab(webdriver, logger);
+    buySellPage = new BuySell(webdriver, logger);
+  });
+
+  it('Open the BuySell dialog', async function () {
+    await transactionsPage.openBuySellDialog();
+    const pageIsDisplayed = await buySellPage.isDisplayed();
+    expect(pageIsDisplayed, 'Buy/Sell dialog is not displayed').to.be.true;
+  });
+
+  it('Check components on Buy tab', async function () {
+    const tabIsSelected = await buySellPage.selectBuyTab();
+    expect(tabIsSelected, 'The Buy tab is not selected').to.be.true;
+    const proceedBtnDisabled = await buySellPage.isProceedBtnDisabled();
+    expect(proceedBtnDisabled, 'The Proceed button should be disabled by default').to.be.true;
+    const providerInfo = await buySellPage.getProviderInfo();
+    expect(providerInfo.name, 'Wrong provider name is displayed on Buy tab').to.be.equal(PROVIDER_BUY);
+    expect(providerInfo.fee, 'Wrong provider fee is displayed on Buy tab').to.be.equal(PROVIDER_BUY_FEE);
+  });
+
+  it('Check components on Sell tab', async function () {
+    const tabIsSelected = await buySellPage.selectSellTab();
+    expect(tabIsSelected, 'The Sell tab is not selected').to.be.true;
+    const proceedBtnDisabled = await buySellPage.isProceedBtnDisabled();
+    expect(proceedBtnDisabled, 'The Proceed button should be disabled by default').to.be.true;
+    const providerInfo = await buySellPage.getProviderInfo();
+    expect(providerInfo.name, 'Wrong provider name is displayed on Buy tab').to.be.equal(PROVIDER_SELL);
+    expect(providerInfo.fee, 'Wrong provider fee is displayed on Buy tab').to.be.equal(PROVIDER_SELL_FEE);
+  });
+
+  it('Close modal', async function () {
+    const modalIsClosed = await buySellPage.closeModal();
+    expect(modalIsClosed, 'The modal window is not closed').to.be.true;
+  });
+
+  afterEach(async function () {
+    await customAfterEach(this, webdriver, logger);
+  });
+
+  after(async function () {
+    await transactionsPage.closeBrowser();
+  });
+});

--- a/packages/e2e-tests/test/extension/general/General_09_buySell_BuyErrorMessage.test.js
+++ b/packages/e2e-tests/test/extension/general/General_09_buySell_BuyErrorMessage.test.js
@@ -1,0 +1,51 @@
+import { customAfterEach } from '../../../utils/customHooks.js';
+import TransactionsSubTab from '../../../pages/wallet/walletTab/walletTransactions.page.js';
+import BuySell from '../../../pages/buySell/buySell.page.js';
+import { expect } from 'chai';
+import { getTestLogger } from '../../../utils/utils.js';
+import { oneMinute } from '../../../helpers/timeConstants.js';
+import driversPoolsManager from '../../../utils/driversPool.js';
+import { prepareWallet } from '../../../helpers/restoreWalletHelper.js';
+import { WebDriver } from 'selenium-webdriver';
+import { Logger } from 'simple-node-logger';
+import { BUY_MINIMUM } from '../../../helpers/messages.js';
+
+describe('Checking Buy workflow error message', function () {
+  this.timeout(2 * oneMinute);
+  /** @type {WebDriver} */
+  let webdriver = null;
+  /** @type {Logger} */
+  let logger = null;
+  /** @type {TransactionsSubTab} */
+  let transactionsPage = null;
+  /** @type {BuySell} */
+  let buySellPage = null;
+
+  before(async function () {
+    logger = getTestLogger(this.test.parent.title);
+    webdriver = await driversPoolsManager.getDriverFromPool();
+    await prepareWallet(webdriver, logger, 'testWallet1Mainnet', this, false);
+    transactionsPage = new TransactionsSubTab(webdriver, logger);
+    buySellPage = new BuySell(webdriver, logger);
+  });
+
+  it('Open the BuySell dialog', async function () {
+    await transactionsPage.openBuySellDialog();
+    const pageIsDisplayed = await buySellPage.isDisplayed();
+    expect(pageIsDisplayed, 'Buy/Sell dialog is not displayed').to.be.true;
+  });
+
+  it('Check minimum amount error', async function () {
+    await buySellPage.enterAdaAmount('1');
+    const helperMessage = await buySellPage.getHelperText();
+    expect(helperMessage).to.be.equal(BUY_MINIMUM);
+  });
+
+  afterEach(async function () {
+    await customAfterEach(this, webdriver, logger);
+  });
+
+  after(async function () {
+    await transactionsPage.closeBrowser();
+  });
+});

--- a/packages/e2e-tests/test/extension/general/General_10_buySell_BuyPositive.test.js
+++ b/packages/e2e-tests/test/extension/general/General_10_buySell_BuyPositive.test.js
@@ -55,8 +55,8 @@ describe('Checking Buy workflow redirection', function () {
   it('Check the Buy provider page', async function () {
     await buySellPage.proceed();
     await windowManager.findNewWindowAndSwitchTo(buyTabName);
-    const title = await windowManager.getCurrentPageTitle();
-    expect(title, 'The Buy provider page is not opened').to.be.equal(buyTabName);
+    const titleIsCorrect = await windowManager.waitTitleEquals(buyTabName);
+    expect(titleIsCorrect, 'The Buy provider page title is not correct').to.be.true;
     const pageUrl = await windowManager.getCurrentUrl();
     const expectedUrlPart = `https://yoroi.banxa.com/?orderType=buy&fiatType=USD&coinType=ADA&coinAmount=${adaAmount}`;
     expect(pageUrl, 'The page URL is not correct')

--- a/packages/e2e-tests/test/extension/general/General_10_buySell_BuyPositive.test.js
+++ b/packages/e2e-tests/test/extension/general/General_10_buySell_BuyPositive.test.js
@@ -1,0 +1,74 @@
+import { customAfterEach } from '../../../utils/customHooks.js';
+import BasePage from '../../../pages/basepage.js';
+import TransactionsSubTab from '../../../pages/wallet/walletTab/walletTransactions.page.js';
+import BuySell from '../../../pages/buySell/buySell.page.js';
+import { expect } from 'chai';
+import { getTestLogger } from '../../../utils/utils.js';
+import { oneMinute } from '../../../helpers/timeConstants.js';
+import driversPoolsManager from '../../../utils/driversPool.js';
+import { prepareWallet } from '../../../helpers/restoreWalletHelper.js';
+import { WebDriver } from 'selenium-webdriver';
+import { Logger } from 'simple-node-logger';
+import { buyTabName, WindowManager } from '../../../helpers/windowManager.js';
+
+describe('Checking Buy workflow redirection', function () {
+  this.timeout(2 * oneMinute);
+  /** @type {WebDriver} */
+  let webdriver = null;
+  /** @type {Logger} */
+  let logger = null;
+  /** @type {BasePage} */
+  let basePage = null;
+  /** @type {TransactionsSubTab} */
+  let transactionsPage = null;
+  /** @type {BuySell} */
+  let buySellPage = null;
+  /** @type {WindowManager} */
+  let windowManager = null;
+
+  const adaAmount = '100';
+
+  before(async function () {
+    logger = getTestLogger(this.test.parent.title);
+    webdriver = await driversPoolsManager.getDriverFromPool();
+    await prepareWallet(webdriver, logger, 'testWallet1Mainnet', this, false);
+    const wmLogger = getTestLogger('windowManager', this.test.parent.title);
+    windowManager = new WindowManager(webdriver, wmLogger);
+    await windowManager.init();
+    basePage = new BasePage(webdriver, logger);
+    transactionsPage = new TransactionsSubTab(webdriver, logger);
+    buySellPage = new BuySell(webdriver, logger);
+  });
+
+  it('Open the BuySell dialog', async function () {
+    await transactionsPage.openBuySellDialog();
+    const pageIsDisplayed = await buySellPage.isDisplayed();
+    expect(pageIsDisplayed, 'Buy/Sell dialog is not displayed').to.be.true;
+  });
+
+  it('Check correct amount entered', async function () {
+    await buySellPage.enterAdaAmount(adaAmount);
+    const btnEnabled = await buySellPage.isProceedBtnEnabled();
+    expect(btnEnabled, 'The proceed button is disabled').to.be.true;
+  });
+
+  it('Check the Buy provider page', async function () {
+    await buySellPage.proceed();
+    await windowManager.findNewWindowAndSwitchTo(buyTabName);
+    const title = await windowManager.getCurrentPageTitle();
+    expect(title, 'The Buy provider page is not opened').to.be.equal(buyTabName);
+    const pageUrl = await windowManager.getCurrentUrl();
+    const expectedUrlPart = `https://yoroi.banxa.com/?orderType=buy&fiatType=USD&coinType=ADA&coinAmount=${adaAmount}`;
+    expect(pageUrl, 'The page URL is not correct')
+      .to.be.a('string')
+      .and.satisfy(msg => msg.startsWith(expectedUrlPart));
+  });
+
+  afterEach(async function () {
+    await customAfterEach(this, webdriver, logger);
+  });
+
+  after(async function () {
+    await transactionsPage.closeBrowser();
+  });
+});

--- a/packages/e2e-tests/test/extension/general/General_11_buySell_SellErrorMessage.test.js
+++ b/packages/e2e-tests/test/extension/general/General_11_buySell_SellErrorMessage.test.js
@@ -1,0 +1,56 @@
+import { customAfterEach } from '../../../utils/customHooks.js';
+import TransactionsSubTab from '../../../pages/wallet/walletTab/walletTransactions.page.js';
+import BuySell from '../../../pages/buySell/buySell.page.js';
+import { expect } from 'chai';
+import { getTestLogger } from '../../../utils/utils.js';
+import { oneMinute } from '../../../helpers/timeConstants.js';
+import driversPoolsManager from '../../../utils/driversPool.js';
+import { prepareWallet } from '../../../helpers/restoreWalletHelper.js';
+import { WebDriver } from 'selenium-webdriver';
+import { Logger } from 'simple-node-logger';
+import { NOT_ENOUGH_BALANCE } from '../../../helpers/messages.js';
+
+describe('Checking Sell workflow error message', function () {
+  this.timeout(2 * oneMinute);
+  /** @type {WebDriver} */
+  let webdriver = null;
+  /** @type {Logger} */
+  let logger = null;
+  /** @type {TransactionsSubTab} */
+  let transactionsPage = null;
+  /** @type {BuySell} */
+  let buySellPage = null;
+
+  before(async function () {
+    logger = getTestLogger(this.test.parent.title);
+    webdriver = await driversPoolsManager.getDriverFromPool();
+    await prepareWallet(webdriver, logger, 'testWallet1Mainnet', this, false);
+    transactionsPage = new TransactionsSubTab(webdriver, logger);
+    buySellPage = new BuySell(webdriver, logger);
+  });
+
+  it('Open the BuySell dialog', async function () {
+    await transactionsPage.openBuySellDialog();
+    const pageIsDisplayed = await buySellPage.isDisplayed();
+    expect(pageIsDisplayed, 'Buy/Sell dialog is not displayed').to.be.true;
+  });
+
+  it('Select the Sell tab', async function () {
+    const tabIsSelected = await buySellPage.selectSellTab();
+    expect(tabIsSelected, 'The Sell tab is not selected').to.be.true;
+  });
+
+  it('Check balance error', async function () {
+    await buySellPage.enterAdaAmount('100');
+    const helperMessage = await buySellPage.getHelperText();
+    expect(helperMessage).to.be.equal(NOT_ENOUGH_BALANCE);
+  });
+
+  afterEach(async function () {
+    await customAfterEach(this, webdriver, logger);
+  });
+
+  after(async function () {
+    await transactionsPage.closeBrowser();
+  });
+});

--- a/packages/e2e-tests/test/extension/general/General_12_buySell_SellPositive.test.js
+++ b/packages/e2e-tests/test/extension/general/General_12_buySell_SellPositive.test.js
@@ -1,0 +1,79 @@
+import { customAfterEach } from '../../../utils/customHooks.js';
+import BasePage from '../../../pages/basepage.js';
+import TransactionsSubTab from '../../../pages/wallet/walletTab/walletTransactions.page.js';
+import BuySell from '../../../pages/buySell/buySell.page.js';
+import { expect } from 'chai';
+import { getTestLogger } from '../../../utils/utils.js';
+import { oneMinute } from '../../../helpers/timeConstants.js';
+import driversPoolsManager from '../../../utils/driversPool.js';
+import { prepareWallet } from '../../../helpers/restoreWalletHelper.js';
+import { WebDriver } from 'selenium-webdriver';
+import { Logger } from 'simple-node-logger';
+import { sellTabName, WindowManager } from '../../../helpers/windowManager.js';
+
+describe('Checking Sell workflow redirection', function () {
+  this.timeout(2 * oneMinute);
+  /** @type {WebDriver} */
+  let webdriver = null;
+  /** @type {Logger} */
+  let logger = null;
+  /** @type {BasePage} */
+  let basePage = null;
+  /** @type {TransactionsSubTab} */
+  let transactionsPage = null;
+  /** @type {BuySell} */
+  let buySellPage = null;
+  /** @type {WindowManager} */
+  let windowManager = null;
+
+  const adaAmount = '1';
+
+  before(async function () {
+    logger = getTestLogger(this.test.parent.title);
+    webdriver = await driversPoolsManager.getDriverFromPool();
+    await prepareWallet(webdriver, logger, 'testWallet1Mainnet', this, false);
+    const wmLogger = getTestLogger('windowManager', this.test.parent.title);
+    windowManager = new WindowManager(webdriver, wmLogger);
+    await windowManager.init();
+    basePage = new BasePage(webdriver, logger);
+    transactionsPage = new TransactionsSubTab(webdriver, logger);
+    buySellPage = new BuySell(webdriver, logger);
+  });
+
+  it('Open the BuySell dialog', async function () {
+    await transactionsPage.openBuySellDialog();
+    const pageIsDisplayed = await buySellPage.isDisplayed();
+    expect(pageIsDisplayed, 'Buy/Sell dialog is not displayed').to.be.true;
+  });
+
+  it('Select the Sell tab', async function () {
+    const tabIsSelected = await buySellPage.selectSellTab();
+    expect(tabIsSelected, 'The Sell tab is not selected').to.be.true;
+  });
+
+  it('Check correct amount entered', async function () {
+    await buySellPage.enterAdaAmount(adaAmount);
+    const btnEnabled = await buySellPage.isProceedBtnEnabled();
+    expect(btnEnabled, 'The proceed button is disabled').to.be.true;
+  });
+
+  it('Check the Sell provider page', async function () {
+    await buySellPage.proceed();
+    await windowManager.findNewWindowAndSwitchTo(sellTabName);
+    const title = await windowManager.getCurrentPageTitle();
+    expect(title, 'The Sell provider page is not opened').to.be.equal(sellTabName);
+    const pageUrl = await windowManager.getCurrentUrl();
+    const expectedUrlPart = `https://hub.encryptus.co/pw/?orderType=sell&fiatType=USD&coinType=ADA&coinAmount=${adaAmount}`;
+    expect(pageUrl, 'The page URL is not correct')
+      .to.be.a('string')
+      .and.satisfy(msg => msg.startsWith(expectedUrlPart));
+  });
+
+  afterEach(async function () {
+    await customAfterEach(this, webdriver, logger);
+  });
+
+  after(async function () {
+    await transactionsPage.closeBrowser();
+  });
+});

--- a/packages/e2e-tests/test/extension/general/General_12_buySell_SellPositive.test.js
+++ b/packages/e2e-tests/test/extension/general/General_12_buySell_SellPositive.test.js
@@ -60,8 +60,8 @@ describe('Checking Sell workflow redirection', function () {
   it('Check the Sell provider page', async function () {
     await buySellPage.proceed();
     await windowManager.findNewWindowAndSwitchTo(sellTabName);
-    const title = await windowManager.getCurrentPageTitle();
-    expect(title, 'The Sell provider page is not opened').to.be.equal(sellTabName);
+    const titleIsCorrect = await windowManager.waitTitleEquals(sellTabName);
+    expect(titleIsCorrect, 'The Buy provider page title is not correct').to.be.true;
     const pageUrl = await windowManager.getCurrentUrl();
     const expectedUrlPart = `https://hub.encryptus.co/pw/?orderType=sell&fiatType=USD&coinType=ADA&coinAmount=${adaAmount}`;
     expect(pageUrl, 'The page URL is not correct')


### PR DESCRIPTION
Task: https://emurgo.atlassian.net/browse/YW-158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds E2E tests for Buy/Sell dialog UI, validation, and provider redirects, plus page object/util updates and helper constants/messages.
> 
> - **E2E Tests**:
>   - Add `General_08_checkBuySell`, `General_09_buySell_BuyErrorMessage`, `General_10_buySell_BuyPositive`, `General_11_buySell_SellErrorMessage`, `General_12_buySell_SellPositive` covering tab selection, default states, validation messages, and redirect URL/title checks.
> - **Page Objects & Utils**:
>   - **`pages/buySell/buySell.page.js`**: Add `closeModal`, `selectTab` (with `aria-selected` wait), `isProceedBtnDisabled`, improved `getHelperText` (waits), and refactor tab selection.
>   - **`pages/walletCommonBase.page.js`**: Add `buySellBtnLocator` and `openBuySellDialog`; make `titleIsCorrect` wait.
>   - **`helpers/windowManager.js`**: Add tab titles (`buyTabName`, `sellTabName`), and utilities `getCurrentPageTitle`, `waitTitleEquals`, `getCurrentUrl`; refine new-window handling.
>   - **`pages/basepage.js`**: Enhance `getAttribute` logging; add `_buttonState`, `buttonIsDisabled`; minor renames/improvements.
> - **Helpers**:
>   - **`helpers/messages.js`**: Add `PROVIDER_BUY`, `PROVIDER_SELL`, `BUY_MINIMUM`.
>   - **`helpers/constants.js`**: Add `PROVIDER_BUY_FEE`, `PROVIDER_SELL_FEE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 155b5186e9f2d25c75ec818beb7dba79d9371ffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->