### PR TITLE
fix(governance): Update DRep list UI to match Figma (SF-1235)

### DIFF
--- a/packages/yoroi-extension/app/UI/common/helpers/formatters.ts
+++ b/packages/yoroi-extension/app/UI/common/helpers/formatters.ts
@@ -5,3 +5,11 @@ export function truncateFormatter(addr: string, cutoff: number): string {
   }
   return addr.substring(0, cutoff / 2) + shortener + addr.substring(addr.length - cutoff / 2, addr.length);
 }
+
+export function formatDrepDisplayName(name: string): string {
+  // Truncate if it's a bech32 DRep ID (no givenName)
+  if (name.startsWith('drep1')) {
+    return truncateFormatter(name, 20);
+  }
+  return name;
+}

--- a/packages/yoroi-extension/app/UI/features/governace/common/constants.ts
+++ b/packages/yoroi-extension/app/UI/features/governace/common/constants.ts
@@ -8,6 +8,14 @@ export const LEARN_MORE_LINK =
 export const FIND_DREPS_LINK = 'https://beta.cexplorer.io/drep?tab=list';
 export const FIND_DREPS_LINK_TESTNET = 'https://preprod.cexplorer.io/drep';
 
+export const CEXPLORER_DREP_URL = 'https://cexplorer.io/drep';
+export const CEXPLORER_DREP_URL_TESTNET = 'https://preprod.cexplorer.io/drep';
+
+export const getDrepExplorerUrl = (drepId: string, isTestnet: boolean): string => {
+  const baseUrl = isTestnet ? CEXPLORER_DREP_URL_TESTNET : CEXPLORER_DREP_URL;
+  return `${baseUrl}/${drepId}`;
+};
+
 export const DREP_ALWAYS_ABSTAIN = API_ABSTAIN;
 export const DREP_ALWAYS_NO_CONFIDENCE = API_NO_CONFIDENCE;
 

