### PR TITLE
[Bump] Nightly Version: 5.20.0.2

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.20.0.1",
+  "version": "5.20.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.20.0.1",
+      "version": "5.20.0.2",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.20.0.1",
+  "version": "5.20.0.2",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:main": "NODE_OPTIONS=--openssl-legacy-provider babel-node scripts/dev main --env mainnet",


### PR DESCRIPTION
This PR was created automatically using GitHub Actions.
Updating the version after publishing the new nightly version from branch `release/5.21`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor metadata update for a nightly release.
> 
> - Bumps `version` in `packages/yoroi-extension/package.json` and `package-lock.json` from `5.20.0.1` to `5.20.0.2`
> - No functional code or dependency changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab958b2b470957942fad0c761548b26896f47850. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->