### PR TITLE
fix a send blocker

### DIFF
--- a/packages/yoroi-extension/app/stores/toplevel/TransactionBuilderStore.js
+++ b/packages/yoroi-extension/app/stores/toplevel/TransactionBuilderStore.js
@@ -392,6 +392,16 @@ export default class TransactionBuilderStore extends Store<StoresMap> {
     const publicDeriver = this.stores.wallets.selected;
     if (!publicDeriver) throw new Error(`${nameof(this.updateAmount)} requires wallet to be selected`);
     const selectedToken = this.selectedToken ?? this.stores.tokenInfoStore.getDefaultTokenInfo(publicDeriver.networkId);
+    if (value?.toString() === '0') {
+      const idx = this.plannedTxInfoMap.findIndex(({ token }) => token.Identifier === selectedToken.Identifier);
+      if (idx !== -1) {
+        runInAction(() => {
+          this.plannedTxInfoMap.splice(idx, 1);
+        });
+      }
+      return;
+    }
+
     const tokenTxInfo = this.plannedTxInfoMap.find(({ token }) => token.Identifier === selectedToken.Identifier);
 
     if (!tokenTxInfo) {


### PR DESCRIPTION
Task: https://emurgo.atlassian.net/browse/YW-295

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Addresses a send blocker by changing how zero amounts are handled.
> 
> - Updates `updateAmount` in `TransactionBuilderStore` to remove the selected token from `plannedTxInfoMap` when the entered amount is `0`, preventing zero-amount entries from interfering with tx building
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d33655108ee6fd203bda3941fd2dc3f90552c527. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->