--- a/packages/yoroi-extension/app/UI/features/governace/common/hooks/useStrings.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/common/hooks/useStrings.tsx
@@ -213,7 +213,7 @@ export const messages = Object.freeze(
     },
     delegatingLabel: {
       id: 'governance.delegatingLabel',
-      defaultMessage: '!!!Delegateing',
+      defaultMessage: '!!!Delegating',
     },
     delegationStatus: {
       id: 'governance.delegationStatus',

--- a/packages/yoroi-extension/app/UI/features/governace/common/hooks/useStrings.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/common/hooks/useStrings.tsx
@@ -281,6 +281,10 @@ export const messages = Object.freeze(
       id: 'governance.legacyDrepId',
       defaultMessage: '!!!Legacy DRep ID (CIP-105)',
     },
+    objectives: {
+      id: 'governance.objectives',
+      defaultMessage: '!!!Objectives',
+    },
     motivations: {
       id: 'governance.motivations',
       defaultMessage: '!!!Motivations',
@@ -374,6 +378,7 @@ export const useStrings = () => {
     viewDetails: intl.formatMessage(messages.viewDetails),
     noDrepsFound: intl.formatMessage(messages.noDrepsFound),
     legacyDrepId: intl.formatMessage(messages.legacyDrepId),
+    objectives: intl.formatMessage(messages.objectives),
     motivations: intl.formatMessage(messages.motivations),
     qualifications: intl.formatMessage(messages.qualifications),
     unverifiedMetadataTitle: intl.formatMessage(messages.unverifiedMetadataTitle),

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
@@ -8,7 +8,7 @@ import { useStrings } from '../../common/hooks/useStrings';
 import { SearchInput } from '../../../../components';
 import { DrepDetailsSlide } from './DrepDetailsSlide';
 import { getDrepExplorerUrl } from '../../common/constants';
-import { truncateFormatter } from '../../../../common/helpers/formatters';
+import { formatDrepDisplayName } from '../../../../common/helpers/formatters';
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -37,14 +37,6 @@ function getDrepName(drep: any, bech32Id: string): string {
   if (!drep.metadata?.givenName) return bech32Id;
   const gn = drep.metadata.givenName;
   return typeof gn === 'string' ? gn : (gn['@value'] ?? bech32Id);
-}
-
-function formatDisplayName(name: string): string {
-  // Truncate if it's a bech32 DRep ID (no givenName)
-  if (name.startsWith('drep1')) {
-    return truncateFormatter(name, 20);
-  }
-  return name;
 }
 
 function getTwitterUrl(drep: any): string | null {
@@ -377,7 +369,7 @@ export const DRepList = () => {
                       sx={{ textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
                     >
                       <Typography variant="body1" color="ds.text_primary_medium" sx={{ wordBreak: 'break-word' }}>
-                        {formatDisplayName(drep.name)}
+                        {formatDrepDisplayName(drep.name)}
                       </Typography>
                     </Box>
                     {drep.twitterUrl && /^https:\/\//.test(drep.twitterUrl) && (

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
@@ -49,8 +49,12 @@ function formatDisplayName(name: string): string {
 
 function getTwitterUrl(drep: any): string | null {
   const refs: any[] = drep.metadata?.references ?? [];
-  const ref = refs.find(r => r.uri?.['@value']?.includes('twitter.com') || r.uri?.['@value']?.includes('x.com'));
-  return ref?.uri['@value'] ?? null;
+  const ref = refs.find(r => {
+    const uri = typeof r.uri === 'string' ? r.uri : r.uri?.['@value'];
+    return uri?.includes('twitter.com') || uri?.includes('x.com');
+  });
+  if (!ref) return null;
+  return typeof ref.uri === 'string' ? ref.uri : ref.uri?.['@value'] ?? null;
 }
 
 function getMetadataText(value: any): string | null {

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
@@ -8,6 +8,7 @@ import { useStrings } from '../../common/hooks/useStrings';
 import { SearchInput } from '../../../../components';
 import { DrepDetailsSlide } from './DrepDetailsSlide';
 import { getDrepExplorerUrl } from '../../common/constants';
+import { truncateFormatter } from '../../../../common/helpers/formatters';
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -32,10 +33,18 @@ export interface DrepRow {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function getDrepName(drep: any): string {
-  if (!drep.metadata?.givenName) return drep.id;
+function getDrepName(drep: any, bech32Id: string): string {
+  if (!drep.metadata?.givenName) return bech32Id;
   const gn = drep.metadata.givenName;
-  return typeof gn === 'string' ? gn : (gn['@value'] ?? drep.id);
+  return typeof gn === 'string' ? gn : (gn['@value'] ?? bech32Id);
+}
+
+function formatDisplayName(name: string): string {
+  // Truncate if it's a bech32 DRep ID (no givenName)
+  if (name.startsWith('drep1')) {
+    return truncateFormatter(name, 20);
+  }
+  return name;
 }
 
 function getTwitterUrl(drep: any): string | null {
@@ -199,10 +208,12 @@ export const DRepList = () => {
       .then(data => {
         const rows: DrepRow[] = data
           .filter(d => d.type === 'registered')
-          .map(d => ({
+          .map(d => {
+            const bech32Id = dRepNormalize(d.id, d.drepKind === 'scripthash' ? 'scripthash' : 'keyhash');
+            return {
             id: d.id,
-            bech32Id: dRepNormalize(d.id, d.drepKind === 'scripthash' ? 'scripthash' : 'keyhash'),
-            name: getDrepName(d),
+            bech32Id,
+            name: getDrepName(d, bech32Id),
             stake: d.stake ?? 0,
             registeredDate: d.registeredDate ?? null,
             delegatorCount: d.delegatorCount ?? 0,
@@ -212,9 +223,9 @@ export const DRepList = () => {
             motivations: getMetadataText(d.metadata?.motivations),
             qualifications: getMetadataText(d.metadata?.qualifications),
             references: getReferences(d),
-            // metadataStatus: 'valid' | 'invalid' | undefined — treat absent or 'valid' as verified
-            metadataVerified: d.metadataStatus == null || d.metadataStatus === 'valid' || d.metadataStatus === 'verified',
-          }));
+            // metadataVerification: 'verified' | 'unverified' | undefined
+            metadataVerified: d.metadataVerification === 'verified',
+          }});
         setDreps(rows);
       })
       .catch(err => console.error('[DRepList] fetch error', err))
@@ -300,31 +311,31 @@ export const DRepList = () => {
 
         {/* ── Column Headers ── */}
         <ColumnHeaderRow>
-          <ColHeaderCell width={304} onClick={() => handleSortClick('name')} sx={{ cursor: 'pointer' }}>
+          <ColHeaderCell flex={2.5} onClick={() => handleSortClick('name')} sx={{ cursor: 'pointer', minWidth: 200 }}>
             <Typography variant="body2" color="ds.text_gray_low">
               {strings.drepColTickerAndName}
             </Typography>
             <SortIcon field="name" sortField={sortField} sortOrder={sortOrder} />
           </ColHeaderCell>
-          <ColHeaderCell width={226} onClick={() => handleSortClick('stake')} sx={{ cursor: 'pointer' }}>
+          <ColHeaderCell flex={1.5} onClick={() => handleSortClick('stake')} sx={{ cursor: 'pointer', minWidth: 120 }}>
             <Typography variant="body2" color="ds.text_gray_low">
               {strings.drepColVotingPower}
             </Typography>
             <SortIcon field="stake" sortField={sortField} sortOrder={sortOrder} />
           </ColHeaderCell>
-          <ColHeaderCell width={226} onClick={() => handleSortClick('registeredDate')} sx={{ cursor: 'pointer' }}>
+          <ColHeaderCell flex={1.5} onClick={() => handleSortClick('registeredDate')} sx={{ cursor: 'pointer', minWidth: 120 }}>
             <Typography variant="body2" color="ds.text_gray_low">
               {strings.drepColRegistered}
             </Typography>
             <SortIcon field="registeredDate" sortField={sortField} sortOrder={sortOrder} />
           </ColHeaderCell>
-          <ColHeaderCell width={226} onClick={() => handleSortClick('delegatorCount')} sx={{ cursor: 'pointer' }}>
+          <ColHeaderCell flex={1} onClick={() => handleSortClick('delegatorCount')} sx={{ cursor: 'pointer', minWidth: 100 }}>
             <Typography variant="body2" color="ds.text_gray_low">
               {strings.drepColDelegators}
             </Typography>
             <SortIcon field="delegatorCount" sortField={sortField} sortOrder={sortOrder} />
           </ColHeaderCell>
-          <ColHeaderCell flex={1} onClick={() => handleSortClick('random')} sx={{ cursor: 'pointer' }}>
+          <ColHeaderCell flex={2} onClick={() => handleSortClick('random')} sx={{ cursor: 'pointer', minWidth: 200 }}>
             <Typography variant="body2" color="ds.text_gray_low">
               {strings.drepColRandom}
             </Typography>
@@ -349,7 +360,7 @@ export const DRepList = () => {
                 }
               >
                 {/* Ticker and name */}
-                <DataCell width={304} sx={{ gap: '16px' }}>
+                <DataCell flex={2.5} sx={{ gap: '16px', minWidth: 200 }}>
                   <DrepAvatar imageUrl={drep.imageUrl} name={drep.name} />
                   <Stack gap="8px">
                     <Box
@@ -361,7 +372,7 @@ export const DRepList = () => {
                       sx={{ textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
                     >
                       <Typography variant="body1" color="ds.text_primary_medium" sx={{ wordBreak: 'break-word' }}>
-                        {drep.name}
+                        {formatDisplayName(drep.name)}
                       </Typography>
                     </Box>
                     {drep.twitterUrl && /^https:\/\//.test(drep.twitterUrl) && (
@@ -379,28 +390,28 @@ export const DRepList = () => {
                 </DataCell>
 
                 {/* Voting power */}
-                <DataCell width={226}>
+                <DataCell flex={1.5} sx={{ minWidth: 120 }}>
                   <Typography variant="body1" color="ds.text_gray_medium">
                     {formatVotingPower(drep.stake)}
                   </Typography>
                 </DataCell>
 
                 {/* Registered */}
-                <DataCell width={226}>
+                <DataCell flex={1.5} sx={{ minWidth: 120 }}>
                   <Typography variant="body1" color="ds.text_gray_medium">
                     {drep.registeredDate ? formatRelativeDate(drep.registeredDate) : '—'}
                   </Typography>
                 </DataCell>
 
                 {/* Delegators */}
-                <DataCell width={226}>
+                <DataCell flex={1} sx={{ minWidth: 100 }}>
                   <Typography variant="body1" color="ds.text_gray_medium">
                     {drep.delegatorCount.toLocaleString()}
                   </Typography>
                 </DataCell>
 
                 {/* View details + Delegate (aligns with Random header) */}
-                <DataCell flex={1} sx={{ gap: '8px' }}>
+                <DataCell flex={2} sx={{ gap: '8px', minWidth: 200 }}>
                   <ActionButton onClick={() => setSelectedDrep(drep)}>
                     <Typography
                       variant="body2"

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
@@ -7,6 +7,7 @@ import { useGovernanceDelegation } from '../../common/hooks/useGovernanceDelegat
 import { useStrings } from '../../common/hooks/useStrings';
 import { SearchInput } from '../../../../components';
 import { DrepDetailsSlide } from './DrepDetailsSlide';
+import { getDrepExplorerUrl } from '../../common/constants';
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -22,6 +23,7 @@ export interface DrepRow {
   delegatorCount: number;
   imageUrl: string | null;
   twitterUrl: string | null;
+  objectives: string | null;
   motivations: string | null;
   qualifications: string | null;
   references: Array<{ label: string | null; uri: string }>;
@@ -157,7 +159,7 @@ const XIcon = () => (
 // ── Main component ────────────────────────────────────────────────────────────
 
 export const DRepList = () => {
-  const { backendServiceZero, governanceStatus } = useGovernance();
+  const { backendServiceZero, governanceStatus, isTestnet } = useGovernance();
   const currentDrepId = React.useMemo(() => {
     if (governanceStatus.status !== 'delegate' || !governanceStatus.drep) return null;
     const credHex = dRepToMaybeCredentialHex(governanceStatus.drep);
@@ -206,6 +208,7 @@ export const DRepList = () => {
             delegatorCount: d.delegatorCount ?? 0,
             imageUrl: d.metadata?.image?.contentUrl ?? null,
             twitterUrl: getTwitterUrl(d),
+            objectives: getMetadataText(d.metadata?.objectives),
             motivations: getMetadataText(d.metadata?.motivations),
             qualifications: getMetadataText(d.metadata?.qualifications),
             references: getReferences(d),
@@ -349,9 +352,18 @@ export const DRepList = () => {
                 <DataCell width={304} sx={{ gap: '16px' }}>
                   <DrepAvatar imageUrl={drep.imageUrl} name={drep.name} />
                   <Stack gap="8px">
-                    <Typography variant="body1" color="ds.text_primary_medium" sx={{ wordBreak: 'break-word' }}>
-                      {drep.name}
-                    </Typography>
+                    <Box
+                      component="a"
+                      href={getDrepExplorerUrl(drep.bech32Id, isTestnet)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                      sx={{ textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
+                    >
+                      <Typography variant="body1" color="ds.text_primary_medium" sx={{ wordBreak: 'break-word' }}>
+                        {drep.name}
+                      </Typography>
+                    </Box>
                     {drep.twitterUrl && /^https:\/\//.test(drep.twitterUrl) && (
                       <Box
                         component="a"
@@ -381,8 +393,7 @@ export const DRepList = () => {
                 </DataCell>
 
                 {/* Delegators */}
-                <DataCell width={226} sx={{ gap: '8px' }}>
-                  <PieChartIcon />
+                <DataCell width={226}>
                   <Typography variant="body1" color="ds.text_gray_medium">
                     {drep.delegatorCount.toLocaleString()}
                   </Typography>
@@ -461,17 +472,6 @@ export const DRepList = () => {
     </>
   );
 };
-
-// ── Pie chart icon (inline SVG) ───────────────────────────────────────────────
-
-const PieChartIcon = () => (
-  <Box sx={{ width: 24, height: 24, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M10 2a8 8 0 1 0 8 8h-8V2Z" fill="#6b7384" opacity="0.5" />
-      <path d="M12 2.26A8.004 8.004 0 0 1 18 10h-6V2.26Z" fill="#6b7384" />
-    </svg>
-  </Box>
-);
 
 // ── Styled components ─────────────────────────────────────────────────────────
 

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DRepList.tsx
@@ -54,7 +54,7 @@ function getTwitterUrl(drep: any): string | null {
     return uri?.includes('twitter.com') || uri?.includes('x.com');
   });
   if (!ref) return null;
-  return typeof ref.uri === 'string' ? ref.uri : ref.uri?.['@value'] ?? null;
+  return typeof ref.uri === 'string' ? ref.uri : (ref.uri?.['@value'] ?? null);
 }
 
 function getMetadataText(value: any): string | null {
@@ -215,21 +215,22 @@ export const DRepList = () => {
           .map(d => {
             const bech32Id = dRepNormalize(d.id, d.drepKind === 'scripthash' ? 'scripthash' : 'keyhash');
             return {
-            id: d.id,
-            bech32Id,
-            name: getDrepName(d, bech32Id),
-            stake: d.stake ?? 0,
-            registeredDate: d.registeredDate ?? null,
-            delegatorCount: d.delegatorCount ?? 0,
-            imageUrl: d.metadata?.image?.contentUrl ?? null,
-            twitterUrl: getTwitterUrl(d),
-            objectives: getMetadataText(d.metadata?.objectives),
-            motivations: getMetadataText(d.metadata?.motivations),
-            qualifications: getMetadataText(d.metadata?.qualifications),
-            references: getReferences(d),
-            // metadataVerification: 'verified' | 'unverified' | undefined
-            metadataVerified: d.metadataVerification === 'verified',
-          }});
+              id: d.id,
+              bech32Id,
+              name: getDrepName(d, bech32Id),
+              stake: d.stake ?? 0,
+              registeredDate: d.registeredDate ?? null,
+              delegatorCount: d.delegatorCount ?? 0,
+              imageUrl: d.metadata?.image?.contentUrl ?? null,
+              twitterUrl: getTwitterUrl(d),
+              objectives: getMetadataText(d.metadata?.objectives),
+              motivations: getMetadataText(d.metadata?.motivations),
+              qualifications: getMetadataText(d.metadata?.qualifications),
+              references: getReferences(d),
+              // metadataVerification: 'verified' | 'unverified' | undefined
+              metadataVerified: d.metadataVerification === 'verified',
+            };
+          });
         setDreps(rows);
       })
       .catch(err => console.error('[DRepList] fetch error', err))

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
@@ -32,10 +32,7 @@ const CopyIcon = ({ done }: { done: boolean }) => (
 
 const WarningIcon = () => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
-    <path
-      d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-      fill="#6b7384"
-    />
+    <path d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z" fill="#6b7384" />
   </svg>
 );
 
@@ -128,7 +125,6 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
 
           {/* ── Body ── */}
           <SlideBody>
-
             {/* DRep IDs */}
             <Stack gap="8px">
               <IdField label={strings.drepId} value={drep.bech32Id} />
@@ -152,9 +148,7 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
                     <Divider />
                   </>
                 )}
-                {drep.qualifications && (
-                  <MetadataSection title={strings.qualifications} content={drep.qualifications} />
-                )}
+                {drep.qualifications && <MetadataSection title={strings.qualifications} content={drep.qualifications} />}
               </>
             ) : (
               <Stack gap="16px">

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
@@ -32,7 +32,10 @@ const CopyIcon = ({ done }: { done: boolean }) => (
 
 const WarningIcon = () => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
-    <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" fill="#f59e0b" />
+    <path
+      d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+      fill="#6b7384"
+    />
   </svg>
 );
 
@@ -109,13 +112,14 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
         <>
           {/* ── Header ── */}
           <SlideHeader>
-            <Box sx={{ width: 24, height: 24, flexShrink: 0 }} /> {/* Spacer to balance close button */}
+            {/* Spacer to balance close button */}
+            <Box sx={{ width: 24, height: 24, flexShrink: 0 }} />
             <Typography
               variant="body1"
               fontWeight={500}
               sx={{ textTransform: 'uppercase', letterSpacing: '0.5px', color: '#242838', flex: 1, textAlign: 'center' }}
             >
-              {drep.name}
+              {drep.name.startsWith('drep1') ? truncateFormatter(drep.name, 20) : drep.name}
             </Typography>
             <CloseButton onClick={onClose}>
               <CloseIcon />
@@ -154,11 +158,11 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
               </>
             ) : (
               <Stack gap="16px">
-                <Stack direction="row" alignItems="center" gap="8px">
-                  <WarningIcon />
+                <Stack direction="row" alignItems="center" justifyContent="space-between">
                   <Typography variant="body1" fontWeight={500} color="ds.text_gray_medium">
                     {strings.unverifiedMetadataTitle}
                   </Typography>
+                  <WarningIcon />
                 </Stack>
                 <Typography variant="body1" color="ds.text_gray_medium">
                   {strings.unverifiedMetadataMessage}

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
@@ -3,7 +3,7 @@ import { Box, Drawer, Divider, Stack, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { dRepToPreCip129 } from '../../../../../api/ada/lib/cardanoCrypto/utils';
 import { useStrings } from '../../common/hooks/useStrings';
-import { truncateFormatter } from '../../../../common/helpers/formatters';
+import { truncateFormatter, formatDrepDisplayName } from '../../../../common/helpers/formatters';
 import type { DrepRow } from './DRepList';
 
 // ── Icons ────────────────────────────────────────────────────────────────────
@@ -116,7 +116,7 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
               fontWeight={500}
               sx={{ textTransform: 'uppercase', letterSpacing: '0.5px', color: '#242838', flex: 1, textAlign: 'center' }}
             >
-              {drep.name.startsWith('drep1') ? truncateFormatter(drep.name, 20) : drep.name}
+              {formatDrepDisplayName(drep.name)}
             </Typography>
             <CloseButton onClick={onClose}>
               <CloseIcon />

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
@@ -3,8 +3,8 @@ import { Box, Drawer, Divider, Stack, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { dRepToPreCip129 } from '../../../../../api/ada/lib/cardanoCrypto/utils';
 import { useStrings } from '../../common/hooks/useStrings';
+import { truncateFormatter } from '../../../../common/helpers/formatters';
 import type { DrepRow } from './DRepList';
-import { DrepAvatar } from './DRepList';
 
 // ── Icons ────────────────────────────────────────────────────────────────────
 
@@ -36,26 +36,6 @@ const WarningIcon = () => (
   </svg>
 );
 
-const XIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-    <path
-      d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.75l7.73-8.835-8.156-10.665h6.07l4.259 5.633L18.244 2.25Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"
-      fill="#6b7384"
-    />
-  </svg>
-);
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-const safeHttpsUrl = (url: string): string | null => {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === 'https:' ? url : null;
-  } catch {
-    return null;
-  }
-};
-
 // ── ID field with copy ────────────────────────────────────────────────────────
 
 const IdField = ({ label, value }: { label: string; value: string }) => {
@@ -71,8 +51,8 @@ const IdField = ({ label, value }: { label: string; value: string }) => {
         {label}
       </Typography>
       <Stack direction="row" alignItems="flex-start" gap="8px" flex={1} minWidth={0}>
-        <Typography variant="body1" color="ds.text_gray_medium" sx={{ wordBreak: 'break-all', flex: 1 }}>
-          {value}
+        <Typography variant="body1" color="ds.text_gray_medium" sx={{ flex: 1 }}>
+          {truncateFormatter(value, 18)}
         </Typography>
         <Box onClick={handleCopy} sx={{ cursor: 'pointer', flexShrink: 0, mt: '2px' }}>
           <CopyIcon done={copied} />
@@ -118,11 +98,6 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
     }
   }, [drep?.bech32Id]);
 
-  const nonSocialRefs = React.useMemo(
-    () => drep?.references.filter(r => !r.uri.includes('twitter.com') && !r.uri.includes('x.com')) ?? [],
-    [drep?.references]
-  );
-
   return (
     <Drawer
       anchor="right"
@@ -137,7 +112,7 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
             <Typography
               variant="body1"
               fontWeight={500}
-              sx={{ textTransform: 'uppercase', letterSpacing: '0.5px', color: '#242838' }}
+              sx={{ textTransform: 'uppercase', letterSpacing: '0.5px', color: '#242838', flex: 1, textAlign: 'center' }}
             >
               {drep.name}
             </Typography>
@@ -148,22 +123,6 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
 
           {/* ── Body ── */}
           <SlideBody>
-            {/* Avatar + name + twitter */}
-            <Stack direction="row" alignItems="center" gap="16px">
-              <DrepAvatar imageUrl={drep.imageUrl} name={drep.name} />
-              <Stack gap="4px">
-                <Typography variant="body1" fontWeight={500} color="ds.text_gray_medium">
-                  {drep.name}
-                </Typography>
-                {drep.twitterUrl && safeHttpsUrl(drep.twitterUrl) && (
-                  <Box component="a" href={safeHttpsUrl(drep.twitterUrl)!} target="_blank" rel="noopener noreferrer">
-                    <XIcon />
-                  </Box>
-                )}
-              </Stack>
-            </Stack>
-
-            <Divider />
 
             {/* DRep IDs */}
             <Stack gap="8px">
@@ -176,6 +135,12 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
             {/* Verified content or warning */}
             {drep.metadataVerified ? (
               <>
+                {drep.objectives && (
+                  <>
+                    <MetadataSection title={strings.objectives} content={drep.objectives} />
+                    <Divider />
+                  </>
+                )}
                 {drep.motivations && (
                   <>
                     <MetadataSection title={strings.motivations} content={drep.motivations} />
@@ -183,31 +148,7 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
                   </>
                 )}
                 {drep.qualifications && (
-                  <>
-                    <MetadataSection title={strings.qualifications} content={drep.qualifications} />
-                    <Divider />
-                  </>
-                )}
-                {nonSocialRefs.length > 0 && (
-                  <Stack gap="8px">
-                    {nonSocialRefs.map((ref, i) => {
-                      const safeUri = safeHttpsUrl(ref.uri);
-                      return safeUri ? (
-                        <Box
-                          key={i}
-                          component="a"
-                          href={safeUri}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          sx={{ textDecoration: 'none' }}
-                        >
-                          <Typography variant="body1" color="ds.text_primary_medium">
-                            {ref.label ?? ref.uri}
-                          </Typography>
-                        </Box>
-                      ) : null;
-                    })}
-                  </Stack>
+                  <MetadataSection title={strings.qualifications} content={drep.qualifications} />
                 )}
               </>
             ) : (

--- a/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
+++ b/packages/yoroi-extension/app/UI/features/governace/useCases/DRepList/DrepDetailsSlide.tsx
@@ -109,6 +109,7 @@ export const DrepDetailsSlide = ({ drep, onClose, onDelegate, isCurrentDrep, del
         <>
           {/* ── Header ── */}
           <SlideHeader>
+            <Box sx={{ width: 24, height: 24, flexShrink: 0 }} /> {/* Spacer to balance close button */}
             <Typography
               variant="body1"
               fontWeight={500}

--- a/packages/yoroi-extension/app/i18n/locales/en-US.json
+++ b/packages/yoroi-extension/app/i18n/locales/en-US.json
@@ -347,7 +347,7 @@
   "governance.delegateToDRep": "Delegate to a DRep",
   "governance.delegateToOtherDrep": "Delegate to other DRep",
   "governance.delegateToYoroiDRep": "Delegate to Yoroi DRep",
-  "governance.delegatingLabel": "Delegateing",
+  "governance.delegatingLabel": "Delegating",
   "governance.delegatingToDRep": "Delegating to a DRep",
   "governance.delegationOptions": "Delegation Options",
   "governance.delegationStatus": "Delegation status",

--- a/packages/yoroi-extension/app/i18n/locales/en-US.json
+++ b/packages/yoroi-extension/app/i18n/locales/en-US.json
@@ -374,6 +374,7 @@
   "governance.legacyDrepId": "Legacy DRep ID (CIP-105)",
   "governance.motivations": "Motivations",
   "governance.needAdaForParticipation": "To participate in governance you need to have ADA in your wallet.",
+  "governance.objectives": "Objectives",
   "governance.noConfidence": "No Confidence",
   "governance.noConfidenceInfo": "You are expressing a lack of trust for all proposals now and in the future.",
   "governance.noDrepsFound": "No DReps found",


### PR DESCRIPTION
## Summary
UI fixes for the DRep list to match Figma design per [SF-1235](https://emurgo.atlassian.net/browse/SF-1235):

- Remove pie chart icon from delegators column
- Make DRep name link to Cexplorer (testnet-aware)
- Center header title in details slide, remove duplicate name/avatar
- Use ellipsis for DRep IDs (reuses existing `truncateFormatter`)
- Add objectives section to details slide
- Remove references/links section from details slide
- Add `getDrepExplorerUrl` helper for consistent URL handling

## Test plan
- [x] Verify delegators column shows plain number (no pie chart)
- [x] Verify DRep name links to Cexplorer (correct URL for mainnet/testnet)
- [x] Verify details slide header is centered with no duplicate name
- [x] Verify DRep IDs are truncated with ellipsis
- [x] Verify objectives, motivations, qualifications sections display
- [x] Verify no links section at bottom of details slide

[SF-1235]: https://emurgo.atlassian.net/browse/SF-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/UX and presentation changes in governance DRep screens, with limited logic changes around metadata parsing and verification flags that could affect which metadata is shown.
> 
> **Overview**
> Improves the governance DRep list and details slide to better match design: DRep names are now clickable links to Cexplorer (testnet-aware via `getDrepExplorerUrl`), column sizing is adjusted, and the delegators column no longer shows an icon.
> 
> Updates DRep data mapping and display: falls back to bech32 ID when no `givenName`, truncates long bech32 IDs/names via `truncateFormatter`/`formatDrepDisplayName`, makes Twitter reference parsing more robust, switches metadata verification to rely on `metadataVerification === 'verified'`, and adds a new verified `Objectives` section while removing the references/links section from the details view.
> 
> Fixes a typo in the `governance.delegatingLabel` string and adds the new `governance.objectives` i18n key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b750c20c8333cd22bb4a6cb5e2b3b4ce654daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->