### PR TITLE
[Bump] Nightly Version: 5.21.0.2

### DIFF
--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.21.0.1",
+  "version": "5.21.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.21.0.1",
+      "version": "5.21.0.2",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.21.0.1",
+  "version": "5.21.0.2",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:main": "NODE_OPTIONS=--openssl-legacy-provider babel-node scripts/dev main --env mainnet",


### PR DESCRIPTION
This PR was created automatically using GitHub Actions.
Updating the version after publishing the new nightly version from branch `develop`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the `yoroi-extension` package version numbers with no functional or dependency changes.
> 
> **Overview**
> Bumps the `packages/yoroi-extension` version from `5.21.0.1` to `5.21.0.2` in both `package.json` and `package-lock.json` to reflect the latest nightly release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aa1e2b82e9204c5c95f148765bbe5157b861936. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->