### PR TITLE
[Bump] Nightly Version: 5.19.0.1

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.19.0",
+  "version": "5.19.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.19.0",
+      "version": "5.19.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.19.0",
+  "version": "5.19.0.1",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:main": "NODE_OPTIONS=--openssl-legacy-provider babel-node scripts/dev main --env mainnet",


### PR DESCRIPTION
This PR was created automatically using GitHub Actions.
Updating the version after publishing the new nightly version from branch `release/5.20`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates nightly version only.
> 
> - Bumps `version` in `packages/yoroi-extension/package.json` and `package-lock.json` to `5.19.0.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a37e19ad577345601df05f6312db832a6181b09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->