### PR TITLE
[Fix] NFT explorer url

### DIFF
--- a/packages/yoroi-extension/app/UI/features/nfts/common/hooks/useNfts.ts
+++ b/packages/yoroi-extension/app/UI/features/nfts/common/hooks/useNfts.ts
@@ -21,7 +21,7 @@ export const useNfts = () => {
   const params = useParams<{ nftId: string | undefined }>();
   const network = getNetworkById(selectedWallet?.networkId);
   const isHaskell = isCardanoHaskell(network);
-  const networkUrl: NetworkUrl = isHaskell ? getNetworkUrl(network) : null;
+  const networkUrl: NetworkUrl = isHaskell ? getNetworkUrl(selectedWallet?.networkId) : null;
 
   useEffect(() => {
     if (spendableBalance == null) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes incorrect NFT explorer URL derivation in the `useNfts` hook.
> 
> - Computes `networkUrl` with `getNetworkUrl(selectedWallet?.networkId)` when on Cardano, ensuring correct explorer links
> - No changes to NFT fetching or selection logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd5c3217f7bf60b386f8c462c8ed80a0e735576a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->