### PR TITLE
Make dRep selection more neutral and dRep-agnostic

### DIFF
--- a/packages/yoroi-extension/app/UI/components/DrepPromotionBanner/DrepPromotionBanner.tsx
+++ b/packages/yoroi-extension/app/UI/components/DrepPromotionBanner/DrepPromotionBanner.tsx
@@ -2,11 +2,9 @@ import { Button, Stack, Typography, styled, useTheme } from '@mui/material';
 import BigNumber from 'bignumber.js';
 import { observer } from 'mobx-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { dRepNormalize } from '../../../api/ada/lib/cardanoCrypto/utils';
 import LocalStorageApi from '../../../api/localStorage/index';
 import globalMessages from '../../../i18n/global-messages';
 import { ROUTES } from '../../../routes-config';
-import { YOROI_DREP_ID } from '../../features/governace/common/constants';
 import { IconWrapper, Icons } from '../icons';
 import { Ilustration } from './Ilustration';
 
@@ -71,7 +69,6 @@ export const DrepPromotionBanner = observer(({ stores, onClose, intl }) => {
 
   const [governanceInfo, setGovernanceInfo] = useState({
     isParticipatingToGovernance: false,
-    isDelegatingToYoroiDrep: false,
   });
 
   useEffect(() => {
@@ -79,9 +76,7 @@ export const DrepPromotionBanner = observer(({ stores, onClose, intl }) => {
       const govInfo = stores.delegation.governanceStatus?.drepDelegation;
       if (govInfo) {
         const isParticipatingToGovernance = govInfo !== null;
-        const drepEncoded = dRepNormalize(govInfo?.drep, govInfo?.drepKind);
-        const isDelegatingToYoroiDrep = isParticipatingToGovernance && drepEncoded === YOROI_DREP_ID;
-        setGovernanceInfo({ isParticipatingToGovernance, isDelegatingToYoroiDrep });
+        setGovernanceInfo({ isParticipatingToGovernance });
       }
     };
 
@@ -126,10 +121,7 @@ export const DrepPromotionBanner = observer(({ stores, onClose, intl }) => {
             },
           }}
           onClick={() => {
-            stores.routing.goToRoute({
-              route: ROUTES.GOVERNANCE.ROOT,
-              query: { delegateToYoroiDrep: true },
-            });
+            stores.routing.goToRoute({ route: ROUTES.GOVERNANCE.ROOT });
           }}
         >
           {intl.formatMessage(globalMessages.delegateVote)}

--- a/packages/yoroi-extension/app/UI/features/governace/common/constants.ts
+++ b/packages/yoroi-extension/app/UI/features/governace/common/constants.ts
@@ -7,8 +7,6 @@ export const LEARN_MORE_LINK =
   'https://help.yoroi-wallet.com/en/article/how-can-i-participate-in-governance-through-yoroi-155o8l3/ ';
 export const FIND_DREPS_LINK = 'https://beta.cexplorer.io/drep?tab=list';
 export const FIND_DREPS_LINK_TESTNET = 'https://preprod.cexplorer.io/drep';
-export const YOROI_DREP_ID = 'drep1ygr9tuapcanc3kpeyy4dc3vmrz9cfe5q7v9wj3x9j0ap3tswtre9j';
-export const YOROI_DREP_ID_TESTNET = 'drep1y23nc498g205wtvp9esysyxam0n7msusm5d734xqlzhvkgq3pn5r7';
 
 export const DREP_ALWAYS_ABSTAIN = API_ABSTAIN;
 export const DREP_ALWAYS_NO_CONFIDENCE = API_NO_CONFIDENCE;

--- a/packages/yoroi-extension/app/UI/features/governace/common/constants.ts
+++ b/packages/yoroi-extension/app/UI/features/governace/common/constants.ts
@@ -5,22 +5,13 @@ import {
 
 export const LEARN_MORE_LINK =
   'https://help.yoroi-wallet.com/en/article/how-can-i-participate-in-governance-through-yoroi-155o8l3/ ';
-export const YOROI_VOTING_RECORD_LINK =
-  'https://2025budget.intersectmbo.org/voters/drep1ygr9tuapcanc3kpeyy4dc3vmrz9cfe5q7v9wj3x9j0ap3tswtre9j';
 export const FIND_DREPS_LINK = 'https://beta.cexplorer.io/drep?tab=list';
 export const FIND_DREPS_LINK_TESTNET = 'https://preprod.cexplorer.io/drep';
 export const YOROI_DREP_ID = 'drep1ygr9tuapcanc3kpeyy4dc3vmrz9cfe5q7v9wj3x9j0ap3tswtre9j';
 export const YOROI_DREP_ID_TESTNET = 'drep1y23nc498g205wtvp9esysyxam0n7msusm5d734xqlzhvkgq3pn5r7';
-export const EMURGO_DREP_ID = 'drep1ytvlwvyjmzfyn56n0zz4f6lj94wxhmsl5zky6knnzrf4jygpyahug';
 
 export const DREP_ALWAYS_ABSTAIN = API_ABSTAIN;
 export const DREP_ALWAYS_NO_CONFIDENCE = API_NO_CONFIDENCE;
-
-export const drepNames = {
-  [YOROI_DREP_ID]: 'Yoroi W₳llet',
-  [EMURGO_DREP_ID]: 'EMURGO',
-  [YOROI_DREP_ID_TESTNET]: 'Testnet DRep',
-};
 
 export const GOVERNANCE_STATUS = {
   IDLE: 'idle',

--- a/packages/yoroi-extension/app/UI/features/governace/common/hooks/useGovernanceDelegationStatus.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/common/hooks/useGovernanceDelegationStatus.tsx
@@ -23,20 +23,21 @@ export const useGovernanceDelegationStatus = ({
 
   return React.useMemo(() => {
     const yoroiDrepId = isTestnet ? YOROI_DREP_ID_TESTNET : YOROI_DREP_ID;
-    const drepID = governanceStatus?.drep ? governanceStatus?.drep : yoroiDrepId;
+    const drepID = governanceStatus?.drep ?? null;
 
     const isAbstain = isDelegated && governanceStatus?.drep === null && governanceStatus?.status === DREP_ALWAYS_ABSTAIN;
     const isNoConfidence =
       isDelegated && governanceStatus?.drep === null && governanceStatus?.status === DREP_ALWAYS_NO_CONFIDENCE;
-    const isDelegationToYoroiDrep = isDelegated && !(isAbstain || isNoConfidence) && drepID === yoroiDrepId;
-    const isDelegationToOtherDrep = isDelegated && !(isAbstain || isNoConfidence) && drepID !== yoroiDrepId;
+    const hasDrepSelection = isDelegated && !(isAbstain || isNoConfidence) && drepID != null;
+    const isDelegationToYoroiDrep = hasDrepSelection && drepID === yoroiDrepId;
+    const isDelegationToOtherDrep = hasDrepSelection && drepID !== yoroiDrepId;
 
     return {
       isAbstain,
       isNoConfidence,
       isDelegationToYoroiDrep,
       isDelegationToOtherDrep,
-      drepID,
+      drepID: drepID ?? '',
     };
   }, [governanceStatus?.status, governanceStatus?.drep, isDelegated, isTestnet]);
 };

--- a/packages/yoroi-extension/app/UI/features/governace/common/hooks/useGovernanceDelegationStatus.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/common/hooks/useGovernanceDelegationStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DREP_ALWAYS_ABSTAIN, DREP_ALWAYS_NO_CONFIDENCE, YOROI_DREP_ID, YOROI_DREP_ID_TESTNET } from '../../common/constants';
+import { DREP_ALWAYS_ABSTAIN, DREP_ALWAYS_NO_CONFIDENCE } from '../../common/constants';
 import { useGovernance } from '../../module/GovernanceContextProvider';
 
 type UseGovernanceDelegationStatusParams = {
@@ -10,8 +10,7 @@ type UseGovernanceDelegationStatusParams = {
 type UseGovernanceDelegationStatusResult = {
   isAbstain: boolean;
   isNoConfidence: boolean;
-  isDelegationToYoroiDrep: boolean;
-  isDelegationToOtherDrep: boolean;
+  isDelegationToDrep: boolean;
   drepID: string;
 };
 
@@ -19,25 +18,19 @@ export const useGovernanceDelegationStatus = ({
   governanceStatus,
   isDelegated,
 }: UseGovernanceDelegationStatusParams): UseGovernanceDelegationStatusResult => {
-  const { isTestnet } = useGovernance();
-
   return React.useMemo(() => {
-    const yoroiDrepId = isTestnet ? YOROI_DREP_ID_TESTNET : YOROI_DREP_ID;
     const drepID = governanceStatus?.drep ?? null;
 
     const isAbstain = isDelegated && governanceStatus?.drep === null && governanceStatus?.status === DREP_ALWAYS_ABSTAIN;
     const isNoConfidence =
       isDelegated && governanceStatus?.drep === null && governanceStatus?.status === DREP_ALWAYS_NO_CONFIDENCE;
-    const hasDrepSelection = isDelegated && !(isAbstain || isNoConfidence) && drepID != null;
-    const isDelegationToYoroiDrep = hasDrepSelection && drepID === yoroiDrepId;
-    const isDelegationToOtherDrep = hasDrepSelection && drepID !== yoroiDrepId;
+    const isDelegationToDrep = isDelegated && !(isAbstain || isNoConfidence) && drepID != null;
 
     return {
       isAbstain,
       isNoConfidence,
-      isDelegationToYoroiDrep,
-      isDelegationToOtherDrep,
+      isDelegationToDrep,
       drepID: drepID ?? '',
     };
-  }, [governanceStatus?.status, governanceStatus?.drep, isDelegated, isTestnet]);
+  }, [governanceStatus?.status, governanceStatus?.drep, isDelegated]);
 };

--- a/packages/yoroi-extension/app/UI/features/governace/common/hooks/useStrings.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/common/hooks/useStrings.tsx
@@ -168,7 +168,7 @@ export const messages = Object.freeze(
     },
     chooseDelegationOption: {
       id: 'governance.chooseDelegationOption',
-      defaultMessage: '!!!Choose to delegate your voting power to Yoroi DRep or explore other options',
+      defaultMessage: '!!!Your delegation to DReps helps shaping Cardano’s future. You may change your governance status at any time.',
     },
     exploreOtherDRepsOrAbstain: {
       id: 'governance.exploreOtherDRepsOrAbstain',

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DRepOptions.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DRepOptions.tsx
@@ -42,7 +42,6 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
       title: strings.delegateToDRep,
       description: strings.identifyDrep,
       buttonText: isDelegationToDrep ? strings.changeToDrep : strings.delegateLabel,
-      variant: 'outlined' as const,
       icon: <Icon.VotingDrep />,
       onAction: () => openDelegateModalForCustomDrep(),
       status: cardState,
@@ -54,7 +53,6 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
       title: strings.abstain,
       description: strings.chooseAbstain,
       buttonText: isAbstain ? strings.changeToDrep : strings.delegateLabel,
-      variant: 'outlined' as const,
       icon: <Icon.VotingAbstain />,
       onAction: () => (isAbstain ? openDelegateModalForCustomDrep() : delegateToAbstain()),
       status: cardState,
@@ -66,7 +64,6 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
       title: strings.noConfidence,
       description: strings.chooseNoConfidence,
       buttonText: isNoConfidence ? strings.changeToDrep : strings.delegateLabel,
-      variant: 'outlined' as const,
       icon: <Icon.VotingNoConfidence />,
       onAction: () => (isNoConfidence ? openDelegateModalForCustomDrep() : delegateToNoConfidence()),
       status: cardState,
@@ -99,7 +96,6 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
               title={option.title}
               description={option.description}
               buttonText={option.buttonText}
-              variant={option.variant}
               icon={option.icon}
               onAction={option.onAction}
               status={option.status}

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DRepOptions.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DRepOptions.tsx
@@ -9,7 +9,7 @@ import { useGovernance } from '../../module/GovernanceContextProvider';
 import { useGovernanceDelegationToYoroiDrep } from '../../common/hooks/useGovernanceDelegationToYoroiDrep';
 import { useGovernanceStatusState } from '../../common/hooks/useGovernanceStatusState';
 import { useGovernanceDelegationStatus } from '../../common/hooks/useGovernanceDelegationStatus';
-import { GOVERNANCE_STATUS, YOROI_DREP_ID, YOROI_DREP_ID_TESTNET, YOROI_VOTING_RECORD_LINK } from '../../common/constants';
+import { GOVERNANCE_STATUS } from '../../common/constants';
 import { OptionsSkeletonScreen } from '../../common/SkeletonCardLoaders';
 
 interface DRepOptionsScreenProps {}
@@ -19,8 +19,8 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
   const strings = useStrings();
   const theme: any = useTheme();
 
-  const { submitedTransactions, isTestnet } = useGovernance();
-  const { loadingUnsignTx, delegateToDrep, openDelegateModalForCustomDrep, delegateToAbstain, delegateToNoConfidence } =
+  const { submitedTransactions } = useGovernance();
+  const { loadingUnsignTx, openDelegateModalForCustomDrep, delegateToAbstain, delegateToNoConfidence } =
     useGovernanceDelegationToYoroiDrep();
   const isPendingDrepDelegationTx = submitedTransactions.length > 0 && submitedTransactions[0]?.isDrepDelegation === true;
 
@@ -30,38 +30,24 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
     governanceStatus,
     isDelegated,
   });
+  const isDelegationToDrep = isDelegationToYoroiDrep || isDelegationToOtherDrep;
 
   const onBack = () => {
     navigateTo.selectRevampStatus();
   };
 
-  const drepYoroiId = isTestnet ? YOROI_DREP_ID_TESTNET : YOROI_DREP_ID;
-
   const drepOptionsConfig = [
     {
-      key: 'yoroi',
-      title: isTestnet ? strings.yoroiTestnetDRep : strings.yoroiDRep,
-      description: strings.yoroiDRepInfo,
-      buttonText: strings.delegateLabel,
-      variant: 'primary' as const,
-      icon: <Icon.YoroiLogo fill={theme.palette.ds.gray_min} />,
-      onAction: () => delegateToDrep(drepYoroiId),
-      onViewDetails: isTestnet ? undefined : () => window.open(YOROI_VOTING_RECORD_LINK, '_blank'),
-      status: cardState,
-      drepId: governanceStatus.drep,
-      isDelegated: isDelegationToYoroiDrep,
-    },
-    {
       key: 'others',
-      title: strings.otherDReps,
-      description: strings.designatingSomeoneElse,
-      buttonText: isDelegationToOtherDrep ? strings.delegateToOtherDrep : strings.delegateLabel,
+      title: strings.delegateToDRep,
+      description: strings.identifyDrep,
+      buttonText: isDelegationToDrep ? strings.changeToDrep : strings.delegateLabel,
       variant: 'outlined' as const,
       icon: <Icon.VotingDrep />,
       onAction: () => openDelegateModalForCustomDrep(),
       status: cardState,
       drepId: governanceStatus.drep,
-      isDelegated: isDelegationToOtherDrep,
+      isDelegated: isDelegationToDrep,
     },
     {
       key: 'abstain',
@@ -101,7 +87,7 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
       <TitleSection>
         <Typography variant="h5">{strings.chooseVotingPower}</Typography>
         <Typography variant="body1" color="ds.text_gray_low">
-          {strings.letYoroiDRepVoteForYou}
+          {strings.chooseDelegationOption}
         </Typography>
       </TitleSection>
 
@@ -116,7 +102,6 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
               variant={option.variant}
               icon={option.icon}
               onAction={option.onAction}
-              onViewDetails={option.onViewDetails}
               status={option.status}
               drepId={option.drepId}
               isDelegated={option.isDelegated}

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DRepOptions.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DRepOptions.tsx
@@ -26,11 +26,10 @@ export const DRepOptions: React.FC<DRepOptionsScreenProps> = () => {
 
   const { governanceStatusState: cardState, governanceStatus } = useGovernanceStatusState();
   const isDelegated = cardState === GOVERNANCE_STATUS.DELEGATED;
-  const { isAbstain, isNoConfidence, isDelegationToYoroiDrep, isDelegationToOtherDrep } = useGovernanceDelegationStatus({
+  const { isAbstain, isNoConfidence, isDelegationToDrep } = useGovernanceDelegationStatus({
     governanceStatus,
     isDelegated,
   });
-  const isDelegationToDrep = isDelegationToYoroiDrep || isDelegationToOtherDrep;
 
   const onBack = () => {
     navigateTo.selectRevampStatus();

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DrepOptionsCard.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DrepOptionsCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Button, Stack, Link } from '@mui/material';
+import { Box, Typography, Button } from '@mui/material';
 import { styled } from '@mui/system';
 import { useStrings } from '../../common/hooks/useStrings';
 import { GOVERNANCE_STATUS, GovernanceStatusState } from '../../common/constants';
@@ -13,7 +13,6 @@ interface ActionCardProps {
   variant: 'primary' | 'outlined';
   icon?: React.ReactNode;
   onAction: () => void;
-  onViewDetails?: () => void;
   status: GovernanceStatusState;
   drepId: string | null;
   isDelegated: boolean;
@@ -27,14 +26,11 @@ export const DrepOptionsCard: React.FC<ActionCardProps> = ({
   variant,
   icon,
   onAction,
-  onViewDetails,
   status,
   drepId,
   isDelegated,
   pending = false,
 }) => {
-  const strings = useStrings();
-
   return (
     <ActionCardContainer variant={variant} status={status} isCardDelegated={isDelegated} pending={pending}>
       <CardWrapper>
@@ -51,30 +47,11 @@ export const DrepOptionsCard: React.FC<ActionCardProps> = ({
       </CardWrapper>
 
       <CTASet>
-        {variant === 'primary' ? (
-          <Stack direction="column" spacing={12} width="100%">
-            {(status === GOVERNANCE_STATUS.DELEGATED || drepId === null) && !isDelegated && (
-              // @ts-ignore
-              <LoadingButton variant="primary" onClick={onAction} fullWidth height="40px">
-                {buttonText}
-              </LoadingButton>
-            )}
-
-            {onViewDetails && (
-              <Link
-                textAlign="center"
-                onClick={e => {
-                  e.stopPropagation();
-                  onViewDetails();
-                }}
-                rel="noopener"
-                underline="hover"
-                sx={{ cursor: 'pointer' }}
-              >
-                {strings.yoroiVotingRecord}
-              </Link>
-            )}
-          </Stack>
+        {(status === GOVERNANCE_STATUS.DELEGATED || drepId === null) && !isDelegated && variant === 'primary' ? (
+          // @ts-ignore
+          <LoadingButton variant="primary" onClick={onAction} fullWidth height="40px">
+            {buttonText}
+          </LoadingButton>
         ) : (
           // @ts-ignore
           <Button height="40px" variant="secondary" onClick={onAction} fullWidth sx={{ padding: '13px 10px !important' }}>

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DrepOptionsCard.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceOptions/DrepOptionsCard.tsx
@@ -2,7 +2,6 @@ import { Box, Typography, Button } from '@mui/material';
 import { styled } from '@mui/system';
 import { useStrings } from '../../common/hooks/useStrings';
 import { GOVERNANCE_STATUS, GovernanceStatusState } from '../../common/constants';
-import { LoadingButton } from '@mui/lab';
 import { CopyButton } from '../../../../components';
 import { truncateFormatter } from '../../../../common/helpers/formatters';
 
@@ -10,7 +9,6 @@ interface ActionCardProps {
   title: string;
   description: string;
   buttonText: string;
-  variant: 'primary' | 'outlined';
   icon?: React.ReactNode;
   onAction: () => void;
   status: GovernanceStatusState;
@@ -23,7 +21,6 @@ export const DrepOptionsCard: React.FC<ActionCardProps> = ({
   title,
   description,
   buttonText,
-  variant,
   icon,
   onAction,
   status,
@@ -32,10 +29,10 @@ export const DrepOptionsCard: React.FC<ActionCardProps> = ({
   pending = false,
 }) => {
   return (
-    <ActionCardContainer variant={variant} status={status} isCardDelegated={isDelegated} pending={pending}>
+    <ActionCardContainer status={status} isCardDelegated={isDelegated} pending={pending}>
       <CardWrapper>
         <CardTitleRow>
-          <CardIcon variant={variant} isDelegated={isDelegated}>
+          <CardIcon isDelegated={isDelegated}>
             {icon}
           </CardIcon>
           <Typography variant="h5">{title}</Typography>
@@ -47,17 +44,15 @@ export const DrepOptionsCard: React.FC<ActionCardProps> = ({
       </CardWrapper>
 
       <CTASet>
-        {(status === GOVERNANCE_STATUS.DELEGATED || drepId === null) && !isDelegated && variant === 'primary' ? (
-          // @ts-ignore
-          <LoadingButton variant="primary" onClick={onAction} fullWidth height="40px">
-            {buttonText}
-          </LoadingButton>
-        ) : (
-          // @ts-ignore
-          <Button height="40px" variant="secondary" onClick={onAction} fullWidth sx={{ padding: '13px 10px !important' }}>
-            {buttonText}
-          </Button>
-        )}
+        <Button
+          fullWidth
+          onClick={onAction}
+          sx={{ height: '40px', padding: '13px 10px !important' }}
+          /* @ts-ignore */
+          variant="secondary"
+        >
+          {buttonText}
+        </Button>
       </CTASet>
     </ActionCardContainer>
   );
@@ -124,18 +119,15 @@ const DelegatingLabel = () => {
   );
 };
 
-type ActionCardVariant = 'primary' | 'outlined';
-
 interface ActionCardContainerProps {
-  variant: ActionCardVariant;
   status: GovernanceStatusState;
   isCardDelegated?: boolean;
   pending?: boolean;
 }
 
 export const ActionCardContainer = styled(Box, {
-  shouldForwardProp: prop => prop !== 'variant' && prop !== 'status' && prop !== 'isCardDelegated' && prop !== 'pending',
-})<ActionCardContainerProps>(({ pending, theme, variant, status, isCardDelegated }: any) => {
+  shouldForwardProp: prop => prop !== 'status' && prop !== 'isCardDelegated' && prop !== 'pending',
+})<ActionCardContainerProps>(({ pending, theme, status, isCardDelegated }: any) => {
   const base: React.CSSProperties = {
     boxSizing: 'border-box',
     display: 'flex',
@@ -143,7 +135,7 @@ export const ActionCardContainer = styled(Box, {
     justifyContent: 'space-between',
     alignItems: 'flex-start',
     padding: '16px',
-    gap: variant === 'primary' ? '16px' : '12px',
+    gap: '12px',
     width: '294px',
     height: '320px',
     borderRadius: '8px',
@@ -166,15 +158,6 @@ export const ActionCardContainer = styled(Box, {
     return {
       ...base,
       background: theme.palette.ds.bg_gradient_2,
-    };
-  }
-  if (variant === 'primary') {
-    return {
-      ...base,
-      backgroundImage: theme.palette.ds.bg_gradient_1,
-      '&:hover': {
-        backgroundImage: theme.palette.ds.bg_gradient_2,
-      },
     };
   }
 
@@ -217,16 +200,11 @@ const CardTitleRow = styled(Box)(() => ({
 }));
 
 const CardIcon = styled(Box, {
-  shouldForwardProp: prop => prop !== 'variant' && prop !== 'isDelegated',
-})<{ variant: 'primary' | 'outlined'; isDelegated?: boolean }>(({ variant, isDelegated, theme }: any) => ({
+  shouldForwardProp: prop => prop !== 'isDelegated',
+})<{ isDelegated?: boolean }>(({ isDelegated, theme }: any) => ({
   width: '48px',
   height: '48px',
-  background:
-    variant === 'primary'
-      ? theme.palette.ds.primary_500
-      : isDelegated
-        ? theme.palette.ds.secondary_200
-        : theme.palette.ds.gray_100,
+  background: isDelegated ? theme.palette.ds.secondary_200 : theme.palette.ds.gray_100,
   borderRadius: '1200px',
   display: 'flex',
   alignItems: 'center',

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceStatus/GovernanceStatus.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceStatus/GovernanceStatus.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
 import { styled } from '@mui/material/styles';
 import { Box, Typography, Button } from '@mui/material';
-import { useLocation } from 'react-router';
 import { GovernanceStatusCard } from './GovernanceStatusCard';
 import { useNavigateTo } from '../../common/useNavigateTo';
 import { useStrings } from '../../common/hooks/useStrings';
-import { GOVERNANCE_STATUS, YOROI_DREP_ID, YOROI_DREP_ID_TESTNET } from '../../common/constants';
+import { GOVERNANCE_STATUS } from '../../common/constants';
 import { useGovernanceDelegationToYoroiDrep } from '../../common/hooks/useGovernanceDelegationToYoroiDrep';
 import { useGovernanceStatusState } from '../../common/hooks/useGovernanceStatusState';
 import { useIsGovernanceAllowed } from '../../common/hooks/useIsGovernanceAllowed';
@@ -16,19 +14,11 @@ import { StatusSkeletonScreen } from '../../common/SkeletonCardLoaders';
 export const GovernanceStatus = () => {
   const navigateTo = useNavigateTo();
   const strings = useStrings();
-  const location = useLocation();
-  const { loadingUnsignTx, error, delegateToDrep, openDelegateModalForCustomDrep } = useGovernanceDelegationToYoroiDrep();
+  const { loadingUnsignTx, error, openDelegateModalForCustomDrep } = useGovernanceDelegationToYoroiDrep();
   const { governanceStatusState: cardState, governanceStatus } = useGovernanceStatusState();
-  const { submitedTransactions, isTestnet } = useGovernance();
+  const { submitedTransactions } = useGovernance();
   const { isNotAllowed, isParticipating } = useIsGovernanceAllowed();
   const isPendingDrepDelegationTx = submitedTransactions.length > 0 && submitedTransactions[0]?.isDrepDelegation === true;
-  const yoroiDrepId = isTestnet ? YOROI_DREP_ID_TESTNET : YOROI_DREP_ID;
-
-  React.useEffect(() => {
-    if (location.search.includes('delegateToYoroiDrep=true')) {
-      delegateToDrep(yoroiDrepId);
-    }
-  }, [useLocation]);
 
   const onExploreMore = () => {
     navigateTo.selectRevampOptions();
@@ -63,7 +53,7 @@ export const GovernanceStatus = () => {
         <GovernanceStatusCard
           state={cardState}
           governanceStatus={governanceStatus}
-          onDelegateClick={() => delegateToDrep(yoroiDrepId)}
+          onDelegateClick={openDelegateModalForCustomDrep}
           btnLoading={loadingUnsignTx}
           openDelegateModalForCustomDrep={openDelegateModalForCustomDrep}
           pending={isPendingDrepDelegationTx}

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceStatus/GovernanceStatusCard.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceStatus/GovernanceStatusCard.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { styled, useTheme } from '@mui/material/styles';
-import { Box, Typography, Link, Stack } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { CopyButton, Icon } from '../../../../components';
 import { useStrings } from '../../common/hooks/useStrings';
 import { LoadingButton } from '@mui/lab';
-import { GOVERNANCE_STATUS, GovernanceStatusState, YOROI_VOTING_RECORD_LINK } from '../../common/constants';
+import { GOVERNANCE_STATUS, GovernanceStatusState } from '../../common/constants';
 import { truncateFormatter } from '../../../../common/helpers/formatters';
 import { useIsGovernanceAllowed } from '../../common/hooks/useIsGovernanceAllowed';
 import { useGovernanceDelegationStatus } from '../../common/hooks/useGovernanceDelegationStatus';
-import { useGovernance } from '../../module/GovernanceContextProvider';
 
 interface GovernanceStatusCardProps {
   state: GovernanceStatusState;
@@ -32,7 +31,6 @@ export const GovernanceStatusCard: React.FC<GovernanceStatusCardProps> = ({
   const isDisabled = state === GOVERNANCE_STATUS.DISABLED || pending;
   const isDelegated = state === GOVERNANCE_STATUS.DELEGATED;
   const { isParticipating } = useIsGovernanceAllowed();
-  const { isTestnet } = useGovernance();
   const strings = useStrings();
   const theme: any = useTheme();
 
@@ -40,13 +38,13 @@ export const GovernanceStatusCard: React.FC<GovernanceStatusCardProps> = ({
     governanceStatus,
     isDelegated,
   });
+  const isDelegationToDrep = isDelegationToYoroiDrep || isDelegationToOtherDrep;
   const primaryButtonLabel = forModal ? strings.delegateLabel : isDelegated ? strings.changeToDrep : strings.delegateLabel;
-  const showDrepStatus = isDelegationToOtherDrep || isDelegationToYoroiDrep || !isParticipating;
-  const showDrepId = isDelegationToOtherDrep || isDelegationToYoroiDrep;
+  const showDrepStatus = isDelegationToDrep || !isParticipating;
+  const showDrepId = isDelegationToDrep;
   const showDelegatingLabel = isParticipating && !forModal;
   const showDelegateToOtherDrepButton = isAbstain || isNoConfidence;
-  const showDelegateToYoroiDrepButton = !isParticipating || forModal || (state === GOVERNANCE_STATUS.IDLE && !isDelegated);
-  const showVotingRecordLink = !forModal && !isAbstain && !isNoConfidence && !isDelegationToOtherDrep && !isTestnet;
+  const showDelegateButton = !isParticipating || forModal || (state === GOVERNANCE_STATUS.IDLE && !isDelegated);
 
   const handleDelegateClick = () => {
     if (isDisabled) return;
@@ -54,17 +52,10 @@ export const GovernanceStatusCard: React.FC<GovernanceStatusCardProps> = ({
   };
 
   const handleCardInfo = () => {
-    if (isDelegationToYoroiDrep) {
-      return {
-        icon: <Icon.YoroiLogo width={forModal ? 16 : 24} height={forModal ? 16 : 24} fill={theme.palette.ds.gray_min} />,
-        title: isTestnet ? strings.yoroiTestnetDRep : strings.yoroiDRep,
-        description: strings.yoroiDRepInfo,
-      };
-    }
-    if (isDelegationToOtherDrep) {
+    if (isDelegationToDrep) {
       return {
         icon: <Icon.VotingDrep width={24} height={24} fill={theme.palette.ds.gray_max} />,
-        title: strings.otherDReps,
+        title: strings.delegateToDRep,
         description: strings.designatedSomeoneElse,
       };
     }
@@ -83,9 +74,9 @@ export const GovernanceStatusCard: React.FC<GovernanceStatusCardProps> = ({
       };
     }
     return {
-      icon: <Icon.YoroiLogo width={24} height={24} fill={theme.palette.ds.gray_min} />,
-      title: isTestnet ? strings.yoroiTestnetDRep : strings.yoroiDRep,
-      description: strings.yoroiDRepInfo,
+      icon: <Icon.VotingDrep width={24} height={24} fill={theme.palette.ds.gray_max} />,
+      title: strings.delegateToDRep,
+      description: strings.identifyDrep,
     };
   };
 
@@ -100,8 +91,6 @@ export const GovernanceStatusCard: React.FC<GovernanceStatusCardProps> = ({
       <TitleRow>
         <Avatar
           forModal={forModal}
-          state={state}
-          isDelegationToYoroiDrep={isDelegationToYoroiDrep}
           isParticipating={isParticipating}
         >
           {handleCardInfo().icon}
@@ -178,7 +167,7 @@ export const GovernanceStatusCard: React.FC<GovernanceStatusCardProps> = ({
             {strings.changeToDrep}
           </LoadingButton>
         )}
-        {showDelegateToYoroiDrepButton && (
+        {showDelegateButton && (
           <LoadingButton
             fullWidth
             loading={btnLoading}
@@ -190,20 +179,6 @@ export const GovernanceStatusCard: React.FC<GovernanceStatusCardProps> = ({
           >
             {primaryButtonLabel}
           </LoadingButton>
-        )}
-        {showVotingRecordLink && (
-          <Stack direction="row" justifyContent="center" alignItems="flex-start" width="100%">
-            <Link
-              onClick={event => event.stopPropagation()}
-              href={YOROI_VOTING_RECORD_LINK}
-              rel="noopener"
-              target="_blank"
-              underline="hover"
-              sx={{ cursor: 'pointer' }}
-            >
-              <Typography variant="body1">{strings.yoroiVotingRecord}</Typography>
-            </Link>
-          </Stack>
         )}
       </CtaSet>
     </Root>
@@ -281,10 +256,8 @@ const TitleRow = styled(Box)(() => ({
 
 const Avatar = styled(Box)<{
   forModal: boolean;
-  state: GovernanceStatusState;
-  isDelegationToYoroiDrep: boolean;
   isParticipating: boolean;
-}>(({ isDelegationToYoroiDrep, forModal, theme, isParticipating }: any) => ({
+}>(({ forModal, theme, isParticipating }: any) => ({
   width: forModal ? '24px' : '48px',
   height: forModal ? '24px' : '48px',
   borderRadius: '1200px',
@@ -292,7 +265,7 @@ const Avatar = styled(Box)<{
   alignItems: 'center',
   justifyContent: 'center',
   flexShrink: 0,
-  background: !isParticipating || isDelegationToYoroiDrep ? theme.palette.ds.primary_500 : theme.palette.ds.secondary_200,
+  background: !isParticipating ? theme.palette.ds.primary_500 : theme.palette.ds.secondary_200,
 }));
 
 const ItemsGroup = styled(Box)(() => ({

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceStatus/GovernanceStatusCard.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/GovernanceStatus/GovernanceStatusCard.tsx
@@ -34,11 +34,10 @@ export const GovernanceStatusCard: React.FC<GovernanceStatusCardProps> = ({
   const strings = useStrings();
   const theme: any = useTheme();
 
-  const { isAbstain, isNoConfidence, isDelegationToYoroiDrep, isDelegationToOtherDrep, drepID } = useGovernanceDelegationStatus({
+  const { isAbstain, isNoConfidence, isDelegationToDrep, drepID } = useGovernanceDelegationStatus({
     governanceStatus,
     isDelegated,
   });
-  const isDelegationToDrep = isDelegationToYoroiDrep || isDelegationToOtherDrep;
   const primaryButtonLabel = forModal ? strings.delegateLabel : isDelegated ? strings.changeToDrep : strings.delegateLabel;
   const showDrepStatus = isDelegationToDrep || !isParticipating;
   const showDrepId = isDelegationToDrep;

--- a/packages/yoroi-extension/app/UI/features/transaction-review/common/operations.tsx
+++ b/packages/yoroi-extension/app/UI/features/transaction-review/common/operations.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { asQuantity, Quantities } from '../../../utils/quantities';
 import { CertificateType, FormattedTx } from './types';
 import { useStrings } from './hooks/useStrings';
-import { drepNames } from '../../governace/common/constants';
 import { dRepNormalize } from '../../../../api/ada/lib/cardanoCrypto/utils';
 
 type OperationsCount = Record<CertificateType, number>;
@@ -167,7 +166,7 @@ export const VoteDelegationOperation = ({
 }) => {
   const strings = useStrings();
   const normalizedDrep = hash == null || hash === '' ? null : dRepNormalize(hash);
-  const drepTitle = normalizedDrep ? (drepNames[normalizedDrep] ?? normalizedDrep) : '-';
+  const drepTitle = normalizedDrep ?? '-';
 
   return (
     <Stack direction="column" spacing={16}>

--- a/packages/yoroi-extension/app/UI/features/transaction-review/useCases/ChooseDrepId/ChooseOtherDrepId.tsx
+++ b/packages/yoroi-extension/app/UI/features/transaction-review/useCases/ChooseDrepId/ChooseOtherDrepId.tsx
@@ -5,15 +5,7 @@ import { dRepToMaybeCredentialHex } from '../../../../../api/ada/lib/cardanoCryp
 import { TextInput } from '../../../../components';
 import { useTxReviewModal } from '../../module/ReviewTxProvider';
 import { useStrings } from '../../common/hooks/useStrings';
-import {
-  GOVERNANCE_STATUS,
-  YOROI_DREP_ID,
-  FIND_DREPS_LINK,
-  FIND_DREPS_LINK_TESTNET,
-  YOROI_DREP_ID_TESTNET,
-} from '../../../governace/common/constants';
-import { GovernanceStatusCard } from '../../../governace/useCases/GovernanceStatus/GovernanceStatusCard';
-import { useGovernanceDelegationToYoroiDrep } from '../../../governace/common/hooks/useGovernanceDelegationToYoroiDrep';
+import { FIND_DREPS_LINK, FIND_DREPS_LINK_TESTNET } from '../../../governace/common/constants';
 import { useGovernance } from '../../../governace/module/GovernanceContextProvider';
 
 const HANDLE_API = 'https://api.handle.me/handles';
@@ -62,12 +54,10 @@ const resolveDrepIdFromHandle = async (raw: string): Promise<{ drepId: string | 
 
 export const ChooseOtherDrepId = () => {
   const { isLoading, changeModalView, createUnsignedTx, setDrepId } = useTxReviewModal();
-  const { delegateToDrep } = useGovernanceDelegationToYoroiDrep();
   const { isTestnet } = useGovernance();
   const strings = useStrings();
 
   const findDrepLink = isTestnet ? FIND_DREPS_LINK_TESTNET : FIND_DREPS_LINK;
-  const yoroiDrepId = isTestnet ? YOROI_DREP_ID_TESTNET : YOROI_DREP_ID;
 
   const [drepIdInput, setDrepIdInput] = React.useState('');
   const [error, setError] = React.useState<DrepError>(null);
@@ -151,19 +141,6 @@ export const ChooseOtherDrepId = () => {
               {strings.findDrepHere}
             </Link>
           </Stack>
-
-          <Typography variant="body1" color="ds.text_gray_medium">
-            {strings.delegateToYoroi}
-          </Typography>
-        </Stack>
-
-        <Stack p={24}>
-          <GovernanceStatusCard
-            state={GOVERNANCE_STATUS.DELEGATED}
-            governanceStatus={{ status: GOVERNANCE_STATUS.IDLE, drep: yoroiDrepId }}
-            forModal
-            onDelegateClick={() => delegateToDrep(yoroiDrepId)}
-          />
         </Stack>
       </Stack>
 


### PR DESCRIPTION
Updates governance selection UI copy/labels to present DRep choices more neutrally and support informed user choice, without changing delegation functionality or available options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/flow changes in governance delegation remove Yoroi-specific defaults and auto-delegation paths, which could affect how delegation status and CTAs are displayed or reached. No security-sensitive or funds-handling logic is changed, but the user journey into delegation is altered.
> 
> **Overview**
> Makes the governance delegation UI **DRep-agnostic** by removing hardcoded Yoroi/Testnet DRep IDs, the Yoroi voting-record link, and the `drepNames` lookup.
> 
> Updates governance screens (`GovernanceStatus`, `DRepOptions`, cards, and the promotion banner) to no longer auto-delegate or deep-link into “delegate to Yoroi”; CTAs now generally open the custom DRep selection modal and the UI tracks delegation as “delegated to a DRep” vs abstain/no-confidence.
> 
> Transaction review and DRep ID selection are simplified by dropping Yoroi-specific shortcuts and displaying the normalized DRep ID directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac711c7de309ec492c5c874eb51bfc7bff1c4973. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->