### PR TITLE
Release / 5.23.200

### DIFF
--- a/packages/yoroi-extension/chrome/manifest.template.js
+++ b/packages/yoroi-extension/chrome/manifest.template.js
@@ -69,7 +69,6 @@ export default ({
     permissions: [
       'storage',
       'tabs',
-      'alarms',
       // so that the background service could access `chrome.system.display.width`
       'system.display',
     ],

--- a/packages/yoroi-extension/package-lock.json
+++ b/packages/yoroi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi",
-  "version": "5.23.100",
+  "version": "5.23.200",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi",
-      "version": "5.23.100",
+      "version": "5.23.200",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",

--- a/packages/yoroi-extension/package.json
+++ b/packages/yoroi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi",
-  "version": "5.23.100",
+  "version": "5.23.200",
   "description": "Cardano ADA wallet",
   "scripts": {
     "dev:main": "NODE_OPTIONS=--openssl-legacy-provider babel-node scripts/dev main --env mainnet",


### PR DESCRIPTION
unused chrome permission removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release housekeeping: removes an unused Chrome `alarms` permission and bumps the extension/package version. Primary risk is unexpected runtime dependence on `chrome.alarms` that would now fail if still referenced somewhere.
> 
> **Overview**
> Updates the Yoroi extension release to `5.23.200` by bumping the version in `package.json` and `package-lock.json`.
> 
> Removes the `alarms` permission from the MV3 `manifest.template.js`, reducing declared Chrome permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fef0d879539d02495dcb068763e01521b45b518c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->